### PR TITLE
Try fix keyboard accessibility

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -278,7 +278,7 @@ class Dropzone extends React.Component {
     customProps.forEach(prop => delete divProps[prop]);
 
     return (
-      <div
+      <button
         className={className}
         style={appliedStyle}
         {...divProps/* expand user provided props first so event handlers are never overridden */}
@@ -294,7 +294,7 @@ class Dropzone extends React.Component {
           {...inputProps/* expand user provided inputProps first so inputAttributes override them */}
           {...inputAttributes}
         />
-      </div>
+      </button>
     );
   }
 }
@@ -334,7 +334,9 @@ Dropzone.propTypes = {
   accept: React.PropTypes.string, // Allow specific types of files. See https://github.com/okonet/attr-accept for more information
   name: React.PropTypes.string, // name attribute for the input tag
   maxSize: React.PropTypes.number,
-  minSize: React.PropTypes.number
+  minSize: React.PropTypes.number,
+
+  tabIndex: React.PropTypes.number
 };
 
 export default Dropzone;


### PR DESCRIPTION
Currently, the markup produced by `react-dropzone` is not accessible by keyboard navigation. The root element is a `div` and the `input` is hidden so it cannot be focused.

See also related discussion in #161 

To solve this problem, a `button` element should be used instead of a `div` at the root, and `tabIndex` should be allowed as a prop, this makes the dropzone focusable and allows the browser to trigger _a synthetic click_ when the user presses `Enter`.

## Why not `aria-*` markup?
Unfortunately, using `aria-*` markup does not cause the browser to trigger `click` handlers with the keyboard, so pressing `Enter` won't open the file picker, even when `onClick` is set. Here is an excellent video explaining why `button` is a better approach: https://www.youtube.com/watch?v=CZGqnp06DnI