### PR TITLE
Remove styles and make the component headless

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,15 +20,76 @@ Install it from npm and include it in your React build process (using [Webpack](
 npm install --save react-dropzone
 ```
 
-## Usage
-
-Import `Dropzone` in your React component:
+## Usage with ES2015 classes
 
 ```javascript
+import React from 'react'
+import cx from 'classnames'
 import Dropzone from 'react-dropzone'
+
+class MyDropzone extends React.Component {
+
+  onDrop = (acceptedFiles, rejectedFiles) => {
+    // Do something with files
+    // i.e. pre-process, upload etc.
+  }
+
+  render() {
+    return (
+      <Dropzone onDrop={this.onDrop}>
+        {
+          ({ isDragActive }) => {
+            return (
+              <div className={cx('dropzone', {
+                'dropzone--isActive': isDragActive
+              })}>
+              {
+                isDragActive ?
+                  <p>Drop files here...</p> :
+                  <p>Try dropping some files here, or click to select files to upload.</p>
+              }
+              </div>
+            )
+          }
+        }
+      </Dropzone>
+    );
+  }
+}
+
 ``` 
+
+## Usage as a HOC with stateless components
+
+```javascript
+import React from 'react'
+import cx from 'classnames'
+import { makeDropzone } from 'react-dropzone'
+
+function MyDropzone({ isDragActive }) {
+  const classNames = cx('dropzone', {
+    isActive: isDragActive
+  })
+  return (
+    <div className={classNames}>
+      { isDragActive ?
+          <p>Drop files here...</p> :
+          <p>Try dropping some files here, or click to select files to upload.</p>
+      }
+    </div>
+  );
+}
+
+// Call HoC with your component and options as arguments
+export default makeDropzone(MyDropzone, {
+  onDrop: (acceptedFiles, rejectedFiles) => {
+    // Do something with files
+    // i.e. pre-process, upload etc.
+  } 
+})
+```
   
-  and specify the `onDrop` method that accepts two arguments. The first argument represents the accepted files and the second argument the rejected files.
+The `onDrop` method that accepts two arguments. The first argument represents the accepted files and the second argument the rejected files.
   
 ```javascript
 function onDrop(acceptedFiles, rejectedFiles) {
@@ -45,13 +106,13 @@ Using `react-dropzone` is similar to using a file form field, but instead of get
 Specifying the `onDrop` method, provides you with an array of [Files](https://developer.mozilla.org/en-US/docs/Web/API/File) which you can then send to a server. For example, with [SuperAgent](https://github.com/visionmedia/superagent) as a http/ajax library:
 
 ```javascript
-    onDrop: acceptedFiles => {
-        const req = request.post('/upload');
-        acceptedFiles.forEach(file => {
-            req.attach(file.name, file);
-        });
-        req.end(callback);
-    }
+function onDrop(acceptedFiles) {
+  const req = request.post('/upload')
+  acceptedFiles.forEach(file => {
+      req.attach(file.name, file)
+  })
+  req.end(callback)
+}
 ```
 
 ## PropTypes

--- a/README.md
+++ b/README.md
@@ -37,21 +37,23 @@ class MyDropzone extends React.Component {
   render() {
     return (
       <Dropzone onDrop={this.onDrop}>
-        {
-          ({ isDragActive }) => {
-            return (
-              <div className={cx('dropzone', {
+        {({ getRootProps, getInputProps, isDragActive }) => {
+          return (
+            <div
+              {...getRootProps()}
+              className={cx('dropzone', {
                 'dropzone--isActive': isDragActive
-              })}>
+              })}
+            >
+              <input {...getInputProps()} />
               {
                 isDragActive ?
                   <p>Drop files here...</p> :
                   <p>Try dropping some files here, or click to select files to upload.</p>
               }
-              </div>
-            )
-          }
-        }
+            </div>
+          )
+        }}
       </Dropzone>
     );
   }
@@ -59,35 +61,66 @@ class MyDropzone extends React.Component {
 
 ``` 
 
-## Usage as a HOC with stateless components
+## Render Prop Function
+
+This is where you render whatever you want to based on the state of `Dropzone`.
+You can also pass it as the children prop if you prefer to do things that way
+> `<Dropzone>{/* right here*/}</Dropzone>`
+
+The properties of this object can be split into two categories as indicated
+below:
+
+### Prop Getters
+
+These functions are used to apply props to the elements that you render. This
+gives you maximum flexibility to render what, when, and wherever you like. You
+call these on the element in question (for example: `<div {...getRootProps()}`)). It's advisable to pass all your props to that function
+rather than applying them on the element yourself to avoid your props being
+overridden (or overriding the props returned). For example:
+`getRootProps({onClick(event) {console.log(event)}})`.
+
+| property          | type           | description                                                                    |
+| ----------------- | -------------- | ------------------------------------------------------------------------------ |
+| `getRootProps`    | `function({})` | Returns the props you should apply to the root drop container you render       |
+| `getInputProps`   | `function({})` | Returns the props you should apply to hidden file input you render             |
+
+### state
+
+These are values that represent the current state of Dropzone component.
+
+| property                               | type      | description                                             |
+| -------------------------------------- | --------- | --------------------------------------------------------|
+| `isDragActive`                         | `boolean` | Flag indicating whether an active drag is in progress   |
+| `isDragAccept`                         | `boolean` | Flag indicating whether the files dragged are accepted  |
+| `isDragReject`                         | `boolean` | Flag indicating whether the files dragged are rejected  |
+| `draggedFiles`                         | `array`   | List of files in active drag                            |
+| `acceptedFiles`                        | `array`   | List of accepted files in active drag                   |
+| `rejectedFiles`                        | `array`   | List of rejected files in active drag                   |
+
+### Custom refKey
+
+Both `getRootProps` and `getInputProps` accept custom `refKey` (defaulted to `ref`) as one of the attributes passed down in the parameter.
+
+This is especially useful when incorporating custom components, e.g. styled-components, in which case you will use `innerRef` as the `refKey`.
 
 ```javascript
-import React from 'react'
-import cx from 'classnames'
-import { makeDropzone } from 'react-dropzone'
+const StyledDropArea = styled.div`
+  // Some styling here
+`
 
-function MyDropzone({ isDragActive }) {
-  const classNames = cx('dropzone', {
-    isActive: isDragActive
-  })
-  return (
-    <div className={classNames}>
-      { isDragActive ?
-          <p>Drop files here...</p> :
-          <p>Try dropping some files here, or click to select files to upload.</p>
-      }
-    </div>
-  );
-}
-
-// Call HoC with your component and options as arguments
-export default makeDropzone(MyDropzone, {
-  onDrop: (acceptedFiles, rejectedFiles) => {
-    // Do something with files
-    // i.e. pre-process, upload etc.
-  } 
-})
+const Example = () => (
+  <Dropzone>
+    {({ getRootProps, getInputProps }) => (
+      <StyledDropArea {...getRootProps({ refKey: 'innerRef' })}>
+        <input {...getInputProps()} />
+        <p>Drop some files here</p>
+      </StyledDropArea>
+    )}
+  </Dropzone>
+)
 ```
+
+## onDrop prop
   
 The `onDrop` method that accepts two arguments. The first argument represents the accepted files and the second argument the rejected files.
   

--- a/README.md
+++ b/README.md
@@ -117,35 +117,7 @@ const Example = () => (
       </StyledDropArea>
     )}
   </Dropzone>
-)
-```
-
-## onDrop prop
-  
-The `onDrop` method that accepts two arguments. The first argument represents the accepted files and the second argument the rejected files.
-  
-```javascript
-function onDrop(acceptedFiles, rejectedFiles) {
-  // do stuff with files...
-}
-``` 
-
-Files accepted or rejected based on `accept` prop. This must be a valid [MIME type](http://www.iana.org/assignments/media-types/media-types.xhtml) according to [input element specification](https://www.w3.org/wiki/HTML/Elements/input/file).
-
-Please note that `onDrop` method will always be called regardless if dropped file was accepted or rejected. The `onDropAccepted` method will be called if all dropped files were accepted and the `onDropRejected` method will be called if any of the dropped files was rejected.
-
-Using `react-dropzone` is similar to using a file form field, but instead of getting the `files` property from the field, you listen to the `onDrop` callback to handle the files. Simple explanation here: http://abandon.ie/notebook/simple-file-uploads-using-jquery-ajax
-
-Specifying the `onDrop` method, provides you with an array of [Files](https://developer.mozilla.org/en-US/docs/Web/API/File) which you can then send to a server. For example, with [SuperAgent](https://github.com/visionmedia/superagent) as a http/ajax library:
-
-```javascript
-function onDrop(acceptedFiles) {
-  const req = request.post('/upload')
-  acceptedFiles.forEach(file => {
-      req.attach(file.name, file)
-  })
-  req.end(callback)
-}
+);
 ```
 
 ## PropTypes

--- a/examples/Accept/Readme.md
+++ b/examples/Accept/Readme.md
@@ -63,15 +63,13 @@ Also, at this moment it's not possible to read file names (and thus, file extens
 <Dropzone
   accept=".jpeg,.png"
 >
-  {({ isDragActive, isDragReject }) => {
-    if (isDragActive) {
-      return "All files will be accepted";
-    }
-    if (isDragReject) {
-      return "Some files will be rejected";
-    }
-    return "Dropping some files here...";
-  }}
+  {({ isDragAccept, isDragReject }) => (
+    <div>
+      {isDragAccept && "All files will be accepted"}
+      {isDragReject && "Some files will be rejected"}
+      Drop some files here...
+    </div>
+  )}   
 </Dropzone>
 ```
 

--- a/examples/Accept/Readme.md
+++ b/examples/Accept/Readme.md
@@ -79,15 +79,13 @@ but this one will:
 <Dropzone
   accept="image/jpeg, image/png"
 >
-  {({ isDragActive, isDragReject }) => {
-    if (isDragActive) {
-      return "All files will be accepted";
-    }
-    if (isDragReject) {
-      return "Some files will be rejected";
-    }
-    return "Dropping some files here...";
-  }}
+  {({ isDragAccept, isDragReject }) => (
+      <div>
+        {isDragAccept && "All files will be accepted"}
+        {isDragReject && "Some files will be rejected"}
+        Drop some files here...
+      </div>
+    )} 
 </Dropzone>
 ```
 

--- a/examples/Accept/Readme.md
+++ b/examples/Accept/Readme.md
@@ -22,15 +22,21 @@ class Accept extends React.Component {
   render() {
     return (
       <section>
-        <div className="dropzone">
-          <Dropzone
-            accept="image/jpeg, image/png"
-            onDrop={(accepted, rejected) => { this.setState({ accepted, rejected }); }}
-          >
-            <p>Try dropping some files here, or click to select files to upload.</p>
-            <p>Only *.jpeg and *.png images will be accepted</p>
-          </Dropzone>
-        </div>
+        <Dropzone
+          accept="image/jpeg, image/png"
+          onDrop={(accepted, rejected) => { this.setState({ accepted, rejected }); }}
+        >
+          {({ getRootProps, getInputProps }) => (
+            <div
+              {...getRootProps()}
+              className="dropzone"
+            >
+              <input {...getInputProps()} />
+              <p>Try dropping some files here, or click to select files to upload.</p>
+              <p>Only *.jpeg and *.png images will be accepted</p>
+            </div>
+          )}
+        </Dropzone>
         <aside>
           <h2>Accepted files</h2>
           <ul>
@@ -63,13 +69,19 @@ Also, at this moment it's not possible to read file names (and thus, file extens
 <Dropzone
   accept=".jpeg,.png"
 >
-  {({ isDragAccept, isDragReject }) => (
-    <div>
-      {isDragAccept && "All files will be accepted"}
-      {isDragReject && "Some files will be rejected"}
-      Drop some files here...
+  {({ getRootProps, getInputProps, isDragActive, isDragAccept, isDragReject }) => (
+    <div
+      {...getRootProps()}
+      className="dropzone"
+    >
+      <input {...getInputProps()} />
+      <div>
+        {isDragAccept && "All files will be accepted"}
+        {isDragReject && "Some files will be rejected"}
+        {!isDragActive && "Drop some files here..."}
+      </div>
     </div>
-  )}   
+  )}
 </Dropzone>
 ```
 
@@ -79,13 +91,19 @@ but this one will:
 <Dropzone
   accept="image/jpeg, image/png"
 >
-  {({ isDragAccept, isDragReject }) => (
+  {({ getRootProps, getInputProps, isDragActive, isDragAccept, isDragReject }) => (
+    <div
+      {...getRootProps()}
+      className="dropzone"
+    >
+      <input {...getInputProps()} />
       <div>
         {isDragAccept && "All files will be accepted"}
         {isDragReject && "Some files will be rejected"}
-        Drop some files here...
+        {!isDragActive && "Drop some files here..."}
       </div>
-    )} 
+    </div>
+  )}
 </Dropzone>
 ```
 

--- a/examples/Basic/Readme.md
+++ b/examples/Basic/Readme.md
@@ -1,4 +1,6 @@
-Dropzone with default properties and displays list of the dropped files.
+By default, Dropzone just renders provided children without applying any styles.  
+
+This example renders a list of the dropped files.
 
 ```
 class Basic extends React.Component {

--- a/examples/Basic/Readme.md
+++ b/examples/Basic/Readme.md
@@ -4,11 +4,12 @@ This example renders a list of the dropped files.
 
 ```
 class Basic extends React.Component {
-  constructor() {
-    super()
+  constructor(props) {
+    super(props)
     this.state = { files: [] }
+    this.onDrop = this.onDrop.bind(this)
   }
-
+  
   onDrop(files) {
     this.setState({
       files
@@ -18,11 +19,17 @@ class Basic extends React.Component {
   render() {
     return (
       <section>
-        <div className="dropzone">
-          <Dropzone onDrop={this.onDrop.bind(this)}>
-            <p>Try dropping some files here, or click to select files to upload.</p>
-          </Dropzone>
-        </div>
+        <Dropzone onDrop={this.onDrop}>
+          {({ getRootProps, getInputProps }) => (
+            <div
+              {...getRootProps()}
+              className="dropzone"
+            >
+              <input {...getInputProps()} />
+              <p>Try dropping some files here, or click to select files to upload.</p>
+            </div>
+          )}
+        </Dropzone>
         <aside>
           <h2>Dropped files</h2>
           <ul>

--- a/examples/File Dialog/Readme.md
+++ b/examples/File Dialog/Readme.md
@@ -5,10 +5,15 @@ let dropzoneRef;
 
 <div>
   <Dropzone ref={(node) => { dropzoneRef = node; }} onDrop={(accepted, rejected) => { alert(accepted) }}>
-      <p>Drop files here.</p>
+    {({ getRootProps, getInputProps }) => (
+      <div {...getRootProps()}>
+        <input {...getInputProps()} />
+        <p>Drop files here.</p>
+      </div>
+    )}
   </Dropzone>
   <button type="button" onClick={() => { dropzoneRef.open() }}>
-      Open File Dialog
+    Open File Dialog
   </button>
 </div>
 ```

--- a/examples/Fullscreen/Readme.md
+++ b/examples/Fullscreen/Readme.md
@@ -7,26 +7,12 @@ class FullScreen extends React.Component {
     this.state = {
       accept: '',
       files: [],
-      dropzoneActive: false
     }
-  }
-
-  onDragEnter() {
-    this.setState({
-      dropzoneActive: true
-    });
-  }
-
-  onDragLeave() {
-    this.setState({
-      dropzoneActive: false
-    });
   }
 
   onDrop(files) {
     this.setState({
       files,
-      dropzoneActive: false
     });
   }
 
@@ -52,30 +38,30 @@ class FullScreen extends React.Component {
     return (
       <Dropzone
         disableClick
-        style={{}}
         accept={accept}
         onDrop={this.onDrop.bind(this)}
-        onDragEnter={this.onDragEnter.bind(this)}
-        onDragLeave={this.onDragLeave.bind(this)}
       >
-        { dropzoneActive && <div style={overlayStyle}>Drop files...</div> }
-        <div>
-          <h1>My awesome app</h1>
-          <label htmlFor="mimetypes">Enter mime types you want to accept: </label>
-          <input
-            type="text"
-            id="mimetypes"
-            onChange={this.applyMimeTypes.bind(this)}
-          />
-
-          <h2>Dropped files</h2>
-          <ul>
-            {
-              files.map(f => <li>{f.name} - {f.size} bytes</li>)
-            }
-          </ul>
-
-        </div>
+        {({ isDragActive }) => (
+          <div style={{ position: 'relative' }}>
+            {isDragActive && <div style={overlayStyle}>Drop files...</div>}
+            
+            <h1>My awesome app</h1>
+            <label htmlFor="mimetypes">Enter mime types you want to accept: </label>
+            <input
+              type="text"
+              id="mimetypes"
+              onChange={this.applyMimeTypes.bind(this)}
+            />
+  
+            <h2>Dropped files</h2>
+            <ul>
+              {
+                files.map(f => <li>{f.name} - {f.size} bytes</li>)
+              }
+            </ul>
+  
+          </div>
+        )}
       </Dropzone>
     );
   }

--- a/examples/Fullscreen/Readme.md
+++ b/examples/Fullscreen/Readme.md
@@ -41,8 +41,13 @@ class FullScreen extends React.Component {
         accept={accept}
         onDrop={this.onDrop.bind(this)}
       >
-        {({ isDragActive }) => (
-          <div style={{ position: 'relative' }}>
+        {({ getRootProps, getInputProps, isDragActive, isDragAccept, isDragReject }) => (
+          <div
+            {...getRootProps()}
+            style={{ position: 'relative' }}
+          >
+            <input {...getInputProps()} />
+            
             {isDragActive && <div style={overlayStyle}>Drop files...</div>}
             
             <h1>My awesome app</h1>
@@ -59,7 +64,6 @@ class FullScreen extends React.Component {
                 files.map(f => <li>{f.name} - {f.size} bytes</li>)
               }
             </ul>
-  
           </div>
         )}
       </Dropzone>

--- a/examples/Styling/Readme.md
+++ b/examples/Styling/Readme.md
@@ -1,23 +1,41 @@
-By default, the Dropzone component picks up some default styling to get you started. You can customize `<Dropzone>` by specifying a `style`, `activeStyle` or `rejectStyle` which is applied when a file is dragged over the zone. You can also specify `className`,  `activeClassName` or `rejectClassName` if you would rather style using CSS.
-
-## Updating styles and contents based on user input
-
-By providing a function that returns the component's children you can not only style Dropzone appropriately but also render appropriate content.
+By default, the Dropzone component doesn't render any styles. By providing a function that returns the component's children you can not only style Dropzone appropriately but also render appropriate content.
 
 ```
-<Dropzone
-  accept="image/png"
->
-  {({ isDragActive, isDragReject, acceptedFiles, rejectedFiles }) => {
-    if (isDragActive) {
-      return "This file is authorized";
-    }
+const baseStyle = {
+  width: 200,
+  height: 200,
+  borderWidth: 2,
+  borderColor: '#666',
+  borderStyle: 'dashed',
+  borderRadius: 5
+};
+const activeStyle = {
+  borderStyle: 'solid',
+  borderColor: '#6c6',
+  backgroundColor: '#eee'
+};
+const rejectStyle = {
+  borderStyle: 'solid',
+  borderColor: '#c66',
+  backgroundColor: '#eee'
+};
+
+<Dropzone accept="image/*">
+  {({ isDragActive, isDragAccept, isDragReject, acceptedFiles, rejectedFiles }) => {
+    let styles = {...baseStyle}
+    styles = isDragActive ? {...styles, ...activeStyle} : styles
+    
     if (isDragReject) {
-      return "This file is not authorized";
-    }
-    return acceptedFiles.length || rejectedFiles.length
-      ? `Accepted ${acceptedFiles.length}, rejected ${rejectedFiles.length} files`
-      : "Try dropping some files.";
+      return <div style={{...styles, ...rejectStyle}}>
+        Unsupported file type...
+      </div>
+    } 
+          
+    return (
+      <div style={styles}>
+        {isDragAccept ? `Drop ${acceptedFiles.length}` : 'Drag'} files here...
+      </div>
+    )
   }}
 </Dropzone>
 ```

--- a/examples/Styling/Readme.md
+++ b/examples/Styling/Readme.md
@@ -1,5 +1,9 @@
 By default, the Dropzone component doesn't render any styles. By providing a function that returns the component's children you can not only style Dropzone appropriately but also render appropriate content.
 
+
+
+### Using inline styles
+
 ```
 const baseStyle = {
   width: 200,
@@ -37,6 +41,42 @@ const rejectStyle = {
         </div>
         {isDragReject && <div>Unsupported file type...</div>}
       </div>
+    )
+  }}
+</Dropzone>
+```
+
+### Using styled-components
+
+```
+const styled = require('styled-components').default;
+
+const getColor = (props) => {
+    if (props.isDragActive) {    
+        return '#6c6';
+    } 
+    if (props.isDragReject) {
+        return '#c66';
+    }
+    return '#666';
+};
+
+const Container = styled.div`
+  width: 200px;
+  height: 200px;
+  border-width: 2px;
+  border-radius: 5px;
+  border-color: ${props => getColor(props)};
+  border-style: ${props => props.isDragReject || props.isDragActive ? 'solid' : 'dashed'};
+  background-color: ${props => props.isDragReject || props.isDragActive ? '#eee' : ''};
+`;
+
+<Dropzone accept="image/*">
+  {({ isDragActive, isDragAccept, isDragReject, acceptedFiles, rejectedFiles }) => {
+    return (
+      <Container isDragActive={isDragActive} isDragReject={isDragReject}>
+        {isDragAccept ? `Drop ${acceptedFiles.length}` : 'Drag'} files here...
+      </Container>
     )
   }}
 </Dropzone>

--- a/examples/Styling/Readme.md
+++ b/examples/Styling/Readme.md
@@ -20,7 +20,7 @@ const rejectStyle = {
   backgroundColor: '#eee'
 };
 
-<Dropzone accept="image/*">
+<Dropzone>
   {({ getRootProps, getInputProps, isDragActive, isDragAccept, isDragReject, acceptedFiles, rejectedFiles }) => {
     let styles = {...baseStyle}
     styles = isDragActive ? {...styles, ...activeStyle} : styles

--- a/examples/Styling/Readme.md
+++ b/examples/Styling/Readme.md
@@ -21,19 +21,21 @@ const rejectStyle = {
 };
 
 <Dropzone accept="image/*">
-  {({ isDragActive, isDragAccept, isDragReject, acceptedFiles, rejectedFiles }) => {
+  {({ getRootProps, getInputProps, isDragActive, isDragAccept, isDragReject, acceptedFiles, rejectedFiles }) => {
     let styles = {...baseStyle}
     styles = isDragActive ? {...styles, ...activeStyle} : styles
-    
-    if (isDragReject) {
-      return <div style={{...styles, ...rejectStyle}}>
-        Unsupported file type...
-      </div>
-    } 
+    styles = isDragReject ? {...styles, ...rejectStyle} : styles
           
     return (
-      <div style={styles}>
-        {isDragAccept ? `Drop ${acceptedFiles.length}` : 'Drag'} files here...
+      <div 
+        {...getRootProps()}
+        style={styles}
+      >
+        <input {...getInputProps()} />
+        <div>
+          {isDragAccept ? `Drop ${acceptedFiles.length}` : 'Drag'} files here...
+        </div>
+        {isDragReject && <div>Unsupported file type...</div>}
       </div>
     )
   }}

--- a/package.json
+++ b/package.json
@@ -58,7 +58,8 @@
   },
   "dependencies": {
     "attr-accept": "^1.0.3",
-    "prop-types": "^15.5.7"
+    "prop-types": "^15.5.7",
+    "styled-components": "^3.2.6"
   },
   "devDependencies": {
     "@commitlint/cli": "^3.0.3",

--- a/src/__snapshots__/index.spec.js.snap
+++ b/src/__snapshots__/index.spec.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Dropzone basics should render children 1`] = `"<div class=\\"\\" style=\\"width: 200px; height: 200px; border-width: 2px; border-color: #666; border-style: dashed; border-radius: 5px;\\"><p>some content</p><input type=\\"file\\" multiple=\\"\\" style=\\"display: none;\\"></div>"`;
+exports[`Dropzone basics should render children 1`] = `"<div><input type=\\"file\\" multiple=\\"\\" autocomplete=\\"off\\" style=\\"display: none;\\"></div>"`;
 
-exports[`Dropzone document drop protection does not prevent stray drops when preventDropOnDocument is false 1`] = `"<div class=\\"\\" style=\\"width: 200px; height: 200px; border-width: 2px; border-color: #666; border-style: dashed; border-radius: 5px;\\"><input type=\\"file\\" multiple=\\"\\" style=\\"display: none;\\"></div>"`;
+exports[`Dropzone document drop protection does not prevent stray drops when preventDropOnDocument is false 1`] = `"<div><input type=\\"file\\" multiple=\\"\\" autocomplete=\\"off\\" style=\\"display: none;\\"></div>"`;
 
-exports[`Dropzone document drop protection installs hooks to prevent stray drops from taking over the browser window 1`] = `"<div class=\\"\\" style=\\"width: 200px; height: 200px; border-width: 2px; border-color: #666; border-style: dashed; border-radius: 5px;\\"><p>Content</p><input type=\\"file\\" multiple=\\"\\" style=\\"display: none;\\"></div>"`;
+exports[`Dropzone document drop protection installs hooks to prevent stray drops from taking over the browser window 1`] = `"<div><input type=\\"file\\" multiple=\\"\\" autocomplete=\\"off\\" style=\\"display: none;\\"><p>Content</p></div>"`;

--- a/src/index.js
+++ b/src/index.js
@@ -391,8 +391,31 @@ Dropzone.propTypes = {
    */
   onClick: PropTypes.func,
 
-  /**
-   * onDrop callback
+  /** The `onDrop` method that accepts two arguments. The first argument represents the accepted files and the second argument the rejected files.
+
+   ```javascript
+   function onDrop(acceptedFiles, rejectedFiles) {
+  // do stuff with files...
+}
+   ```
+
+   Files accepted or rejected based on `accept` prop. This must be a valid [MIME type](http://www.iana.org/assignments/media-types/media-types.xhtml) according to [input element specification](https://www.w3.org/wiki/HTML/Elements/input/file).
+
+   Please note that `onDrop` method will always be called regardless if dropped file was accepted or rejected. The `onDropAccepted` method will be called if all dropped files were accepted and the `onDropRejected` method will be called if any of the dropped files was rejected.
+
+   Using `react-dropzone` is similar to using a file form field, but instead of getting the `files` property from the field, you listen to the `onDrop` callback to handle the files. Simple explanation here: http://abandon.ie/notebook/simple-file-uploads-using-jquery-ajax
+
+   Specifying the `onDrop` method, provides you with an array of [Files](https://developer.mozilla.org/en-US/docs/Web/API/File) which you can then send to a server. For example, with [SuperAgent](https://github.com/visionmedia/superagent) as a http/ajax library:
+
+   ```javascript
+   function onDrop(acceptedFiles) {
+  const req = request.post('/upload')
+  acceptedFiles.forEach(file => {
+      req.attach(file.name, file)
+  })
+  req.end(callback)
+}
+   ```
    */
   onDrop: PropTypes.func,
 

--- a/src/index.spec.js
+++ b/src/index.spec.js
@@ -347,6 +347,7 @@ describe('Dropzone', () => {
       const child = dropzone.find(DummyChildComponent)
       dropzone.simulate('dragEnter', { dataTransfer: { files } })
       expect(child).toHaveProp('isDragActive', true)
+      expect(child).toHaveProp('isDragAccept', true)
       expect(child).toHaveProp('isDragReject', false)
     })
 
@@ -358,11 +359,12 @@ describe('Dropzone', () => {
       )
       const child = dropzone.find(DummyChildComponent)
       dropzone.simulate('dragEnter', { dataTransfer: { files: files.concat(images) } })
-      expect(child).toHaveProp('isDragActive', false)
+      expect(child).toHaveProp('isDragActive', true)
+      expect(child).toHaveProp('isDragAccept', false)
       expect(child).toHaveProp('isDragReject', true)
     })
 
-    it('should set proper dragActive state if multiple is false', () => {
+    it('should set proper dragAccept state if multiple is false', () => {
       const dropzone = mount(
         <Dropzone accept="image/*" multiple={false}>
           {props => <DummyChildComponent {...props} />}
@@ -370,11 +372,12 @@ describe('Dropzone', () => {
       )
       const child = dropzone.find(DummyChildComponent)
       dropzone.simulate('dragEnter', { dataTransfer: { files } })
-      expect(child).toHaveProp('isDragActive', false)
+      expect(child).toHaveProp('isDragActive', true)
+      expect(child).toHaveProp('isDragAccept', false)
       expect(child).toHaveProp('isDragReject', true)
     })
 
-    it('should set proper dragActive state if multiple is false', () => {
+    it('should set proper dragAccept state if multiple is false', () => {
       const dropzone = mount(
         <Dropzone accept="image/*" multiple={false}>
           {props => <DummyChildComponent {...props} />}
@@ -383,6 +386,7 @@ describe('Dropzone', () => {
       const child = dropzone.find(DummyChildComponent)
       dropzone.simulate('dragEnter', { dataTransfer: { files: images } })
       expect(child).toHaveProp('isDragActive', true)
+      expect(child).toHaveProp('isDragAccept', true)
       expect(child).toHaveProp('isDragReject', true)
     })
 
@@ -395,22 +399,24 @@ describe('Dropzone', () => {
       const child = dropzone.find(DummyChildComponent)
       dropzone.simulate('dragEnter', { dataTransfer: { files: images } })
       expect(child).toHaveProp('isDragActive', true)
+      expect(child).toHaveProp('isDragAccept', true)
       expect(child).toHaveProp('isDragReject', false)
 
       dropzone.setProps({ accept: 'text/*' })
-      expect(child).toHaveProp('isDragActive', false)
+      expect(child).toHaveProp('isDragActive', true)
+      expect(child).toHaveProp('isDragAccept', false)
       expect(child).toHaveProp('isDragReject', true)
     })
 
     it('should expose state to children', () => {
       const dropzone = mount(
         <Dropzone accept="image/*">
-          {({ isDragActive, isDragReject }) => {
+          {({ isDragActive, isDragAccept, isDragReject }) => {
             if (isDragReject) {
-              return 'Rejected'
+              return `${isDragActive && 'Active but'} Reject`
             }
-            if (isDragActive) {
-              return 'Active'
+            if (isDragAccept) {
+              return `${isDragActive && 'Active and'} Accept`
             }
             return 'Empty'
           }}
@@ -418,24 +424,24 @@ describe('Dropzone', () => {
       )
       expect(dropzone.text()).toEqual('Empty')
       dropzone.simulate('dragEnter', { dataTransfer: { files: images } })
-      expect(dropzone.text()).toEqual('Active')
+      expect(dropzone.text()).toEqual('Active and Accept')
       dropzone.simulate('dragEnter', { dataTransfer: { files } })
-      expect(dropzone.text()).toEqual('Rejected')
+      expect(dropzone.text()).toEqual('Active but Reject')
     })
 
-    it('should reset the dragActive/dragReject state when leaving after a child goes away', () => {
-      const DragActiveComponent = () => <p>Active</p>
+    it('should reset the dragAccept/dragReject state when leaving after a child goes away', () => {
+      const DragActiveComponent = () => <p>Accept</p>
       const ChildComponent = () => <p>Child component content</p>
       const dropzone = mount(
         <Dropzone>
-          {({ isDragActive, isDragReject }) => {
+          {({ isDragAccept, isDragReject }) => {
             if (isDragReject) {
               return 'Rejected'
             }
-            if (isDragActive) {
-              return <DragActiveComponent isDragActive={isDragActive} isDragReject={isDragReject} />
+            if (isDragAccept) {
+              return <DragActiveComponent isDragAccept={isDragAccept} isDragReject={isDragReject} />
             }
-            return <ChildComponent isDragActive={isDragActive} isDragReject={isDragReject} />
+            return <ChildComponent isDragAccept={isDragAccept} isDragReject={isDragReject} />
           }}
         </Dropzone>
       )
@@ -446,12 +452,12 @@ describe('Dropzone', () => {
       dropzone.simulate('dragEnter', { dataTransfer: { files } })
       const dragActiveChild = dropzone.find(DragActiveComponent)
       expect(dragActiveChild).toBePresent()
-      expect(dragActiveChild).toHaveProp('isDragActive', true)
+      expect(dragActiveChild).toHaveProp('isDragAccept', true)
       expect(dragActiveChild).toHaveProp('isDragReject', false)
 
       dropzone.simulate('dragLeave', { dataTransfer: { files } })
       expect(dropzone.find(DragActiveComponent)).toBeEmpty()
-      expect(child).toHaveProp('isDragActive', false)
+      expect(child).toHaveProp('isDragAccept', false)
       expect(child).toHaveProp('isDragReject', false)
     })
   })

--- a/src/index.spec.js
+++ b/src/index.spec.js
@@ -36,66 +36,58 @@ describe('Dropzone', () => {
     it('should render children', () => {
       const dropzone = mount(
         <Dropzone>
-          <p>some content</p>
+          {({ getRootProps, getInputProps }) => (
+            <div {...getRootProps()}>
+              <input {...getInputProps()} />
+            </div>
+          )}
         </Dropzone>
       )
       expect(dropzone.html()).toMatchSnapshot()
     })
 
-    it('should render an input HTML element', () => {
+    it('sets ref properly', () => {
       const dropzone = mount(
         <Dropzone>
-          <p>some content</p>
+          {({ getRootProps, getInputProps }) => (
+            <div {...getRootProps()}>
+              <input {...getInputProps()} />
+            </div>
+          )}
         </Dropzone>
       )
-      expect(dropzone.find('input').length).toEqual(1)
-    })
-
-    it('sets ref properly', () => {
-      const dropzone = mount(<Dropzone />)
       expect(dropzone.instance().fileInputEl).not.toBeUndefined()
       expect(dropzone.instance().fileInputEl.tagName).toEqual('INPUT')
     })
 
-    it('renders dynamic props on the root element', () => {
-      const component = mount(<Dropzone hidden aria-hidden title="Dropzone" />)
-      expect(component.html()).toContain('aria-hidden="true"')
-      expect(component.html()).toContain('hidden=""')
-      expect(component.html()).toContain('title="Dropzone"')
-    })
-
-    it('renders dynamic props on the input element', () => {
-      const component = mount(<Dropzone inputProps={{ id: 'hiddenFileInput' }} />)
-      expect(component.find('input').html()).toContain('id="hiddenFileInput"')
-    })
-
     it('applies the accept prop to the child input', () => {
-      const component = render(<Dropzone className="my-dropzone" accept="image/jpeg" />)
+      const component = render(
+        <Dropzone accept="image/jpeg">
+          {({ getRootProps, getInputProps }) => (
+            <div className="my-dropzone" {...getRootProps()}>
+              <input {...getInputProps()} />
+            </div>
+          )}
+        </Dropzone>
+      )
       expect(component.find('.my-dropzone').attr()).not.toContain('accept')
       expect(Object.keys(component.find('input').attr())).toContain('accept')
       expect(component.find('input').attr('accept')).toEqual('image/jpeg')
     })
 
     it('applies the name prop to the child input', () => {
-      const component = render(<Dropzone className="my-dropzone" name="test-file-input" />)
+      const component = render(
+        <Dropzone name="test-file-input">
+          {({ getRootProps, getInputProps }) => (
+            <div className="my-dropzone" {...getRootProps()}>
+              <input {...getInputProps()} />
+            </div>
+          )}
+        </Dropzone>
+      )
       expect(component.find('.my-dropzone').attr()).not.toContain('name')
       expect(Object.keys(component.find('input').attr())).toContain('name')
       expect(component.find('input').attr('name')).toEqual('test-file-input')
-    })
-
-    it('should render children function', () => {
-      const content = <p>some content</p>
-      const dropzone = mount(
-        <Dropzone>
-          {content}
-        </Dropzone>
-      )
-      const dropzoneWithFunction = mount(
-        <Dropzone>
-          {() => content}
-        </Dropzone>
-      )
-      expect(dropzoneWithFunction.html()).toEqual(dropzone.html())
     })
   })
 
@@ -126,7 +118,16 @@ describe('Dropzone', () => {
     }
 
     it('installs hooks to prevent stray drops from taking over the browser window', () => {
-      dropzone = mount(<Dropzone><p>Content</p></Dropzone>)
+      dropzone = mount(
+        <Dropzone>
+          {({ getRootProps, getInputProps }) => (
+            <div {...getRootProps()}>
+              <input {...getInputProps()} />
+              <p>Content</p>
+            </div>
+          )}
+        </Dropzone>
+      )
       expect(dropzone.html()).toMatchSnapshot()
       expect(document.addEventListener.callCount).toEqual(2)
       addEventCalls = collectEventListenerCalls(document.addEventListener.args)
@@ -165,7 +166,15 @@ describe('Dropzone', () => {
     })
 
     it('does not prevent stray drops when preventDropOnDocument is false', () => {
-      dropzone = mount(<Dropzone preventDropOnDocument={false} />)
+      dropzone = mount(
+        <Dropzone preventDropOnDocument={false}>
+          {({ getRootProps, getInputProps }) => (
+            <div {...getRootProps()}>
+              <input {...getInputProps()} />
+            </div>
+          )}
+        </Dropzone>
+      )
       expect(dropzone.html()).toMatchSnapshot()
       expect(document.addEventListener.callCount).toEqual(0)
 
@@ -176,7 +185,15 @@ describe('Dropzone', () => {
 
   describe('onClick', () => {
     it('should call `open` method', done => {
-      const dropzone = mount(<Dropzone />)
+      const dropzone = mount(
+        <Dropzone>
+          {({ getRootProps, getInputProps }) => (
+            <div {...getRootProps()}>
+              <input {...getInputProps()} />
+            </div>
+          )}
+        </Dropzone>
+      )
       spy(dropzone.instance(), 'open')
       dropzone.simulate('click')
       setTimeout(() => {
@@ -186,7 +203,15 @@ describe('Dropzone', () => {
     })
 
     it('should not call `open` if disableClick prop is true', () => {
-      const dropzone = mount(<Dropzone disableClick />)
+      const dropzone = mount(
+        <Dropzone disableClick>
+          {({ getRootProps, getInputProps }) => (
+            <div {...getRootProps()}>
+              <input {...getInputProps()} />
+            </div>
+          )}
+        </Dropzone>
+      )
       spy(dropzone.instance(), 'open')
       dropzone.simulate('click')
       expect(dropzone.instance().open.callCount).toEqual(0)
@@ -194,7 +219,15 @@ describe('Dropzone', () => {
 
     it('should call `onClick` callback if provided', done => {
       const clickSpy = spy()
-      const dropzone = mount(<Dropzone onClick={clickSpy} />)
+      const dropzone = mount(
+        <Dropzone onClick={clickSpy}>
+          {({ getRootProps, getInputProps }) => (
+            <div {...getRootProps()}>
+              <input {...getInputProps()} />
+            </div>
+          )}
+        </Dropzone>
+      )
       spy(dropzone.instance(), 'open')
       dropzone.simulate('click')
       setTimeout(() => {
@@ -205,7 +238,15 @@ describe('Dropzone', () => {
     })
 
     it('should reset the value of input', () => {
-      const dropzone = mount(<Dropzone />)
+      const dropzone = mount(
+        <Dropzone>
+          {({ getRootProps, getInputProps }) => (
+            <div {...getRootProps()}>
+              <input {...getInputProps()} />
+            </div>
+          )}
+        </Dropzone>
+      )
       expect(dropzone.render().find('input').attr('value')).toBeUndefined()
       expect(dropzone.render().find('input').attr('value', 10)).not.toBeUndefined()
       dropzone.simulate('click')
@@ -213,7 +254,15 @@ describe('Dropzone', () => {
     })
 
     it('should trigger click even on the input', done => {
-      const dropzone = mount(<Dropzone />)
+      const dropzone = mount(
+        <Dropzone>
+          {({ getRootProps, getInputProps }) => (
+            <div {...getRootProps()}>
+              <input {...getInputProps()} />
+            </div>
+          )}
+        </Dropzone>
+      )
       const clickSpy = spy(dropzone.instance().fileInputEl, 'click')
       dropzone.simulate('click')
       dropzone.simulate('click')
@@ -228,7 +277,13 @@ describe('Dropzone', () => {
       const onClickInnerSpy = spy()
       const component = mount(
         <div onClick={onClickOuterSpy}>
-          <Dropzone onClick={onClickInnerSpy} />
+          <Dropzone onClick={onClickInnerSpy}>
+            {({ getRootProps, getInputProps }) => (
+              <div {...getRootProps()}>
+                <input {...getInputProps()} />
+              </div>
+            )}
+          </Dropzone>
         </div>
       )
 
@@ -248,7 +303,13 @@ describe('Dropzone', () => {
       const onClickOuterSpy = spy()
       const component = mount(
         <div onClick={onClickOuterSpy}>
-          <Dropzone disableClick />
+          <Dropzone disableClick>
+            {({ getRootProps, getInputProps }) => (
+              <div {...getRootProps()}>
+                <input {...getInputProps()} />
+              </div>
+            )}
+          </Dropzone>
         </div>
       )
 
@@ -258,9 +319,21 @@ describe('Dropzone', () => {
 
     it('should invoke inputProps onClick if provided', done => {
       const inputPropsClickSpy = spy()
-      const component = mount(<Dropzone inputProps={{ onClick: inputPropsClickSpy }} />)
+      const component = mount(
+        <Dropzone>
+          {({ getRootProps, getInputProps }) => (
+            <div {...getRootProps()}>
+              <input
+                {...getInputProps({
+                  onClick: inputPropsClickSpy
+                })}
+              />
+            </div>
+          )}
+        </Dropzone>
+      )
 
-      component.find('Dropzone').simulate('click')
+      component.find('input').simulate('click')
       setTimeout(() => {
         expect(inputPropsClickSpy.callCount).toEqual(1)
         done()
@@ -280,7 +353,13 @@ describe('Dropzone', () => {
           onDragEnter={dragEnterSpy}
           onDragOver={dragOverSpy}
           onDragLeave={dragLeaveSpy}
-        />
+        >
+          {({ getRootProps, getInputProps }) => (
+            <div {...getRootProps()}>
+              <input {...getInputProps()} />
+            </div>
+          )}
+        </Dropzone>
       )
       component.simulate('dragStart')
       component.simulate('dragEnter', { dataTransfer: { items: files } })
@@ -297,11 +376,13 @@ describe('Dropzone', () => {
       const dragEnterSpy = spy()
       const dragLeaveSpy = spy()
       const component = mount(
-        <Dropzone
-          onDragStart={dragStartSpy}
-          onDragEnter={dragEnterSpy}
-          onDragLeave={dragLeaveSpy}
-        />
+        <Dropzone onDragStart={dragStartSpy} onDragEnter={dragEnterSpy} onDragLeave={dragLeaveSpy}>
+          {({ getRootProps, getInputProps }) => (
+            <div {...getRootProps()}>
+              <input {...getInputProps()} />
+            </div>
+          )}
+        </Dropzone>
       )
 
       // Using Proxy we'll emulate IE throwing when setting dataTransfer.dropEffect
@@ -341,7 +422,12 @@ describe('Dropzone', () => {
     it('should set proper dragActive state on dragEnter', () => {
       const dropzone = mount(
         <Dropzone>
-          {props => <DummyChildComponent {...props} />}
+          {({ getRootProps, getInputProps, ...restProps }) => (
+            <div {...getRootProps()}>
+              <input {...getInputProps()} />
+              <DummyChildComponent {...restProps} />
+            </div>
+          )}
         </Dropzone>
       )
       const child = dropzone.find(DummyChildComponent)
@@ -354,7 +440,12 @@ describe('Dropzone', () => {
     it('should set proper dragReject state on dragEnter', () => {
       const dropzone = mount(
         <Dropzone accept="image/*">
-          {props => <DummyChildComponent {...props} />}
+          {({ getRootProps, getInputProps, ...restProps }) => (
+            <div {...getRootProps()}>
+              <input {...getInputProps()} />
+              <DummyChildComponent {...restProps} />
+            </div>
+          )}
         </Dropzone>
       )
       const child = dropzone.find(DummyChildComponent)
@@ -367,7 +458,12 @@ describe('Dropzone', () => {
     it('should set proper dragAccept state if multiple is false', () => {
       const dropzone = mount(
         <Dropzone accept="image/*" multiple={false}>
-          {props => <DummyChildComponent {...props} />}
+          {({ getRootProps, getInputProps, ...rest }) => (
+            <div {...getRootProps()}>
+              <input {...getInputProps()} />
+              <DummyChildComponent {...rest} />
+            </div>
+          )}
         </Dropzone>
       )
       const child = dropzone.find(DummyChildComponent)
@@ -380,7 +476,12 @@ describe('Dropzone', () => {
     it('should set proper dragAccept state if multiple is false', () => {
       const dropzone = mount(
         <Dropzone accept="image/*" multiple={false}>
-          {props => <DummyChildComponent {...props} />}
+          {({ getRootProps, getInputProps, ...rest }) => (
+            <div {...getRootProps()}>
+              <input {...getInputProps()} />
+              <DummyChildComponent {...rest} />
+            </div>
+          )}
         </Dropzone>
       )
       const child = dropzone.find(DummyChildComponent)
@@ -393,7 +494,12 @@ describe('Dropzone', () => {
     it('should set proper dragActive state if accept prop changes mid-drag', () => {
       const dropzone = mount(
         <Dropzone accept="image/*">
-          {props => <DummyChildComponent {...props} />}
+          {({ getRootProps, getInputProps, ...rest }) => (
+            <div {...getRootProps()}>
+              <input {...getInputProps()} />
+              <DummyChildComponent {...rest} />
+            </div>
+          )}
         </Dropzone>
       )
       const child = dropzone.find(DummyChildComponent)
@@ -411,15 +517,14 @@ describe('Dropzone', () => {
     it('should expose state to children', () => {
       const dropzone = mount(
         <Dropzone accept="image/*">
-          {({ isDragActive, isDragAccept, isDragReject }) => {
-            if (isDragReject) {
-              return `${isDragActive && 'Active but'} Reject`
-            }
-            if (isDragAccept) {
-              return `${isDragActive && 'Active and'} Accept`
-            }
-            return 'Empty'
-          }}
+          {({ getRootProps, getInputProps, isDragActive, isDragAccept, isDragReject }) => (
+            <div {...getRootProps()}>
+              <input {...getInputProps()} />
+              {isDragReject && `${isDragActive && 'Active but'} Reject`}
+              {isDragAccept && `${isDragActive && 'Active and'} Accept`}
+              {!isDragActive && 'Empty'}
+            </div>
+          )}
         </Dropzone>
       )
       expect(dropzone.text()).toEqual('Empty')
@@ -434,15 +539,16 @@ describe('Dropzone', () => {
       const ChildComponent = () => <p>Child component content</p>
       const dropzone = mount(
         <Dropzone>
-          {({ isDragAccept, isDragReject }) => {
-            if (isDragReject) {
-              return 'Rejected'
-            }
-            if (isDragAccept) {
-              return <DragActiveComponent isDragAccept={isDragAccept} isDragReject={isDragReject} />
-            }
-            return <ChildComponent isDragAccept={isDragAccept} isDragReject={isDragReject} />
-          }}
+          {({ getRootProps, getInputProps, isDragActive, isDragAccept, isDragReject }) => (
+            <div {...getRootProps()}>
+              <input {...getInputProps()} />
+              {isDragReject && 'Rejected'}
+              {isDragAccept &&
+                <DragActiveComponent isDragAccept={isDragAccept} isDragReject={isDragReject} />}
+              {!isDragActive &&
+                <ChildComponent isDragAccept={isDragAccept} isDragReject={isDragReject} />}
+            </div>
+          )}
         </Dropzone>
       )
       const child = dropzone.find(ChildComponent)
@@ -486,7 +592,12 @@ describe('Dropzone', () => {
           onDropAccepted={dropAcceptedSpy}
           onDropRejected={dropRejectedSpy}
         >
-          {props => <DummyChildComponent {...props} />}
+          {({ getRootProps, getInputProps, ...restProps }) => (
+            <div {...getRootProps()}>
+              <input {...getInputProps()} />
+              <DummyChildComponent {...restProps} />
+            </div>
+          )}
         </Dropzone>
       )
       const child = dropzone.find(DummyChildComponent)
@@ -499,21 +610,45 @@ describe('Dropzone', () => {
     })
 
     it('should add valid files to rejected files on a multple drop when multiple false', () => {
-      const dropzone = mount(<Dropzone accept="image/*" onDrop={dropSpy} multiple={false} />)
+      const dropzone = mount(
+        <Dropzone accept="image/*" onDrop={dropSpy} multiple={false}>
+          {({ getRootProps, getInputProps }) => (
+            <div {...getRootProps()}>
+              <input {...getInputProps()} />
+            </div>
+          )}
+        </Dropzone>
+      )
       dropzone.simulate('drop', { dataTransfer: { files: images } })
       const rejected = dropSpy.firstCall.args[0]
       expect(rejected.length).toEqual(1)
     })
 
     it('should add invalid files to rejected when multiple is false', () => {
-      const dropzone = mount(<Dropzone accept="image/*" onDrop={dropSpy} multiple={false} />)
+      const dropzone = mount(
+        <Dropzone accept="image/*" onDrop={dropSpy} multiple={false}>
+          {({ getRootProps, getInputProps }) => (
+            <div {...getRootProps()}>
+              <input {...getInputProps()} />
+            </div>
+          )}
+        </Dropzone>
+      )
       dropzone.simulate('drop', { dataTransfer: { files: images.concat(files) } })
       const rejected = dropSpy.firstCall.args[1]
       expect(rejected.length).toEqual(2)
     })
 
     it('should allow single files to be dropped if multiple is false', () => {
-      const dropzone = mount(<Dropzone accept="image/*" onDrop={dropSpy} multiple={false} />)
+      const dropzone = mount(
+        <Dropzone accept="image/*" onDrop={dropSpy} multiple={false}>
+          {({ getRootProps, getInputProps }) => (
+            <div {...getRootProps()}>
+              <input {...getInputProps()} />
+            </div>
+          )}
+        </Dropzone>
+      )
 
       dropzone.simulate('drop', { dataTransfer: { files: [images[0]] } })
       const [accepted, rejected] = dropSpy.firstCall.args
@@ -522,7 +657,15 @@ describe('Dropzone', () => {
     })
 
     it('should take all dropped files if multiple is true', () => {
-      const dropzone = mount(<Dropzone onDrop={dropSpy} multiple />)
+      const dropzone = mount(
+        <Dropzone onDrop={dropSpy} multiple>
+          {({ getRootProps, getInputProps }) => (
+            <div {...getRootProps()}>
+              <input {...getInputProps()} />
+            </div>
+          )}
+        </Dropzone>
+      )
       dropzone.simulate('drop', { dataTransfer: { files: images } })
       expect(dropSpy.firstCall.args[0]).toHaveLength(2)
       expect(dropSpy.firstCall.args[0][0].name).toEqual(images[0].name)
@@ -530,7 +673,15 @@ describe('Dropzone', () => {
     })
 
     it('should set this.isFileDialogActive to false', () => {
-      const dropzone = mount(<Dropzone />)
+      const dropzone = mount(
+        <Dropzone>
+          {({ getRootProps, getInputProps }) => (
+            <div {...getRootProps()}>
+              <input {...getInputProps()} />
+            </div>
+          )}
+        </Dropzone>
+      )
       dropzone.instance().isFileDialogActive = true
       dropzone.simulate('drop', { dataTransfer: { files } })
       expect(dropzone.instance().isFileDialogActive).toEqual(false)
@@ -543,7 +694,13 @@ describe('Dropzone', () => {
           onDropAccepted={dropAcceptedSpy}
           onDropRejected={dropRejectedSpy}
           accept="image/*"
-        />
+        >
+          {({ getRootProps, getInputProps }) => (
+            <div {...getRootProps()}>
+              <input {...getInputProps()} />
+            </div>
+          )}
+        </Dropzone>
       )
       dropzone.simulate('drop', { dataTransfer: { files } })
       expect(dropSpy.callCount).toEqual(1)
@@ -563,7 +720,13 @@ describe('Dropzone', () => {
           onDropAccepted={dropAcceptedSpy}
           onDropRejected={dropRejectedSpy}
           accept="image/*"
-        />
+        >
+          {({ getRootProps, getInputProps }) => (
+            <div {...getRootProps()}>
+              <input {...getInputProps()} />
+            </div>
+          )}
+        </Dropzone>
       )
       dropzone.simulate('drop', { dataTransfer: { files } })
       expect(dropAcceptedSpy.callCount).toEqual(0)
@@ -582,7 +745,13 @@ describe('Dropzone', () => {
           onDropAccepted={dropAcceptedSpy}
           onDropRejected={dropRejectedSpy}
           accept="image/*"
-        />
+        >
+          {({ getRootProps, getInputProps }) => (
+            <div {...getRootProps()}>
+              <input {...getInputProps()} />
+            </div>
+          )}
+        </Dropzone>
       )
       dropzone.simulate('drop', { dataTransfer: { files } })
       expect(dropRejectedSpy.callCount).toEqual(1)
@@ -601,7 +770,13 @@ describe('Dropzone', () => {
           onDropAccepted={dropAcceptedSpy}
           onDropRejected={dropRejectedSpy}
           accept="image/*"
-        />
+        >
+          {({ getRootProps, getInputProps }) => (
+            <div {...getRootProps()}>
+              <input {...getInputProps()} />
+            </div>
+          )}
+        </Dropzone>
       )
       dropzone.simulate('drop', { dataTransfer: { files } })
       expect(dropSpy.callCount).toEqual(1)
@@ -619,7 +794,13 @@ describe('Dropzone', () => {
           onDropAccepted={dropAcceptedSpy}
           onDropRejected={dropRejectedSpy}
           accept="image/*"
-        />
+        >
+          {({ getRootProps, getInputProps }) => (
+            <div {...getRootProps()}>
+              <input {...getInputProps()} />
+            </div>
+          )}
+        </Dropzone>
       )
 
       dropzone.simulate('drop', { dataTransfer: { files: images } })
@@ -638,7 +819,13 @@ describe('Dropzone', () => {
           onDropAccepted={dropAcceptedSpy}
           onDropRejected={dropRejectedSpy}
           accept="image/*"
-        />
+        >
+          {({ getRootProps, getInputProps }) => (
+            <div {...getRootProps()}>
+              <input {...getInputProps()} />
+            </div>
+          )}
+        </Dropzone>
       )
       const bogusImages = [
         {
@@ -663,7 +850,13 @@ describe('Dropzone', () => {
           onDrop={dropSpy}
           onDropAccepted={dropAcceptedSpy}
           onDropRejected={dropRejectedSpy}
-        />
+        >
+          {({ getRootProps, getInputProps }) => (
+            <div {...getRootProps()}>
+              <input {...getInputProps()} />
+            </div>
+          )}
+        </Dropzone>
       )
       dropzone.simulate('drop', { dataTransfer: { files: files.concat(images) } })
       expect(dropSpy.callCount).toEqual(1)
@@ -681,7 +874,13 @@ describe('Dropzone', () => {
           onDropAccepted={dropAcceptedSpy}
           onDropRejected={dropRejectedSpy}
           maxSize={1111}
-        />
+        >
+          {({ getRootProps, getInputProps }) => (
+            <div {...getRootProps()}>
+              <input {...getInputProps()} />
+            </div>
+          )}
+        </Dropzone>
       )
 
       dropzone.simulate('drop', { dataTransfer: { files } })
@@ -700,7 +899,13 @@ describe('Dropzone', () => {
           onDropAccepted={dropAcceptedSpy}
           onDropRejected={dropRejectedSpy}
           maxSize={1111}
-        />
+        >
+          {({ getRootProps, getInputProps }) => (
+            <div {...getRootProps()}>
+              <input {...getInputProps()} />
+            </div>
+          )}
+        </Dropzone>
       )
       dropzone.simulate('drop', { dataTransfer: { files: images } })
       expect(dropSpy.callCount).toEqual(1)
@@ -718,7 +923,13 @@ describe('Dropzone', () => {
           onDropAccepted={dropAcceptedSpy}
           onDropRejected={dropRejectedSpy}
           minSize={1112}
-        />
+        >
+          {({ getRootProps, getInputProps }) => (
+            <div {...getRootProps()}>
+              <input {...getInputProps()} />
+            </div>
+          )}
+        </Dropzone>
       )
       dropzone.simulate('drop', { dataTransfer: { files } })
       expect(dropSpy.callCount).toEqual(1)
@@ -736,7 +947,13 @@ describe('Dropzone', () => {
           onDropAccepted={dropAcceptedSpy}
           onDropRejected={dropRejectedSpy}
           minSize={1112}
-        />
+        >
+          {({ getRootProps, getInputProps }) => (
+            <div {...getRootProps()}>
+              <input {...getInputProps()} />
+            </div>
+          )}
+        </Dropzone>
       )
       dropzone.simulate('drop', { dataTransfer: { files: images } })
       expect(dropSpy.callCount).toEqual(1)
@@ -753,7 +970,13 @@ describe('Dropzone', () => {
           onDrop={dropSpy}
           onDropAccepted={dropAcceptedSpy}
           onDropRejected={dropRejectedSpy}
-        />
+        >
+          {({ getRootProps, getInputProps }) => (
+            <div {...getRootProps()}>
+              <input {...getInputProps()} />
+            </div>
+          )}
+        </Dropzone>
       )
       dropzone.simulate('drop', { dataTransfer: { files: files.concat(images) } })
       expect(dropSpy.callCount).toEqual(1)
@@ -768,7 +991,15 @@ describe('Dropzone', () => {
   describe('preview', () => {
     it('should generate previews for non-images', () => {
       const dropSpy = spy()
-      const dropzone = mount(<Dropzone onDrop={dropSpy} />)
+      const dropzone = mount(
+        <Dropzone onDrop={dropSpy}>
+          {({ getRootProps, getInputProps }) => (
+            <div {...getRootProps()}>
+              <input {...getInputProps()} />
+            </div>
+          )}
+        </Dropzone>
+      )
       dropzone.simulate('drop', { dataTransfer: { files } })
       expect(Object.keys(dropSpy.firstCall.args[0][0])).toContain('preview')
       expect(dropSpy.firstCall.args[0][0].preview).toContain('data://file1.pdf')
@@ -776,7 +1007,15 @@ describe('Dropzone', () => {
 
     it('should generate previews for images', () => {
       const dropSpy = spy()
-      const dropzone = mount(<Dropzone onDrop={dropSpy} />)
+      const dropzone = mount(
+        <Dropzone onDrop={dropSpy}>
+          {({ getRootProps, getInputProps }) => (
+            <div {...getRootProps()}>
+              <input {...getInputProps()} />
+            </div>
+          )}
+        </Dropzone>
+      )
       dropzone.simulate('drop', { dataTransfer: { files: images } })
       expect(Object.keys(dropSpy.firstCall.args[0][0])).toContain('preview')
       expect(dropSpy.firstCall.args[0][0].preview).toContain('data://cats.gif')
@@ -784,7 +1023,15 @@ describe('Dropzone', () => {
 
     it('should not throw error when preview cannot be created', () => {
       const dropSpy = spy()
-      const dropzone = mount(<Dropzone onDrop={dropSpy} />)
+      const dropzone = mount(
+        <Dropzone onDrop={dropSpy}>
+          {({ getRootProps, getInputProps }) => (
+            <div {...getRootProps()}>
+              <input {...getInputProps()} />
+            </div>
+          )}
+        </Dropzone>
+      )
 
       dropzone.simulate('drop', { dataTransfer: { files: ['bad_val'] } })
 
@@ -793,7 +1040,15 @@ describe('Dropzone', () => {
 
     it('should not generate previews if disablePreview is true', () => {
       const dropSpy = spy()
-      const dropzone = mount(<Dropzone disablePreview onDrop={dropSpy} />)
+      const dropzone = mount(
+        <Dropzone disablePreview onDrop={dropSpy}>
+          {({ getRootProps, getInputProps }) => (
+            <div {...getRootProps()}>
+              <input {...getInputProps()} />
+            </div>
+          )}
+        </Dropzone>
+      )
       dropzone.simulate('drop', { dataTransfer: { files: images } })
       dropzone.simulate('drop', { dataTransfer: { files } })
       expect(dropSpy.callCount).toEqual(2)
@@ -807,7 +1062,15 @@ describe('Dropzone', () => {
   describe('onCancel', () => {
     it('should not invoke onFileDialogCancel everytime window receives focus', done => {
       const onCancelSpy = spy()
-      mount(<Dropzone id="on-cancel-example" onFileDialogCancel={onCancelSpy} />)
+      mount(
+        <Dropzone onFileDialogCancel={onCancelSpy}>
+          {({ getRootProps, getInputProps }) => (
+            <div id="on-cancel-example" {...getRootProps()}>
+              <input {...getInputProps()} />
+            </div>
+          )}
+        </Dropzone>
+      )
       // Simulated DOM event - onfocus
       document.body.addEventListener('focus', () => {})
       const evt = document.createEvent('HTMLEvents')
@@ -823,7 +1086,13 @@ describe('Dropzone', () => {
     it('should invoke onFileDialogCancel when window receives focus via cancel button', done => {
       const onCancelSpy = spy()
       const component = mount(
-        <Dropzone className="dropzone-content" onFileDialogCancel={onCancelSpy} />
+        <Dropzone onFileDialogCancel={onCancelSpy}>
+          {({ getRootProps, getInputProps }) => (
+            <div className="dropzone-content" {...getRootProps()}>
+              <input {...getInputProps()} />
+            </div>
+          )}
+        </Dropzone>
       )
 
       // Test / invoke the click event
@@ -867,11 +1136,14 @@ describe('Dropzone', () => {
         onDropRejected={innerDropRejectedSpy}
         accept="image/*"
       >
-        {({ isDragActive, isDragReject }) => {
-          if (isDragReject) return <InnerDragRejected />
-          if (isDragActive) return <InnerDragAccepted />
-          return <p>No drag</p>
-        }}
+        {({ getRootProps, getInputProps, isDragAccept, isDragReject, isDragActive }) => (
+          <div {...getRootProps()}>
+            <input {...getInputProps()} />
+            {isDragReject && <InnerDragRejected />}
+            {isDragAccept && <InnerDragAccepted />}
+            {!isDragActive && <p>No drag</p>}
+          </div>
+        )}
       </Dropzone>
     )
 
@@ -890,7 +1162,12 @@ describe('Dropzone', () => {
             onDropRejected={outerDropRejectedSpy}
             accept="image/*"
           >
-            {props => <InnerDropzone {...props} />}
+            {({ getRootProps, getInputProps, ...restProps }) => (
+              <div {...getRootProps()}>
+                <input {...getInputProps()} />
+                <InnerDropzone {...restProps} />
+              </div>
+            )}
           </Dropzone>
         )
         innerDropzone = outerDropzone.find(InnerDropzone)
@@ -936,7 +1213,15 @@ describe('Dropzone', () => {
 
   describe('behavior', () => {
     it('does not throw an error when html is dropped instead of files and multiple is false', () => {
-      const dropzone = mount(<Dropzone multiple={false} />)
+      const dropzone = mount(
+        <Dropzone multiple={false}>
+          {({ getRootProps, getInputProps }) => (
+            <div {...getRootProps()}>
+              <input {...getInputProps()} />
+            </div>
+          )}
+        </Dropzone>
+      )
 
       const fn = () => dropzone.simulate('drop', { dataTransfer: { files: [] } })
       expect(fn).not.toThrow()

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,0 +1,16 @@
+/* eslint-disable */
+/**
+ * This is intended to be used to compose event handlers
+ * They are executed in order until one of them calls
+ * `event.preventDefault()`. Not sure this is the best
+ * way to do this, but it seems legit...
+ * @param {Function} fns the event hanlder functions
+ * @return {Function} the event handler to add to an element
+ */
+export function composeEventHandlers(...fns) {
+  return (event, ...args) =>
+    fns.some(fn => {
+      fn && fn(event, ...args)
+      return event.preventDropzoneDefault
+    })
+}

--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -7,6 +7,10 @@ module.exports = {
   showUsage: true,
   showSidebar: false,
   serverPort: 8080,
+  compilerConfig: {
+    transforms: { dangerousTaggedTemplateString: true },
+    objectAssign: 'Object.assign'
+  },
   sections: [
     {
       content: 'README.md'

--- a/wallaby.config.js
+++ b/wallaby.config.js
@@ -12,10 +12,7 @@ module.exports = wallaby => ({
 
   env: {
     type: 'node',
-    runner: 'node',
-    params: {
-      runner: '--harmony_proxies'
-    }
+    runner: 'node'
   },
 
   testFramework: 'jest',

--- a/yarn.lock
+++ b/yarn.lock
@@ -1389,6 +1389,13 @@ buffer@^4.9.0:
     ieee754 "^1.1.4"
     isarray "^1.0.0"
 
+buffer@^5.0.3:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/buffer/-/buffer-5.1.0.tgz#c913e43678c7cb7c8bd16afbcddb6c5505e8f9fe"
+  dependencies:
+    base64-js "^1.0.2"
+    ieee754 "^1.1.4"
+
 builtin-modules@^1.0.0, builtin-modules@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/builtin-modules/-/builtin-modules-1.1.1.tgz#270f076c5a72c02f5b65a47df94c5fe3a278892f"
@@ -1981,6 +1988,10 @@ crypto-browserify@3.3.0:
     ripemd160 "0.2.0"
     sha.js "2.2.6"
 
+css-color-keywords@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/css-color-keywords/-/css-color-keywords-1.0.0.tgz#fea2616dc676b2962686b3af8dbdbe180b244e05"
+
 css-color-names@0.0.4:
   version "0.0.4"
   resolved "https://registry.yarnpkg.com/css-color-names/-/css-color-names-0.0.4.tgz#808adc2e79cf84738069b646cb20ec27beb629e0"
@@ -2020,6 +2031,14 @@ css-selector-tokenizer@^0.7.0:
     cssesc "^0.1.0"
     fastparse "^1.1.1"
     regexpu-core "^1.0.0"
+
+css-to-react-native@^2.0.3:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/css-to-react-native/-/css-to-react-native-2.2.0.tgz#d524ef7f39a2747a8914e86563669ba35b7cf2e7"
+  dependencies:
+    css-color-keywords "^1.0.0"
+    fbjs "^0.8.5"
+    postcss-value-parser "^3.3.0"
 
 css-what@2.1:
   version "2.1.0"
@@ -3039,6 +3058,18 @@ fb-watchman@^2.0.0:
   dependencies:
     bser "^2.0.0"
 
+fbjs@^0.8.16, fbjs@^0.8.5:
+  version "0.8.16"
+  resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.16.tgz#5e67432f550dc41b572bf55847b8aca64e5337db"
+  dependencies:
+    core-js "^1.0.0"
+    isomorphic-fetch "^2.1.1"
+    loose-envify "^1.0.0"
+    object-assign "^4.1.0"
+    promise "^7.1.1"
+    setimmediate "^1.0.5"
+    ua-parser-js "^0.7.9"
+
 fbjs@^0.8.4, fbjs@^0.8.9:
   version "0.8.12"
   resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.12.tgz#10b5d92f76d45575fd63a217d4ea02bea2f8ed04"
@@ -3783,6 +3814,10 @@ hoek@2.x.x:
   version "2.16.3"
   resolved "https://registry.yarnpkg.com/hoek/-/hoek-2.16.3.tgz#20bb7403d3cea398e91dc4710a8ff1b8274a25ed"
 
+hoist-non-react-statics@^2.5.0:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-2.5.0.tgz#d2ca2dfc19c5a91c5a6615ce8e564ef0347e2a40"
+
 home-or-tmp@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/home-or-tmp/-/home-or-tmp-2.0.0.tgz#e36c3f2d2cae7d746a857e38d18d5f32a7882db8"
@@ -4319,6 +4354,12 @@ is-plain-obj@^1.0.0, is-plain-obj@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-plain-obj/-/is-plain-obj-1.1.0.tgz#71a50c8429dfca773c92a390a4a03b39fcd51d3e"
 
+is-plain-object@^2.0.1:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/is-plain-object/-/is-plain-object-2.0.4.tgz#2c163b3fafb1b606d9d17928f05c2a1c38e07677"
+  dependencies:
+    isobject "^3.0.1"
+
 is-png@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-png/-/is-png-1.1.0.tgz#d574b12bf275c0350455570b0e5b57ab062077ce"
@@ -4440,6 +4481,10 @@ isobject@^2.0.0:
   resolved "https://registry.yarnpkg.com/isobject/-/isobject-2.1.0.tgz#f065561096a3f1da2ef46272f815c840d87e0c89"
   dependencies:
     isarray "1.0.0"
+
+isobject@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/isobject/-/isobject-3.0.1.tgz#4e431e92b11a9731636aa1f9c8d1ccbcfdab78df"
 
 isomorphic-fetch@^2.1.1:
   version "2.2.1"
@@ -6815,6 +6860,10 @@ react-icons@^2.2.5:
   dependencies:
     react-icon-base "2.0.7"
 
+react-is@^16.3.1:
+  version "16.3.2"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.3.2.tgz#f4d3d0e2f5fbb6ac46450641eb2e25bf05d36b22"
+
 react-styleguidist@^5.4.2:
   version "5.5.9"
   resolved "https://registry.yarnpkg.com/react-styleguidist/-/react-styleguidist-5.5.9.tgz#10f6e78a7ce4a5e945fee0a17909d0fb589b6d45"
@@ -7857,6 +7906,29 @@ style-loader@^0.17.0:
   resolved "https://registry.yarnpkg.com/style-loader/-/style-loader-0.17.0.tgz#e8254bccdb7af74bd58274e36107b4d5ab4df310"
   dependencies:
     loader-utils "^1.0.2"
+
+styled-components@^3.2.6:
+  version "3.2.6"
+  resolved "https://registry.yarnpkg.com/styled-components/-/styled-components-3.2.6.tgz#99e6e75a746bdedd295a17e03dd1493055a1cc3b"
+  dependencies:
+    buffer "^5.0.3"
+    css-to-react-native "^2.0.3"
+    fbjs "^0.8.16"
+    hoist-non-react-statics "^2.5.0"
+    is-plain-object "^2.0.1"
+    prop-types "^15.5.4"
+    react-is "^16.3.1"
+    stylis "^3.5.0"
+    stylis-rule-sheet "^0.0.10"
+    supports-color "^3.2.3"
+
+stylis-rule-sheet@^0.0.10:
+  version "0.0.10"
+  resolved "https://registry.yarnpkg.com/stylis-rule-sheet/-/stylis-rule-sheet-0.0.10.tgz#44e64a2b076643f4b52e5ff71efc04d8c3c4a430"
+
+stylis@^3.5.0:
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/stylis/-/stylis-3.5.0.tgz#016fa239663d77f868fef5b67cf201c4b7c701e1"
 
 sum-up@^1.0.1:
   version "1.0.3"


### PR DESCRIPTION
 🚧🚧🚧
Please don't merge yet. Still WIP!!!
🚧🚧🚧

The idea of this PR is to remove the internal styles and element management and make the library "headless" i.e. not concerned about how styles applied to elements (like downshift). The dropzone component should only be concerned with drag-n-drop behavior leaving style management up to the user since every implementation can be unique.

~~We might consider creating a SimpleDropzone component for the backward compatibility and drop-in replacement for current installations.~~

**What kind of change does this PR introduce?**

- [ ] bugfix
- [x] feature
- [x] refactoring / style
- [ ] build / chore
- [ ] documentation

**Did you add tests for your changes?**

- [ ] Yes, my code is well tested
- [ ] Not relevant

**If relevant, did you update the documentation?**

- [ ] Yes, I've updated the documentation
- [ ] Not relevant

**Summary**

See discussion around https://github.com/okonet/react-dropzone/issues/321

**Does this PR introduce a breaking change?**

Yes!
