### PR TITLE
test: Increase size-limit threshold to 6KB

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "size-limit": [
     {
       "path": "dist/index.js",
-      "limit": "5.76 KB"
+      "limit": "6 KB"
     }
   ],
   "lint-staged": {


### PR DESCRIPTION
Previous limit would fail the build even for tiniest changes like in https://github.com/react-dropzone/react-dropzone/pull/504. It should not fail such PRs.