### PR TITLE
fix: Add null check for node in onDocumentDrop

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -71,7 +71,7 @@ class Dropzone extends React.Component {
   }
 
   onDocumentDrop(evt) {
-    if (this.node.contains(evt.target)) {
+    if (this.node && this.node.contains(evt.target)) {
       // if we intercepted an event for our instance, let it propagate down to the instance's onDrop handler
       return
     }


### PR DESCRIPTION



**What kind of change does this PR introduce?**

- [x] bugfix


**If relevant, did you update the documentation?**

- [ ] Yes, I've updated the documentation
- [x] Not relevant

**Summary**

- Protect calling `this.node.contains` when `this.node` is null
- Fix IE11 bug where `onDocumentDrop` gets called with null `this.node` ref

closes #492

