### PR TITLE
Support fullscreen through documents eventListeners

### DIFF
--- a/examples/Basic/Readme.md
+++ b/examples/Basic/Readme.md
@@ -17,7 +17,7 @@ class Basic extends React.Component {
     return (
       <section>
         <div className="dropzone">
-          <Dropzone onDrop={this.onDrop.bind(this)}>
+          <Dropzone onDrop={this.onDrop.bind(this)} fullScreen={true} >
             <p>Try dropping some files here, or click to select files to upload.</p>
           </Dropzone>
         </div>

--- a/src/index.js
+++ b/src/index.js
@@ -16,13 +16,13 @@ class Dropzone extends React.Component {
   constructor(props, context) {
     super(props, context)
     this.composeHandlers = this.composeHandlers.bind(this)
-    this.onClick = this.onClick.bind(this)
+    this.onClick = this.composeHandlers(this.onClick.bind(this))
     this.onDocumentDrop = this.onDocumentDrop.bind(this)
-    this.onDragEnter = this.onDragEnter.bind(this)
-    this.onDragLeave = this.onDragLeave.bind(this)
-    this.onDragOver = this.onDragOver.bind(this)
-    this.onDragStart = this.onDragStart.bind(this)
-    this.onDrop = this.onDrop.bind(this)
+    this.onDragEnter = this.composeHandlers(this.onDragEnter.bind(this))
+    this.onDragLeave = this.composeHandlers(this.onDragLeave.bind(this))
+    this.onDragOver = this.composeHandlers(this.onDragOver.bind(this))
+    this.onDragStart = this.composeHandlers(this.onDragStart.bind(this))
+    this.onDrop = this.composeHandlers(this.onDrop.bind(this))
     this.onFileDialogCancel = this.onFileDialogCancel.bind(this)
     this.onInputElementClick = this.onInputElementClick.bind(this)
 
@@ -395,12 +395,12 @@ class Dropzone extends React.Component {
         className={className}
         style={appliedStyle}
         {...divProps /* expand user provided props first so event handlers are never overridden */}
-        onClick={this.composeHandlers(this.onClick)}
-        onDragStart={this.composeHandlers(this.onDragStart)}
-        onDragEnter={this.composeHandlers(this.onDragEnter)}
-        onDragOver={this.composeHandlers(this.onDragOver)}
-        onDragLeave={this.composeHandlers(this.onDragLeave)}
-        onDrop={this.composeHandlers(this.onDrop)}
+        onClick={this.onClick}
+        onDragStart={this.onDragStart}
+        onDragEnter={this.onDragEnter}
+        onDragOver={this.onDragOver}
+        onDragLeave={this.onDragLeave}
+        onDrop={this.onDrop}
         ref={this.setRef}
         aria-disabled={disabled}
       >

--- a/src/index.js
+++ b/src/index.js
@@ -16,12 +16,14 @@ class Dropzone extends React.Component {
   constructor(props, context) {
     super(props, context)
     this.composeHandlers = this.composeHandlers.bind(this)
+    this.composeHandlersFullscreen = this.composeHandlersFullscreen.bind(this)
     this.onClick = this.composeHandlers(this.onClick.bind(this))
     this.onDocumentDrop = this.onDocumentDrop.bind(this)
     this.onDragEnter = this.composeHandlers(this.onDragEnter.bind(this))
     this.onDragLeave = this.composeHandlers(this.onDragLeave.bind(this))
     this.onDragOver = this.composeHandlers(this.onDragOver.bind(this))
     this.onDragStart = this.composeHandlers(this.onDragStart.bind(this))
+    this.onDragEnd = this.composeHandlers(this.onDragEnd.bind(this))
     this.onDrop = this.composeHandlers(this.onDrop.bind(this))
     this.onFileDialogCancel = this.onFileDialogCancel.bind(this)
     this.onInputElementClick = this.onInputElementClick.bind(this)
@@ -39,23 +41,41 @@ class Dropzone extends React.Component {
   }
 
   componentDidMount() {
-    const { preventDropOnDocument } = this.props
+    const { preventDropOnDocument, fullScreen } = this.props
     this.dragTargets = []
 
-    if (preventDropOnDocument) {
+    if (preventDropOnDocument && !fullScreen) {
       document.addEventListener('dragover', onDocumentDragOver, false)
       document.addEventListener('drop', this.onDocumentDrop, false)
     }
+
+    if (fullScreen) {
+      document.addEventListener('dragenter', this.onDragEnter, false)
+      document.addEventListener('dragend', this.onDragEnd, false)
+      document.addEventListener('dragover', this.onDragOver, false)
+      document.addEventListener('dragStart', this.onDragStart, false)
+      document.addEventListener('drop', this.onDrop, false)
+    }
+
     this.fileInputEl.addEventListener('click', this.onInputElementClick, false)
     // Tried implementing addEventListener, but didn't work out
     document.body.onfocus = this.onFileDialogCancel
   }
 
   componentWillUnmount() {
-    const { preventDropOnDocument } = this.props
-    if (preventDropOnDocument) {
+    const { preventDropOnDocument, fullScreen } = this.props
+
+    if (preventDropOnDocument && !fullScreen) {
       document.removeEventListener('dragover', onDocumentDragOver)
       document.removeEventListener('drop', this.onDocumentDrop)
+    }
+
+    if (fullScreen) {
+      document.removeEventListener('dragenter', this.onDragEnter)
+      document.removeEventListener('dragend', this.onDragEnd)
+      document.removeEventListener('dragover', this.onDragOver)
+      document.removeEventListener('dragStart', this.onDragStart)
+      document.removeEventListener('drop', this.onDrop)
     }
     this.fileInputEl.removeEventListener('click', this.onInputElementClick, false)
     // Can be replaced with removeEventListener, if addEventListener works
@@ -64,6 +84,14 @@ class Dropzone extends React.Component {
 
   composeHandlers(handler) {
     if (this.props.disabled) {
+      return null
+    }
+
+    return handler
+  }
+
+  composeHandlersFullscreen(handler) {
+    if (this.props.fullScreen) {
       return null
     }
 
@@ -82,6 +110,19 @@ class Dropzone extends React.Component {
   onDragStart(evt) {
     if (this.props.onDragStart) {
       this.props.onDragStart.call(this, evt)
+    }
+  }
+
+  onDragEnd(evt) {
+    evt.preventDefault()
+
+    this.setState({
+      isDragActive: false,
+      draggedFiles: []
+    })
+
+    if (this.props.onDragLeave) {
+      this.props.onDragLeave.call(this, evt)
     }
   }
 
@@ -375,6 +416,7 @@ class Dropzone extends React.Component {
     const customProps = [
       'acceptedFiles',
       'preventDropOnDocument',
+      'fullScreen',
       'disablePreview',
       'disableClick',
       'activeClassName',
@@ -387,6 +429,7 @@ class Dropzone extends React.Component {
       'maxSize',
       'minSize'
     ]
+
     const divProps = { ...props }
     customProps.forEach(prop => delete divProps[prop])
 
@@ -396,11 +439,11 @@ class Dropzone extends React.Component {
         style={appliedStyle}
         {...divProps /* expand user provided props first so event handlers are never overridden */}
         onClick={this.onClick}
-        onDragStart={this.onDragStart}
-        onDragEnter={this.onDragEnter}
-        onDragOver={this.onDragOver}
-        onDragLeave={this.onDragLeave}
-        onDrop={this.onDrop}
+        onDragStart={this.composeHandlersFullscreen(this.onDragStart)}
+        onDragEnter={this.composeHandlersFullscreen(this.onDragEnter)}
+        onDragOver={this.composeHandlersFullscreen(this.onDragOver)}
+        onDragLeave={this.composeHandlersFullscreen(this.onDragLeave)}
+        onDrop={this.composeHandlersFullscreen(this.onDrop)}
         ref={this.setRef}
         aria-disabled={disabled}
       >
@@ -450,6 +493,11 @@ Dropzone.propTypes = {
    * If false, allow dropped items to take over the current browser window
    */
   preventDropOnDocument: PropTypes.bool,
+
+  /**
+   * If true, make dropzone in the document
+   */
+  fullScreen: PropTypes.bool,
 
   /**
    * Pass additional attributes to the `<input type="file"/>` tag
@@ -578,6 +626,7 @@ Dropzone.defaultProps = {
   disabled: false,
   disablePreview: false,
   disableClick: false,
+  fullScreen: false,
   multiple: true,
   maxSize: Infinity,
   minSize: 0

--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -24,23 +24,23 @@ module.exports = {
         {
           name: 'Basic example',
           content: 'examples/Basic/Readme.md'
-        },
-        {
-          name: 'Styling Dropzone',
-          content: 'examples/Styling/Readme.md'
-        },
-        {
-          name: 'Accepting specific file types',
-          content: 'examples/Accept/Readme.md'
-        },
-        {
-          name: 'Opening File Dialog Programmatically',
-          content: 'examples/File Dialog/Readme.md'
-        },
-        {
-          name: 'Full Screen Dropzone',
-          content: 'examples/Fullscreen/Readme.md'
         }
+        // {
+        //   name: 'Styling Dropzone',
+        //   content: 'examples/Styling/Readme.md'
+        // },
+        // {
+        //   name: 'Accepting specific file types',
+        //   content: 'examples/Accept/Readme.md'
+        // },
+        // {
+        //   name: 'Opening File Dialog Programmatically',
+        //   content: 'examples/File Dialog/Readme.md'
+        // },
+        // {
+        //   name: 'Full Screen Dropzone',
+        //   content: 'examples/Fullscreen/Readme.md'
+        // }
       ]
     }
   ]


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

⚠️  This PR is a proof of concept and also a way to explain the struggle that I'm facing **DO NOT** merge it.

**What kind of change does this PR introduce?**

- [ ] bugfix
- [x] feature
- [ ] refactoring / style
- [ ] build / chore
- [ ] documentation

**Did you add tests for your changes?**

- [ ] Yes, my code is well tested
- [x] Not relevant

**If relevant, did you update the documentation?**

- [ ] Yes, I've updated the documentation
- [x] Not relevant

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

My react application is just an container in my whole web application.
Which means that I can't make Dropzone fullscreen since I'm not able to wrap my whole website with dropzone component.

The workaround that I found was add a prop that enable the "fullscreen mode" setting the event listeners straight to the document.


**Other information**

The reason why I'm creating this PR is that I need some help.
Everything is working as expected except one thing:

The `dragend` event is not been fired.

If I drag an element from the DOM like a link it works, but if I drag a file from the finder it doesn't work.

I don't know what I'm missing here, maybe some one have a insight.
