### PR TITLE
fix: click on dropzone not working on Safari 10.1

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -252,6 +252,7 @@ class Dropzone extends React.Component {
   setRefs(ref) {
     this.fileInputEl = ref
   }
+
   /**
    * Open system file upload dialog.
    *
@@ -286,6 +287,7 @@ class Dropzone extends React.Component {
       multiple,
       name,
       rejectClassName,
+      disableClick,
       ...rest
     } = this.props
 
@@ -363,12 +365,10 @@ class Dropzone extends React.Component {
       multiple: supportMultiple && multiple,
       ref: this.setRefs,
       onChange: this.onDrop,
-      autoComplete: 'off',
-      id: 'selectFile'
+      autoComplete: 'off'
     }
 
     const labelAttributes = {
-      htmlFor: 'selectFile',
       style: {
         width: '100%',
         height: '100%',
@@ -399,6 +399,15 @@ class Dropzone extends React.Component {
     ]
     const divProps = { ...props }
     customProps.forEach(prop => delete divProps[prop])
+    const childContainer = (
+      <div>
+        <input
+          {...inputProps /* expand user provided inputProps first so inputAttributes override them */}
+          {...inputAttributes}
+        />
+        {this.renderChildren(children, isDragActive, isDragAccept, isDragReject)}
+      </div>
+    )
 
     return (
       <div
@@ -414,13 +423,7 @@ class Dropzone extends React.Component {
         ref={this.setRef}
         aria-disabled={disabled}
       >
-        <label {...labelAttributes}>
-          {this.renderChildren(children, isDragActive, isDragAccept, isDragReject)}
-        </label>
-        <input
-          {...inputProps /* expand user provided inputProps first so inputAttributes override them */}
-          {...inputAttributes}
-        />
+        {disableClick ? childContainer : <label {...labelAttributes}>{childContainer}</label>}
       </div>
     )
   }
@@ -449,8 +452,8 @@ Dropzone.propTypes = {
   disableClick: PropTypes.bool,
 
   /**
- * Enable/disable the dropzone entirely
- */
+   * Enable/disable the dropzone entirely
+   */
   disabled: PropTypes.bool,
 
   /**

--- a/src/index.js
+++ b/src/index.js
@@ -260,7 +260,6 @@ class Dropzone extends React.Component {
   open() {
     this.isFileDialogActive = true
     this.fileInputEl.value = null
-    this.fileInputEl.click()
   }
 
   renderChildren = (children, isDragActive, isDragAccept, isDragReject) => {
@@ -364,7 +363,18 @@ class Dropzone extends React.Component {
       multiple: supportMultiple && multiple,
       ref: this.setRefs,
       onChange: this.onDrop,
-      autoComplete: 'off'
+      autoComplete: 'off',
+      id: 'selectFile'
+    }
+
+    const labelAttributes = {
+      htmlFor: 'selectFile',
+      style: {
+        width: '100%',
+        height: '100%',
+        margin: 0,
+        cursor: 'pointer'
+      }
     }
 
     if (name && name.length) {
@@ -404,7 +414,9 @@ class Dropzone extends React.Component {
         ref={this.setRef}
         aria-disabled={disabled}
       >
-        {this.renderChildren(children, isDragActive, isDragAccept, isDragReject)}
+        <label {...labelAttributes}>
+          {this.renderChildren(children, isDragActive, isDragAccept, isDragReject)}
+        </label>
         <input
           {...inputProps /* expand user provided inputProps first so inputAttributes override them */}
           {...inputAttributes}


### PR DESCRIPTION
Change triggering click on the input to label with for attribute

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

- [x] bugfix
- [ ] feature
- [ ] refactoring / style
- [ ] build / chore
- [ ] documentation

**Did you add tests for your changes?**

- [ ] Yes, my code is well tested
- [x] Not relevant

**If relevant, did you update the documentation?**

- [ ] Yes, I've updated the documentation
- [x] Not relevant

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
The click event does not trigger on Safari 10.1. This is due to a security restriction. 

<!-- Try to link to an open issue for more information. -->
https://github.com/react-dropzone/react-dropzone/issues/522

**Does this PR introduce a breaking change?**
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->
No
**Other information**
