### PR TITLE
feat: add childrenProps

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -266,8 +266,8 @@ class Dropzone extends React.Component {
   renderChildren = (children, isDragActive, isDragAccept, isDragReject, childrenProps) => {
     if (typeof children === 'function') {
       return children({
-        ...this.state,
         ...childrenProps,
+        ...this.state,
         isDragActive,
         isDragAccept,
         isDragReject

--- a/src/index.js
+++ b/src/index.js
@@ -263,10 +263,11 @@ class Dropzone extends React.Component {
     this.fileInputEl.click()
   }
 
-  renderChildren = (children, isDragActive, isDragAccept, isDragReject) => {
+  renderChildren = (children, isDragActive, isDragAccept, isDragReject, childrenProps) => {
     if (typeof children === 'function') {
       return children({
         ...this.state,
+        ...childrenProps,
         isDragActive,
         isDragAccept,
         isDragReject
@@ -284,6 +285,7 @@ class Dropzone extends React.Component {
       disabled,
       disabledClassName,
       inputProps,
+      childrenProps,
       multiple,
       name,
       rejectClassName,
@@ -404,7 +406,7 @@ class Dropzone extends React.Component {
         ref={this.setRef}
         aria-disabled={disabled}
       >
-        {this.renderChildren(children, isDragActive, isDragAccept, isDragReject)}
+        {this.renderChildren(children, isDragActive, isDragAccept, isDragReject, childrenProps)}
         <input
           {...inputProps /* expand user provided inputProps first so inputAttributes override them */}
           {...inputAttributes}
@@ -430,6 +432,11 @@ Dropzone.propTypes = {
    * Contents of the dropzone
    */
   children: PropTypes.oneOfType([PropTypes.node, PropTypes.func]),
+
+  /**
+   * Additional props passed to children (only if 'children' is a function)
+   */
+  childrenProps: PropTypes.object,
 
   /**
    * Disallow clicking on the dropzone container to open file dialog

--- a/src/index.spec.js
+++ b/src/index.spec.js
@@ -103,6 +103,20 @@ describe('Dropzone', () => {
       const dropzoneWithFunction = mount(<Dropzone>{() => content}</Dropzone>)
       expect(dropzoneWithFunction.html()).toEqual(dropzone.html())
     })
+
+    it('should pass childrenProps to children function', () => {
+      const dropzone = mount(
+        <Dropzone>
+          <p>some content</p>
+        </Dropzone>
+      )
+      const dropzoneWithFunction = mount(
+        <Dropzone childrenProps={{ myProp: 'some content' }}>
+          {({ myProp }) => <p>{myProp}</p>}
+        </Dropzone>
+      )
+      expect(dropzoneWithFunction.html()).toEqual(dropzone.html())
+    })
   })
 
   describe('document drop protection', () => {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

- [ ] bugfix
- [x] feature
- [ ] refactoring / style
- [ ] build / chore
- [ ] documentation

**Did you add tests for your changes?**

- [x] Yes, my code is well tested
- [ ] Not relevant

**If relevant, did you update the documentation?**

- [ ] Yes, I've updated the documentation
- [x] Not relevant

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

Additionally to internal props like `isDragActive` or the state, i think it is useful to also pass custom props to a children function. In my particular use case, I want to re-use the function in several places, but also want to apply custom labels and styling to the content.

**Does this PR introduce a breaking change?**
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

No

**Other information**
