### PR TITLE
Fix: Add 'yarn.lock' to '.npmignore'

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -4,3 +4,4 @@
 logo/
 styleguide/
 coverage/
+yarn.lock


### PR DESCRIPTION
**What kind of change does this PR introduce?**

- [x] bugfix
- [ ] feature
- [ ] refactoring / style
- [ ] build / chore
- [ ] documentation

**Did you add tests for your changes?**

- [ ] Yes, my code is well tested
- [x] Not relevant

**If relevant, did you update the documentation?**

- [ ] Yes, I've updated the documentation
- [x] Not relevant

**Summary**

Due to the existence of `yarn.lock` in a package published to NPM register, we have problems with using proper versions of `@types/react` in our apps.

**Does this PR introduce a breaking change?**

No.

**Other information**
