### PR TITLE
feat(ssr): remove listener only if we added them

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -57,9 +57,9 @@ class Dropzone extends React.Component {
       document.removeEventListener('dragover', onDocumentDragOver)
       document.removeEventListener('drop', this.onDocumentDrop)
     }
-    this.fileInputEl.removeEventListener('click', this.onInputElementClick, false)
+    this.fileInputEl && this.fileInputEl.removeEventListener('click', this.onInputElementClick, false)
     // Can be replaced with removeEventListener, if addEventListener works
-    document.body.onfocus = null
+    document && document.body.onfocus = null
   }
 
   composeHandlers(handler) {


### PR DESCRIPTION
**What kind of change does this PR introduce?**

- [x] bugfix
- [ ] feature
- [ ] refactoring / style
- [ ] build / chore
- [ ] documentation

**Did you add tests for your changes?**

- [ ] Yes, my code is well tested
- [x] Not relevant

**If relevant, did you update the documentation?**

- [ ] Yes, I've updated the documentation
- [x] Not relevant

**Summary**

I have a tree-walker running for SSR and although componentWillMount and componentWillUnmount will be called on server, componentDidMount will not. Therefore we can't remove eventListener for the null ref.

**Does this PR introduce a breaking change?**
No