### PR TITLE
Chrome 63 hangs dragging a file onto the drop zone whilst the file dialog is open.

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,13 +53,13 @@ Using `react-dropzone` is similar to using a file form field, but instead of get
 Specifying the `onDrop` method, provides you with an array of [Files](https://developer.mozilla.org/en-US/docs/Web/API/File) which you can then send to a server. For example, with [SuperAgent](https://github.com/visionmedia/superagent) as a http/ajax library:
 
 ```javascript static
-    onDrop: acceptedFiles => {
-        const req = request.post('/upload');
-        acceptedFiles.forEach(file => {
-            req.attach(file.name, file);
-        });
-        req.end(callback);
-    }
+onDrop: acceptedFiles => {
+    const req = request.post('/upload');
+    acceptedFiles.forEach(file => {
+        req.attach(file.name, file);
+    });
+    req.end(callback);
+}
 ```
 
 **Warning**: On most recent browsers versions, the files given by `onDrop` won't have properties `path` or `fullPath`, see [this SO question](https://stackoverflow.com/a/23005925/2275818) and [this issue](https://github.com/react-dropzone/react-dropzone/issues/477).

--- a/src/index.js
+++ b/src/index.js
@@ -112,7 +112,10 @@ class Dropzone extends React.Component {
     evt.preventDefault()
     evt.stopPropagation()
     try {
-      evt.dataTransfer.dropEffect = 'copy' // eslint-disable-line no-param-reassign
+      // The file dialog on Chrome allows users to drag files from the dialog onto
+      // the dropzone, causing the browser the crash when the file dialog is closed.
+      // A drop effect of 'none' prevents the file from being dropped
+      evt.dataTransfer.dropEffect = this.isFileDialogActive ? 'none' : 'copy' // eslint-disable-line no-param-reassign
     } catch (err) {
       // continue regardless of error
     }


### PR DESCRIPTION
**What kind of change does this PR introduce?**

- [x] bugfix
- [ ] feature
- [ ] refactoring / style
- [ ] build / chore
- [ ] documentation

**Did you add tests for your changes?**

- [ ] Yes, my code is well tested
- [x] Not relevant

**If relevant, did you update the documentation?**

- [ ] Yes, I've updated the documentation
- [x] Not relevant

**Summary**

Chrome 63 hangs dragging a file onto the drop zone whilst the file dialog is open. 

https://github.com/react-dropzone/react-dropzone/issues/549
