### PR TITLE
fix: restore isFileDialogActive to false after the FileDialog was closed

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -236,16 +236,17 @@ class Dropzone extends React.Component {
   onFileDialogCancel() {
     // timeout will not recognize context of this method
     const { onFileDialogCancel } = this.props
-    const { fileInputEl } = this
-    let { isFileDialogActive } = this
-    // execute the timeout only if the onFileDialogCancel is defined and FileDialog
-    // is opened in the browser
-    if (onFileDialogCancel && isFileDialogActive) {
+    // execute the timeout only if the FileDialog is opened in the browser
+    if (this.isFileDialogActive) {
       setTimeout(() => {
         // Returns an object as FileList
-        const FileList = fileInputEl.files
-        if (!FileList.length) {
-          isFileDialogActive = false
+        const { files } = this.fileInputEl
+
+        if (!files.length) {
+          this.isFileDialogActive = false
+        }
+
+        if (typeof onFileDialogCancel === 'function') {
           onFileDialogCancel()
         }
       }, 300)

--- a/src/index.spec.js
+++ b/src/index.spec.js
@@ -981,6 +981,26 @@ describe('Dropzone', () => {
         }, 300)
       }, 0)
     })
+
+    it('should restore isFileDialogActive to false after the FileDialog was closed', done => {
+      const component = mount(<Dropzone />)
+
+      spy(component.instance(), 'open')
+      component.simulate('click')
+
+      setTimeout(() => {
+        expect(component.instance().isFileDialogActive).toEqual(true)
+
+        const evt = document.createEvent('HTMLEvents')
+        evt.initEvent('focus', false, true)
+        document.body.dispatchEvent(evt)
+
+        setTimeout(() => {
+          expect(component.instance().isFileDialogActive).toEqual(false)
+          done()
+        }, 300)
+      }, 0)
+    })
   })
 
   describe('nested Dropzone component behavior', () => {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

- [x] bugfix
- [ ] feature
- [ ] refactoring / style
- [ ] build / chore
- [ ] documentation

**Did you add tests for your changes?**

- [x] Yes, my code is well tested
- [ ] Not relevant

**If relevant, did you update the documentation?**

- [ ] Yes, I've updated the documentation
- [x] Not relevant

**Summary**

The `isFileDialogActive` wasn't changed after onFileDialogCancel() because it was a local variable

**Does this PR introduce a breaking change?**

No