### PR TITLE
umd build fix

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -26,8 +26,18 @@ module.exports = env => {
       extensions: ['.js', '.json']
     },
     externals: {
-      react: 'react',
-      'prop-types': 'prop-types'
+      react: {
+        root: 'React',
+        commonjs2: 'react',
+        commonjs: 'react',
+        amd: 'react'
+      },
+      'prop-types': {
+        root: 'PropTypes',
+        commonjs2: 'prop-types',
+        commonjs: 'prop-types',
+        amd: 'prop-types'
+      }
     }
   }
 }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

- [ ] bugfix
- [ ] feature
- [ ] refactoring / style
- [x] build / chore
- [ ] documentation

**Did you add tests for your changes?**

- [ ] Yes, my code is well tested
- [x] Not relevant

**If relevant, did you update the documentation?**

- [ ] Yes, I've updated the documentation
- [x] Not relevant

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

This pr solves a problem for the umd build with React loaded from the <script> tag as a global library. When including React from the script tag, it is available to the global namespace as the `window.React` object. However, when specifying the external library in webpack `externals: { "react" : "react" }`, it will return an error `Uncaught Error: Cannot find module "react".` since React is not available as a module but instead as a global object. Using `externals: { "react" : "React" }` instead will actually make Webpack fail to build, since the `import React from "react";` statement will not match any module.

It appears a solution, based on the comments on the link below (by user jide), is to specify `externals: { "react" : "umd react" }`, which takes care of both cases.

<!-- Try to link to an open issue for more information. -->
**Does this PR introduce a breaking change?**
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**

This is a [link](https://github.com/webpack/webpack/issues/1275
) describing the issue with webpack, packaging with react as an external library and umd.
Another [link](https://stackoverflow.com/a/34254167) from stackoverflow with another potential solution.
