### PR TITLE
Drop and Drop Folders - keeps package smaller

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,11 +26,11 @@
   "size-limit": [
     {
       "path": "dist/index.js",
-      "limit": "5.5 KB"
+      "limit": "5.8 KB"
     },
     {
       "path": "dist/es/index.js",
-      "limit": "3 KB"
+      "limit": "3.3 KB"
     }
   ],
   "lint-staged": {

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
   },
   "dependencies": {
     "attr-accept": "^1.0.3",
+    "html5-file-selector": "^1.0.1",
     "prop-types": "^15.5.7"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -75,7 +75,6 @@
   },
   "dependencies": {
     "attr-accept": "^1.0.3",
-    "html5-file-selector": "^1.0.1",
     "prop-types": "^15.5.7"
   },
   "devDependencies": {

--- a/src/index.js
+++ b/src/index.js
@@ -205,9 +205,7 @@ class Dropzone extends React.Component {
     // Reset drag state
     this.setState({
       isDragActive: false,
-      draggedFiles: [],
-      acceptedFiles,
-      rejectedFiles
+      draggedFiles: []
     })
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,7 @@
 
 import React from 'react'
 import PropTypes from 'prop-types'
-import { getDroppedOrSelectedFiles } from 'html5-file-selector'
+import { getDroppedOrSelectedFiles } from './utils/Html5FileSelector'
 import {
   supportMultiple,
   fileAccepted,

--- a/src/index.js
+++ b/src/index.js
@@ -170,7 +170,8 @@ class Dropzone extends React.Component {
     getDroppedOrSelectedFiles(evt).then(fileList => {
       const acceptedFiles = []
       const rejectedFiles = []
-      fileList.forEach(file => {
+      fileList.forEach(fileWrap => {
+        const file = fileWrap.fileObject
         if (!disablePreview) {
           try {
             file.preview = window.URL.createObjectURL(file) // eslint-disable-line no-param-reassign

--- a/src/index.spec.js
+++ b/src/index.spec.js
@@ -633,49 +633,43 @@ describe('Dropzone', () => {
       expect(child).toHaveProp('isDragReject', false)
     })
 
-    it('should add valid files to rejected files on a multple drop when multiple false', done => {
+    it('should add valid files to rejected files on a multple drop when multiple false', async () => {
       const dropzone = mount(<Dropzone accept="image/*" onDrop={dropSpy} multiple={false} />)
       dropzone.simulate('drop', { dataTransfer: { files: images } })
-      setTimeout(() => {
-        const rejected = dropSpy.firstCall.args[0]
-        expect(rejected.length).toEqual(1)
-        done()
-      }, 0)
+      await null
+      const rejected = dropSpy.firstCall.args[0]
+      expect(rejected.length).toEqual(1)
     })
 
-    it('should add invalid files to rejected when multiple is false', done => {
+    it('should add invalid files to rejected when multiple is false', async () => {
       const dropzone = mount(<Dropzone accept="image/*" onDrop={dropSpy} multiple={false} />)
       dropzone.simulate('drop', {
         dataTransfer: { files: images.concat(files) }
       })
-      setTimeout(() => {
-        const rejected = dropSpy.firstCall.args[1]
-        expect(rejected.length).toEqual(2)
-        done()
-      }, 0)
+      await null
+      const rejected = dropSpy.firstCall.args[1]
+      expect(rejected.length).toEqual(2)
     })
 
-    it('should allow single files to be dropped if multiple is false', done => {
+    it('should allow single files to be dropped if multiple is false', async () => {
       const dropzone = mount(<Dropzone accept="image/*" onDrop={dropSpy} multiple={false} />)
 
       dropzone.simulate('drop', { dataTransfer: { files: [images[0]] } })
-      setTimeout(() => {
-        const [accepted, rejected] = dropSpy.firstCall.args
-        expect(accepted.length).toEqual(1)
-        expect(rejected.length).toEqual(0)
-        done()
-      }, 0)
+
+      await null
+      const [accepted, rejected] = dropSpy.firstCall.args
+      expect(accepted.length).toEqual(1)
+      expect(rejected.length).toEqual(0)
     })
 
-    it('should take all dropped files if multiple is true', done => {
+    it('should take all dropped files if multiple is true', async () => {
       const dropzone = mount(<Dropzone onDrop={dropSpy} multiple />)
       dropzone.simulate('drop', { dataTransfer: { files: images } })
-      setTimeout(() => {
-        expect(dropSpy.firstCall.args[0]).toHaveLength(2)
-        expect(dropSpy.firstCall.args[0][0].name).toEqual(images[0].name)
-        expect(dropSpy.firstCall.args[0][1].name).toEqual(images[1].name)
-        done()
-      }, 0)
+
+      await null
+      expect(dropSpy.firstCall.args[0]).toHaveLength(2)
+      expect(dropSpy.firstCall.args[0][0].name).toEqual(images[0].name)
+      expect(dropSpy.firstCall.args[0][1].name).toEqual(images[1].name)
     })
 
     it('should set this.isFileDialogActive to false', () => {
@@ -685,7 +679,7 @@ describe('Dropzone', () => {
       expect(dropzone.instance().isFileDialogActive).toEqual(false)
     })
 
-    it('should always call onDrop callback with accepted and rejected arguments', done => {
+    it('should always call onDrop callback with accepted and rejected arguments', async () => {
       const dropzone = mount(
         <Dropzone
           onDrop={dropSpy}
@@ -695,26 +689,22 @@ describe('Dropzone', () => {
         />
       )
       dropzone.simulate('drop', { dataTransfer: { files } })
-      setTimeout(() => {
-        expect(dropSpy.callCount).toEqual(1)
-        expect(dropSpy.firstCall.args[0]).toEqual([], [...files])
-        dropzone.simulate('drop', { dataTransfer: { files: images } })
-        setTimeout(() => {
-          expect(dropSpy.callCount).toEqual(2)
-          expect(dropSpy.lastCall.args[0]).toEqual([...images], [])
-          dropzone.simulate('drop', {
-            dataTransfer: { files: files.concat(images) }
-          })
-          setTimeout(() => {
-            expect(dropSpy.callCount).toEqual(3)
-            expect(dropSpy.lastCall.args[0]).toEqual([...images], [...files])
-            done()
-          }, 0)
-        }, 0)
-      }, 0)
+      await null
+      expect(dropSpy.callCount).toEqual(1)
+      expect(dropSpy.firstCall.args[0]).toEqual([], [...files])
+      dropzone.simulate('drop', { dataTransfer: { files: images } })
+      await null
+      expect(dropSpy.callCount).toEqual(2)
+      expect(dropSpy.lastCall.args[0]).toEqual([...images], [])
+      dropzone.simulate('drop', {
+        dataTransfer: { files: files.concat(images) }
+      })
+      await null
+      expect(dropSpy.callCount).toEqual(3)
+      expect(dropSpy.lastCall.args[0]).toEqual([...images], [...files])
     })
 
-    it('should call onDropAccepted callback if some files were accepted', done => {
+    it('should call onDropAccepted callback if some files were accepted', async () => {
       const dropzone = mount(
         <Dropzone
           onDrop={dropSpy}
@@ -724,25 +714,21 @@ describe('Dropzone', () => {
         />
       )
       dropzone.simulate('drop', { dataTransfer: { files } })
-      setTimeout(() => {
-        expect(dropAcceptedSpy.callCount).toEqual(0)
-        dropzone.simulate('drop', { dataTransfer: { files: images } })
-        setTimeout(() => {
-          expect(dropAcceptedSpy.callCount).toEqual(1)
-          expect(dropAcceptedSpy.lastCall.args[0]).toEqual([...images])
-          dropzone.simulate('drop', {
-            dataTransfer: { files: files.concat(images) }
-          })
-          setTimeout(() => {
-            expect(dropAcceptedSpy.callCount).toEqual(2)
-            expect(dropAcceptedSpy.lastCall.args[0]).toEqual([...images])
-            done()
-          }, 0)
-        }, 0)
-      }, 0)
+      await null
+      expect(dropAcceptedSpy.callCount).toEqual(0)
+      dropzone.simulate('drop', { dataTransfer: { files: images } })
+      await null
+      expect(dropAcceptedSpy.callCount).toEqual(1)
+      expect(dropAcceptedSpy.lastCall.args[0]).toEqual([...images])
+      dropzone.simulate('drop', {
+        dataTransfer: { files: files.concat(images) }
+      })
+      await null
+      expect(dropAcceptedSpy.callCount).toEqual(2)
+      expect(dropAcceptedSpy.lastCall.args[0]).toEqual([...images])
     })
 
-    it('should call onDropRejected callback if some files were rejected', done => {
+    it('should call onDropRejected callback if some files were rejected', async () => {
       const dropzone = mount(
         <Dropzone
           onDrop={dropSpy}
@@ -752,25 +738,21 @@ describe('Dropzone', () => {
         />
       )
       dropzone.simulate('drop', { dataTransfer: { files } })
-      setTimeout(() => {
-        expect(dropRejectedSpy.callCount).toEqual(1)
-        expect(dropRejectedSpy.lastCall.args[0]).toEqual([...files])
-        dropzone.simulate('drop', { dataTransfer: { files: images } })
-        setTimeout(() => {
-          expect(dropRejectedSpy.callCount).toEqual(1)
-          dropzone.simulate('drop', {
-            dataTransfer: { files: files.concat(images) }
-          })
-          setTimeout(() => {
-            expect(dropRejectedSpy.callCount).toEqual(2)
-            expect(dropRejectedSpy.lastCall.args[0]).toEqual([...files])
-            done()
-          }, 0)
-        }, 0)
-      }, 0)
+      await null
+      expect(dropRejectedSpy.callCount).toEqual(1)
+      expect(dropRejectedSpy.lastCall.args[0]).toEqual([...files])
+      dropzone.simulate('drop', { dataTransfer: { files: images } })
+      await null
+      expect(dropRejectedSpy.callCount).toEqual(1)
+      dropzone.simulate('drop', {
+        dataTransfer: { files: files.concat(images) }
+      })
+      await null
+      expect(dropRejectedSpy.callCount).toEqual(2)
+      expect(dropRejectedSpy.lastCall.args[0]).toEqual([...files])
     })
 
-    it('applies the accept prop to the dropped files', done => {
+    it('applies the accept prop to the dropped files', async () => {
       const dropzone = mount(
         <Dropzone
           onDrop={dropSpy}
@@ -780,18 +762,16 @@ describe('Dropzone', () => {
         />
       )
       dropzone.simulate('drop', { dataTransfer: { files } })
-      setTimeout(() => {
-        expect(dropSpy.callCount).toEqual(1)
-        expect(dropSpy.firstCall.args[0]).toHaveLength(0)
-        expect(dropSpy.firstCall.args[1]).toHaveLength(1)
-        expect(dropAcceptedSpy.callCount).toEqual(0)
-        expect(dropRejectedSpy.callCount).toEqual(1)
-        expect(dropRejectedSpy.firstCall.args[0]).toHaveLength(1)
-        done()
-      }, 0)
+      await null
+      expect(dropSpy.callCount).toEqual(1)
+      expect(dropSpy.firstCall.args[0]).toHaveLength(0)
+      expect(dropSpy.firstCall.args[1]).toHaveLength(1)
+      expect(dropAcceptedSpy.callCount).toEqual(0)
+      expect(dropRejectedSpy.callCount).toEqual(1)
+      expect(dropRejectedSpy.firstCall.args[0]).toHaveLength(1)
     })
 
-    it('applies the accept prop to the dropped images', done => {
+    it('applies the accept prop to the dropped images', async () => {
       const dropzone = mount(
         <Dropzone
           onDrop={dropSpy}
@@ -802,18 +782,16 @@ describe('Dropzone', () => {
       )
 
       dropzone.simulate('drop', { dataTransfer: { files: images } })
-      setTimeout(() => {
-        expect(dropSpy.callCount).toEqual(1)
-        expect(dropSpy.firstCall.args[0]).toHaveLength(2)
-        expect(dropSpy.firstCall.args[1]).toHaveLength(0)
-        expect(dropAcceptedSpy.callCount).toEqual(1)
-        expect(dropAcceptedSpy.firstCall.args[0]).toHaveLength(2)
-        expect(dropRejectedSpy.callCount).toEqual(0)
-        done()
-      }, 0)
+      await null
+      expect(dropSpy.callCount).toEqual(1)
+      expect(dropSpy.firstCall.args[0]).toHaveLength(2)
+      expect(dropSpy.firstCall.args[1]).toHaveLength(0)
+      expect(dropAcceptedSpy.callCount).toEqual(1)
+      expect(dropAcceptedSpy.firstCall.args[0]).toHaveLength(2)
+      expect(dropRejectedSpy.callCount).toEqual(0)
     })
 
-    it('accepts a dropped image when Firefox provides a bogus file type', done => {
+    it('accepts a dropped image when Firefox provides a bogus file type', async () => {
       const dropzone = mount(
         <Dropzone
           onDrop={dropSpy}
@@ -831,18 +809,16 @@ describe('Dropzone', () => {
       ]
 
       dropzone.simulate('drop', { dataTransfer: { files: bogusImages } })
-      setTimeout(() => {
-        expect(dropSpy.callCount).toEqual(1)
-        expect(dropSpy.firstCall.args[0]).toHaveLength(1)
-        expect(dropSpy.firstCall.args[1]).toHaveLength(0)
-        expect(dropAcceptedSpy.callCount).toEqual(1)
-        expect(dropAcceptedSpy.firstCall.args[0]).toHaveLength(1)
-        expect(dropRejectedSpy.callCount).toEqual(0)
-        done()
-      }, 0)
+      await null
+      expect(dropSpy.callCount).toEqual(1)
+      expect(dropSpy.firstCall.args[0]).toHaveLength(1)
+      expect(dropSpy.firstCall.args[1]).toHaveLength(0)
+      expect(dropAcceptedSpy.callCount).toEqual(1)
+      expect(dropAcceptedSpy.firstCall.args[0]).toHaveLength(1)
+      expect(dropRejectedSpy.callCount).toEqual(0)
     })
 
-    it('accepts all dropped files and images when no accept prop is specified', done => {
+    it('accepts all dropped files and images when no accept prop is specified', async () => {
       const dropzone = mount(
         <Dropzone
           onDrop={dropSpy}
@@ -853,18 +829,16 @@ describe('Dropzone', () => {
       dropzone.simulate('drop', {
         dataTransfer: { files: files.concat(images) }
       })
-      setTimeout(() => {
-        expect(dropSpy.callCount).toEqual(1)
-        expect(dropSpy.firstCall.args[0]).toHaveLength(3)
-        expect(dropSpy.firstCall.args[1]).toHaveLength(0)
-        expect(dropAcceptedSpy.callCount).toEqual(1)
-        expect(dropAcceptedSpy.firstCall.args[0]).toHaveLength(3)
-        expect(dropRejectedSpy.callCount).toEqual(0)
-        done()
-      }, 0)
+      await null
+      expect(dropSpy.callCount).toEqual(1)
+      expect(dropSpy.firstCall.args[0]).toHaveLength(3)
+      expect(dropSpy.firstCall.args[1]).toHaveLength(0)
+      expect(dropAcceptedSpy.callCount).toEqual(1)
+      expect(dropAcceptedSpy.firstCall.args[0]).toHaveLength(3)
+      expect(dropRejectedSpy.callCount).toEqual(0)
     })
 
-    it('applies the maxSize prop to the dropped files', done => {
+    it('applies the maxSize prop to the dropped files', async () => {
       const dropzone = mount(
         <Dropzone
           onDrop={dropSpy}
@@ -875,18 +849,16 @@ describe('Dropzone', () => {
       )
 
       dropzone.simulate('drop', { dataTransfer: { files } })
-      setTimeout(() => {
-        expect(dropSpy.callCount).toEqual(1)
-        expect(dropSpy.firstCall.args[0]).toHaveLength(1)
-        expect(dropSpy.firstCall.args[1]).toHaveLength(0)
-        expect(dropAcceptedSpy.callCount).toEqual(1)
-        expect(dropAcceptedSpy.firstCall.args[0]).toHaveLength(1)
-        expect(dropRejectedSpy.callCount).toEqual(0)
-        done()
-      }, 0)
+      await null
+      expect(dropSpy.callCount).toEqual(1)
+      expect(dropSpy.firstCall.args[0]).toHaveLength(1)
+      expect(dropSpy.firstCall.args[1]).toHaveLength(0)
+      expect(dropAcceptedSpy.callCount).toEqual(1)
+      expect(dropAcceptedSpy.firstCall.args[0]).toHaveLength(1)
+      expect(dropRejectedSpy.callCount).toEqual(0)
     })
 
-    it('applies the maxSize prop to the dropped images', done => {
+    it('applies the maxSize prop to the dropped images', async () => {
       const dropzone = mount(
         <Dropzone
           onDrop={dropSpy}
@@ -896,18 +868,16 @@ describe('Dropzone', () => {
         />
       )
       dropzone.simulate('drop', { dataTransfer: { files: images } })
-      setTimeout(() => {
-        expect(dropSpy.callCount).toEqual(1)
-        expect(dropSpy.firstCall.args[0]).toHaveLength(0)
-        expect(dropSpy.firstCall.args[1]).toHaveLength(2)
-        expect(dropAcceptedSpy.callCount).toEqual(0)
-        expect(dropRejectedSpy.callCount).toEqual(1)
-        expect(dropRejectedSpy.firstCall.args[0]).toHaveLength(2)
-        done()
-      }, 0)
+      await null
+      expect(dropSpy.callCount).toEqual(1)
+      expect(dropSpy.firstCall.args[0]).toHaveLength(0)
+      expect(dropSpy.firstCall.args[1]).toHaveLength(2)
+      expect(dropAcceptedSpy.callCount).toEqual(0)
+      expect(dropRejectedSpy.callCount).toEqual(1)
+      expect(dropRejectedSpy.firstCall.args[0]).toHaveLength(2)
     })
 
-    it('applies the minSize prop to the dropped files', done => {
+    it('applies the minSize prop to the dropped files', async () => {
       const dropzone = mount(
         <Dropzone
           onDrop={dropSpy}
@@ -918,18 +888,16 @@ describe('Dropzone', () => {
       )
       dropzone.simulate('drop', { dataTransfer: { files } })
 
-      setTimeout(() => {
-        expect(dropSpy.callCount).toEqual(1)
-        expect(dropSpy.firstCall.args[0]).toHaveLength(0)
-        expect(dropSpy.firstCall.args[1]).toHaveLength(1)
-        expect(dropAcceptedSpy.callCount).toEqual(0)
-        expect(dropRejectedSpy.callCount).toEqual(1)
-        expect(dropRejectedSpy.firstCall.args[0]).toHaveLength(1)
-        done()
-      }, 0)
+      await null
+      expect(dropSpy.callCount).toEqual(1)
+      expect(dropSpy.firstCall.args[0]).toHaveLength(0)
+      expect(dropSpy.firstCall.args[1]).toHaveLength(1)
+      expect(dropAcceptedSpy.callCount).toEqual(0)
+      expect(dropRejectedSpy.callCount).toEqual(1)
+      expect(dropRejectedSpy.firstCall.args[0]).toHaveLength(1)
     })
 
-    it('applies the minSize prop to the dropped images', done => {
+    it('applies the minSize prop to the dropped images', async () => {
       const dropzone = mount(
         <Dropzone
           onDrop={dropSpy}
@@ -939,18 +907,16 @@ describe('Dropzone', () => {
         />
       )
       dropzone.simulate('drop', { dataTransfer: { files: images } })
-      setTimeout(() => {
-        expect(dropSpy.callCount).toEqual(1)
-        expect(dropSpy.firstCall.args[0]).toHaveLength(2)
-        expect(dropSpy.firstCall.args[1]).toHaveLength(0)
-        expect(dropAcceptedSpy.callCount).toEqual(1)
-        expect(dropAcceptedSpy.firstCall.args[0]).toHaveLength(2)
-        expect(dropRejectedSpy.callCount).toEqual(0)
-        done()
-      }, 0)
+      await null
+      expect(dropSpy.callCount).toEqual(1)
+      expect(dropSpy.firstCall.args[0]).toHaveLength(2)
+      expect(dropSpy.firstCall.args[1]).toHaveLength(0)
+      expect(dropAcceptedSpy.callCount).toEqual(1)
+      expect(dropAcceptedSpy.firstCall.args[0]).toHaveLength(2)
+      expect(dropRejectedSpy.callCount).toEqual(0)
     })
 
-    it('accepts all dropped files and images when no size prop is specified', done => {
+    it('accepts all dropped files and images when no size prop is specified', async () => {
       const dropzone = mount(
         <Dropzone
           onDrop={dropSpy}
@@ -962,15 +928,13 @@ describe('Dropzone', () => {
         dataTransfer: { files: files.concat(images) }
       })
 
-      setTimeout(() => {
-        expect(dropSpy.callCount).toEqual(1)
-        expect(dropSpy.firstCall.args[0]).toHaveLength(3)
-        expect(dropSpy.firstCall.args[1]).toHaveLength(0)
-        expect(dropAcceptedSpy.callCount).toEqual(1)
-        expect(dropAcceptedSpy.firstCall.args[0]).toHaveLength(3)
-        expect(dropRejectedSpy.callCount).toEqual(0)
-        done()
-      }, 0)
+      await null
+      expect(dropSpy.callCount).toEqual(1)
+      expect(dropSpy.firstCall.args[0]).toHaveLength(3)
+      expect(dropSpy.firstCall.args[1]).toHaveLength(0)
+      expect(dropAcceptedSpy.callCount).toEqual(1)
+      expect(dropAcceptedSpy.firstCall.args[0]).toHaveLength(3)
+      expect(dropRejectedSpy.callCount).toEqual(0)
     })
   })
 
@@ -987,51 +951,43 @@ describe('Dropzone', () => {
       getDroppedOrSelectedFilesStub.restore()
     })
 
-    it('should generate previews for non-images', done => {
+    it('should generate previews for non-images', async () => {
       const dropSpy = spy()
       const dropzone = mount(<Dropzone onDrop={dropSpy} />)
       dropzone.simulate('drop', { dataTransfer: { files } })
-      setTimeout(() => {
-        expect(Object.keys(dropSpy.firstCall.args[0][0])).toContain('preview')
-        expect(dropSpy.firstCall.args[0][0].preview).toContain('data://file1.pdf')
-        done()
-      }, 0)
+      await null
+      expect(Object.keys(dropSpy.firstCall.args[0][0])).toContain('preview')
+      expect(dropSpy.firstCall.args[0][0].preview).toContain('data://file1.pdf')
     })
 
-    it('should generate previews for images', done => {
+    it('should generate previews for images', async () => {
       const dropSpy = spy()
       const dropzone = mount(<Dropzone onDrop={dropSpy} />)
       dropzone.simulate('drop', { dataTransfer: { files: images } })
-      setTimeout(() => {
-        expect(Object.keys(dropSpy.firstCall.args[0][0])).toContain('preview')
-        expect(dropSpy.firstCall.args[0][0].preview).toContain('data://cats.gif')
-        done()
-      }, 0)
+      await null
+      expect(Object.keys(dropSpy.firstCall.args[0][0])).toContain('preview')
+      expect(dropSpy.firstCall.args[0][0].preview).toContain('data://cats.gif')
     })
 
-    it('should not throw error when preview cannot be created', done => {
+    it('should not throw error when preview cannot be created', async () => {
       const dropSpy = spy()
       const dropzone = mount(<Dropzone onDrop={dropSpy} />)
 
       dropzone.simulate('drop', { dataTransfer: { files: ['bad_val'] } })
 
-      setTimeout(() => {
-        expect(Object.keys(dropSpy.firstCall.args[1][0])).not.toContain('preview')
-        done()
-      }, 0)
+      await null
+      expect(Object.keys(dropSpy.firstCall.args[1][0])).not.toContain('preview')
     })
 
-    it('should not generate previews if disablePreview is true', done => {
+    it('should not generate previews if disablePreview is true', async () => {
       const dropSpy = spy()
       const dropzone = mount(<Dropzone disablePreview onDrop={dropSpy} />)
       dropzone.simulate('drop', { dataTransfer: { files: images } })
       dropzone.simulate('drop', { dataTransfer: { files } })
-      setTimeout(() => {
-        expect(dropSpy.callCount).toEqual(2)
-        expect(Object.keys(dropSpy.firstCall.args[0][0])).not.toContain('preview')
-        expect(Object.keys(dropSpy.lastCall.args[0][0])).not.toContain('preview')
-        done()
-      }, 0)
+      await null
+      expect(dropSpy.callCount).toEqual(2)
+      expect(Object.keys(dropSpy.firstCall.args[0][0])).not.toContain('preview')
+      expect(Object.keys(dropSpy.lastCall.args[0][0])).not.toContain('preview')
     })
   })
 

--- a/src/index.spec.js
+++ b/src/index.spec.js
@@ -594,7 +594,7 @@ describe('Dropzone', () => {
 
     beforeAll(() => {
       getDroppedOrSelectedFilesStub = stub(html5, 'getDroppedOrSelectedFiles').callsFake(evt =>
-        Promise.resolve(evt.dataTransfer.files)
+        Promise.resolve(evt.dataTransfer.files.map(file => ({ fileObject: file })))
       )
     })
 
@@ -979,7 +979,7 @@ describe('Dropzone', () => {
 
     beforeAll(() => {
       getDroppedOrSelectedFilesStub = stub(html5, 'getDroppedOrSelectedFiles').callsFake(evt =>
-        Promise.resolve(evt.dataTransfer.files)
+        Promise.resolve(evt.dataTransfer.files.map(file => ({ fileObject: file })))
       )
     })
 

--- a/src/index.spec.js
+++ b/src/index.spec.js
@@ -621,37 +621,49 @@ describe('Dropzone', () => {
       expect(child).toHaveProp('isDragReject', false)
     })
 
-    it('should add valid files to rejected files on a multple drop when multiple false', () => {
+    it('should add valid files to rejected files on a multple drop when multiple false', done => {
       const dropzone = mount(<Dropzone accept="image/*" onDrop={dropSpy} multiple={false} />)
       dropzone.simulate('drop', { dataTransfer: { files: images } })
-      const rejected = dropSpy.firstCall.args[0]
-      expect(rejected.length).toEqual(1)
+      setTimeout(() => {
+        const rejected = dropSpy.firstCall.args[0]
+        expect(rejected.length).toEqual(1)
+        done()
+      }, 0)
     })
 
-    it('should add invalid files to rejected when multiple is false', () => {
+    it('should add invalid files to rejected when multiple is false', done => {
       const dropzone = mount(<Dropzone accept="image/*" onDrop={dropSpy} multiple={false} />)
       dropzone.simulate('drop', {
         dataTransfer: { files: images.concat(files) }
       })
-      const rejected = dropSpy.firstCall.args[1]
-      expect(rejected.length).toEqual(2)
+      setTimeout(() => {
+        const rejected = dropSpy.firstCall.args[1]
+        expect(rejected.length).toEqual(2)
+        done()
+      }, 0)
     })
 
-    it('should allow single files to be dropped if multiple is false', () => {
+    it('should allow single files to be dropped if multiple is false', done => {
       const dropzone = mount(<Dropzone accept="image/*" onDrop={dropSpy} multiple={false} />)
 
       dropzone.simulate('drop', { dataTransfer: { files: [images[0]] } })
-      const [accepted, rejected] = dropSpy.firstCall.args
-      expect(accepted.length).toEqual(1)
-      expect(rejected.length).toEqual(0)
+      setTimeout(() => {
+        const [accepted, rejected] = dropSpy.firstCall.args
+        expect(accepted.length).toEqual(1)
+        expect(rejected.length).toEqual(0)
+        done()
+      }, 0)
     })
 
-    it('should take all dropped files if multiple is true', () => {
+    it('should take all dropped files if multiple is true', done => {
       const dropzone = mount(<Dropzone onDrop={dropSpy} multiple />)
       dropzone.simulate('drop', { dataTransfer: { files: images } })
-      expect(dropSpy.firstCall.args[0]).toHaveLength(2)
-      expect(dropSpy.firstCall.args[0][0].name).toEqual(images[0].name)
-      expect(dropSpy.firstCall.args[0][1].name).toEqual(images[1].name)
+      setTimeout(() => {
+        expect(dropSpy.firstCall.args[0]).toHaveLength(2)
+        expect(dropSpy.firstCall.args[0][0].name).toEqual(images[0].name)
+        expect(dropSpy.firstCall.args[0][1].name).toEqual(images[1].name)
+        done()
+      }, 0)
     })
 
     it('should set this.isFileDialogActive to false', () => {
@@ -725,7 +737,7 @@ describe('Dropzone', () => {
       expect(dropRejectedSpy.lastCall.args[0]).toEqual([...files])
     })
 
-    it('applies the accept prop to the dropped files', () => {
+    it('applies the accept prop to the dropped files', done => {
       const dropzone = mount(
         <Dropzone
           onDrop={dropSpy}
@@ -735,15 +747,18 @@ describe('Dropzone', () => {
         />
       )
       dropzone.simulate('drop', { dataTransfer: { files } })
-      expect(dropSpy.callCount).toEqual(1)
-      expect(dropSpy.firstCall.args[0]).toHaveLength(0)
-      expect(dropSpy.firstCall.args[1]).toHaveLength(1)
-      expect(dropAcceptedSpy.callCount).toEqual(0)
-      expect(dropRejectedSpy.callCount).toEqual(1)
-      expect(dropRejectedSpy.firstCall.args[0]).toHaveLength(1)
+      setTimeout(() => {
+        expect(dropSpy.callCount).toEqual(1)
+        expect(dropSpy.firstCall.args[0]).toHaveLength(0)
+        expect(dropSpy.firstCall.args[1]).toHaveLength(1)
+        expect(dropAcceptedSpy.callCount).toEqual(0)
+        expect(dropRejectedSpy.callCount).toEqual(1)
+        expect(dropRejectedSpy.firstCall.args[0]).toHaveLength(1)
+        done()
+      }, 0)
     })
 
-    it('applies the accept prop to the dropped images', () => {
+    it('applies the accept prop to the dropped images', done => {
       const dropzone = mount(
         <Dropzone
           onDrop={dropSpy}
@@ -754,15 +769,18 @@ describe('Dropzone', () => {
       )
 
       dropzone.simulate('drop', { dataTransfer: { files: images } })
-      expect(dropSpy.callCount).toEqual(1)
-      expect(dropSpy.firstCall.args[0]).toHaveLength(2)
-      expect(dropSpy.firstCall.args[1]).toHaveLength(0)
-      expect(dropAcceptedSpy.callCount).toEqual(1)
-      expect(dropAcceptedSpy.firstCall.args[0]).toHaveLength(2)
-      expect(dropRejectedSpy.callCount).toEqual(0)
+      setTimeout(() => {
+        expect(dropSpy.callCount).toEqual(1)
+        expect(dropSpy.firstCall.args[0]).toHaveLength(2)
+        expect(dropSpy.firstCall.args[1]).toHaveLength(0)
+        expect(dropAcceptedSpy.callCount).toEqual(1)
+        expect(dropAcceptedSpy.firstCall.args[0]).toHaveLength(2)
+        expect(dropRejectedSpy.callCount).toEqual(0)
+        done()
+      }, 0)
     })
 
-    it('accepts a dropped image when Firefox provides a bogus file type', () => {
+    it('accepts a dropped image when Firefox provides a bogus file type', done => {
       const dropzone = mount(
         <Dropzone
           onDrop={dropSpy}
@@ -780,15 +798,18 @@ describe('Dropzone', () => {
       ]
 
       dropzone.simulate('drop', { dataTransfer: { files: bogusImages } })
-      expect(dropSpy.callCount).toEqual(1)
-      expect(dropSpy.firstCall.args[0]).toHaveLength(1)
-      expect(dropSpy.firstCall.args[1]).toHaveLength(0)
-      expect(dropAcceptedSpy.callCount).toEqual(1)
-      expect(dropAcceptedSpy.firstCall.args[0]).toHaveLength(1)
-      expect(dropRejectedSpy.callCount).toEqual(0)
+      setTimeout(() => {
+        expect(dropSpy.callCount).toEqual(1)
+        expect(dropSpy.firstCall.args[0]).toHaveLength(1)
+        expect(dropSpy.firstCall.args[1]).toHaveLength(0)
+        expect(dropAcceptedSpy.callCount).toEqual(1)
+        expect(dropAcceptedSpy.firstCall.args[0]).toHaveLength(1)
+        expect(dropRejectedSpy.callCount).toEqual(0)
+        done()
+      }, 0)
     })
 
-    it('accepts all dropped files and images when no accept prop is specified', () => {
+    it('accepts all dropped files and images when no accept prop is specified', done => {
       const dropzone = mount(
         <Dropzone
           onDrop={dropSpy}
@@ -799,15 +820,18 @@ describe('Dropzone', () => {
       dropzone.simulate('drop', {
         dataTransfer: { files: files.concat(images) }
       })
-      expect(dropSpy.callCount).toEqual(1)
-      expect(dropSpy.firstCall.args[0]).toHaveLength(3)
-      expect(dropSpy.firstCall.args[1]).toHaveLength(0)
-      expect(dropAcceptedSpy.callCount).toEqual(1)
-      expect(dropAcceptedSpy.firstCall.args[0]).toHaveLength(3)
-      expect(dropRejectedSpy.callCount).toEqual(0)
+      setTimeout(() => {
+        expect(dropSpy.callCount).toEqual(1)
+        expect(dropSpy.firstCall.args[0]).toHaveLength(3)
+        expect(dropSpy.firstCall.args[1]).toHaveLength(0)
+        expect(dropAcceptedSpy.callCount).toEqual(1)
+        expect(dropAcceptedSpy.firstCall.args[0]).toHaveLength(3)
+        expect(dropRejectedSpy.callCount).toEqual(0)
+        done()
+      }, 0)
     })
 
-    it('applies the maxSize prop to the dropped files', () => {
+    it('applies the maxSize prop to the dropped files', done => {
       const dropzone = mount(
         <Dropzone
           onDrop={dropSpy}
@@ -818,15 +842,18 @@ describe('Dropzone', () => {
       )
 
       dropzone.simulate('drop', { dataTransfer: { files } })
-      expect(dropSpy.callCount).toEqual(1)
-      expect(dropSpy.firstCall.args[0]).toHaveLength(1)
-      expect(dropSpy.firstCall.args[1]).toHaveLength(0)
-      expect(dropAcceptedSpy.callCount).toEqual(1)
-      expect(dropAcceptedSpy.firstCall.args[0]).toHaveLength(1)
-      expect(dropRejectedSpy.callCount).toEqual(0)
+      setTimeout(() => {
+        expect(dropSpy.callCount).toEqual(1)
+        expect(dropSpy.firstCall.args[0]).toHaveLength(1)
+        expect(dropSpy.firstCall.args[1]).toHaveLength(0)
+        expect(dropAcceptedSpy.callCount).toEqual(1)
+        expect(dropAcceptedSpy.firstCall.args[0]).toHaveLength(1)
+        expect(dropRejectedSpy.callCount).toEqual(0)
+        done()
+      }, 0)
     })
 
-    it('applies the maxSize prop to the dropped images', () => {
+    it('applies the maxSize prop to the dropped images', done => {
       const dropzone = mount(
         <Dropzone
           onDrop={dropSpy}
@@ -836,15 +863,18 @@ describe('Dropzone', () => {
         />
       )
       dropzone.simulate('drop', { dataTransfer: { files: images } })
-      expect(dropSpy.callCount).toEqual(1)
-      expect(dropSpy.firstCall.args[0]).toHaveLength(0)
-      expect(dropSpy.firstCall.args[1]).toHaveLength(2)
-      expect(dropAcceptedSpy.callCount).toEqual(0)
-      expect(dropRejectedSpy.callCount).toEqual(1)
-      expect(dropRejectedSpy.firstCall.args[0]).toHaveLength(2)
+      setTimeout(() => {
+        expect(dropSpy.callCount).toEqual(1)
+        expect(dropSpy.firstCall.args[0]).toHaveLength(0)
+        expect(dropSpy.firstCall.args[1]).toHaveLength(2)
+        expect(dropAcceptedSpy.callCount).toEqual(0)
+        expect(dropRejectedSpy.callCount).toEqual(1)
+        expect(dropRejectedSpy.firstCall.args[0]).toHaveLength(2)
+        done()
+      }, 0)
     })
 
-    it('applies the minSize prop to the dropped files', () => {
+    it('applies the minSize prop to the dropped files', done => {
       const dropzone = mount(
         <Dropzone
           onDrop={dropSpy}
@@ -854,15 +884,19 @@ describe('Dropzone', () => {
         />
       )
       dropzone.simulate('drop', { dataTransfer: { files } })
-      expect(dropSpy.callCount).toEqual(1)
-      expect(dropSpy.firstCall.args[0]).toHaveLength(0)
-      expect(dropSpy.firstCall.args[1]).toHaveLength(1)
-      expect(dropAcceptedSpy.callCount).toEqual(0)
-      expect(dropRejectedSpy.callCount).toEqual(1)
-      expect(dropRejectedSpy.firstCall.args[0]).toHaveLength(1)
+
+      setTimeout(() => {
+        expect(dropSpy.callCount).toEqual(1)
+        expect(dropSpy.firstCall.args[0]).toHaveLength(0)
+        expect(dropSpy.firstCall.args[1]).toHaveLength(1)
+        expect(dropAcceptedSpy.callCount).toEqual(0)
+        expect(dropRejectedSpy.callCount).toEqual(1)
+        expect(dropRejectedSpy.firstCall.args[0]).toHaveLength(1)
+        done()
+      }, 0)
     })
 
-    it('applies the minSize prop to the dropped images', () => {
+    it('applies the minSize prop to the dropped images', done => {
       const dropzone = mount(
         <Dropzone
           onDrop={dropSpy}
@@ -872,15 +906,18 @@ describe('Dropzone', () => {
         />
       )
       dropzone.simulate('drop', { dataTransfer: { files: images } })
-      expect(dropSpy.callCount).toEqual(1)
-      expect(dropSpy.firstCall.args[0]).toHaveLength(2)
-      expect(dropSpy.firstCall.args[1]).toHaveLength(0)
-      expect(dropAcceptedSpy.callCount).toEqual(1)
-      expect(dropAcceptedSpy.firstCall.args[0]).toHaveLength(2)
-      expect(dropRejectedSpy.callCount).toEqual(0)
+      setTimeout(() => {
+        expect(dropSpy.callCount).toEqual(1)
+        expect(dropSpy.firstCall.args[0]).toHaveLength(2)
+        expect(dropSpy.firstCall.args[1]).toHaveLength(0)
+        expect(dropAcceptedSpy.callCount).toEqual(1)
+        expect(dropAcceptedSpy.firstCall.args[0]).toHaveLength(2)
+        expect(dropRejectedSpy.callCount).toEqual(0)
+        done()
+      }, 0)
     })
 
-    it('accepts all dropped files and images when no size prop is specified', () => {
+    it('accepts all dropped files and images when no size prop is specified', done => {
       const dropzone = mount(
         <Dropzone
           onDrop={dropSpy}
@@ -891,49 +928,65 @@ describe('Dropzone', () => {
       dropzone.simulate('drop', {
         dataTransfer: { files: files.concat(images) }
       })
-      expect(dropSpy.callCount).toEqual(1)
-      expect(dropSpy.firstCall.args[0]).toHaveLength(3)
-      expect(dropSpy.firstCall.args[1]).toHaveLength(0)
-      expect(dropAcceptedSpy.callCount).toEqual(1)
-      expect(dropAcceptedSpy.firstCall.args[0]).toHaveLength(3)
-      expect(dropRejectedSpy.callCount).toEqual(0)
+
+      setTimeout(() => {
+        expect(dropSpy.callCount).toEqual(1)
+        expect(dropSpy.firstCall.args[0]).toHaveLength(3)
+        expect(dropSpy.firstCall.args[1]).toHaveLength(0)
+        expect(dropAcceptedSpy.callCount).toEqual(1)
+        expect(dropAcceptedSpy.firstCall.args[0]).toHaveLength(3)
+        expect(dropRejectedSpy.callCount).toEqual(0)
+        done()
+      }, 0)
     })
   })
 
   describe('preview', () => {
-    it('should generate previews for non-images', () => {
+    it('should generate previews for non-images', done => {
       const dropSpy = spy()
       const dropzone = mount(<Dropzone onDrop={dropSpy} />)
       dropzone.simulate('drop', { dataTransfer: { files } })
-      expect(Object.keys(dropSpy.firstCall.args[0][0])).toContain('preview')
-      expect(dropSpy.firstCall.args[0][0].preview).toContain('data://file1.pdf')
+      setTimeout(() => {
+        expect(Object.keys(dropSpy.firstCall.args[0][0])).toContain('preview')
+        expect(dropSpy.firstCall.args[0][0].preview).toContain('data://file1.pdf')
+        done()
+      }, 0)
     })
 
-    it('should generate previews for images', () => {
+    it('should generate previews for images', done => {
       const dropSpy = spy()
       const dropzone = mount(<Dropzone onDrop={dropSpy} />)
       dropzone.simulate('drop', { dataTransfer: { files: images } })
-      expect(Object.keys(dropSpy.firstCall.args[0][0])).toContain('preview')
-      expect(dropSpy.firstCall.args[0][0].preview).toContain('data://cats.gif')
+      setTimeout(() => {
+        expect(Object.keys(dropSpy.firstCall.args[0][0])).toContain('preview')
+        expect(dropSpy.firstCall.args[0][0].preview).toContain('data://cats.gif')
+        done()
+      }, 0)
     })
 
-    it('should not throw error when preview cannot be created', () => {
+    it('should not throw error when preview cannot be created', done => {
       const dropSpy = spy()
       const dropzone = mount(<Dropzone onDrop={dropSpy} />)
 
       dropzone.simulate('drop', { dataTransfer: { files: ['bad_val'] } })
 
-      expect(Object.keys(dropSpy.firstCall.args[1][0])).not.toContain('preview')
+      setTimeout(() => {
+        expect(Object.keys(dropSpy.firstCall.args[1][0])).not.toContain('preview')
+        done()
+      }, 0)
     })
 
-    it('should not generate previews if disablePreview is true', () => {
+    it('should not generate previews if disablePreview is true', done => {
       const dropSpy = spy()
       const dropzone = mount(<Dropzone disablePreview onDrop={dropSpy} />)
       dropzone.simulate('drop', { dataTransfer: { files: images } })
       dropzone.simulate('drop', { dataTransfer: { files } })
-      expect(dropSpy.callCount).toEqual(2)
-      expect(Object.keys(dropSpy.firstCall.args[0][0])).not.toContain('preview')
-      expect(Object.keys(dropSpy.lastCall.args[0][0])).not.toContain('preview')
+      setTimeout(() => {
+        expect(dropSpy.callCount).toEqual(2)
+        expect(Object.keys(dropSpy.firstCall.args[0][0])).not.toContain('preview')
+        expect(Object.keys(dropSpy.lastCall.args[0][0])).not.toContain('preview')
+        done()
+      }, 0)
     })
   })
 

--- a/src/index.spec.js
+++ b/src/index.spec.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import { mount, render } from 'enzyme'
 import { spy, stub } from 'sinon'
+import * as html5 from 'html5-file-selector'
 import { onDocumentDragOver } from './utils'
 
 const Dropzone = require(process.env.JEST_TARGET ? process.env.JEST_TARGET : './index') // eslint-disable-line import/no-dynamic-require
@@ -589,6 +590,17 @@ describe('Dropzone', () => {
     let dropSpy
     let dropAcceptedSpy
     let dropRejectedSpy
+    let getDroppedOrSelectedFilesStub
+
+    beforeAll(() => {
+      getDroppedOrSelectedFilesStub = stub(html5, 'getDroppedOrSelectedFiles').callsFake(evt =>
+        Promise.resolve(evt.dataTransfer.files)
+      )
+    })
+
+    afterAll(() => {
+      getDroppedOrSelectedFilesStub.restore()
+    })
 
     beforeEach(() => {
       dropSpy = spy()
@@ -673,7 +685,7 @@ describe('Dropzone', () => {
       expect(dropzone.instance().isFileDialogActive).toEqual(false)
     })
 
-    it('should always call onDrop callback with accepted and rejected arguments', () => {
+    it('should always call onDrop callback with accepted and rejected arguments', done => {
       const dropzone = mount(
         <Dropzone
           onDrop={dropSpy}
@@ -683,19 +695,26 @@ describe('Dropzone', () => {
         />
       )
       dropzone.simulate('drop', { dataTransfer: { files } })
-      expect(dropSpy.callCount).toEqual(1)
-      expect(dropSpy.firstCall.args[0]).toEqual([], [...files])
-      dropzone.simulate('drop', { dataTransfer: { files: images } })
-      expect(dropSpy.callCount).toEqual(2)
-      expect(dropSpy.lastCall.args[0]).toEqual([...images], [])
-      dropzone.simulate('drop', {
-        dataTransfer: { files: files.concat(images) }
-      })
-      expect(dropSpy.callCount).toEqual(3)
-      expect(dropSpy.lastCall.args[0]).toEqual([...images], [...files])
+      setTimeout(() => {
+        expect(dropSpy.callCount).toEqual(1)
+        expect(dropSpy.firstCall.args[0]).toEqual([], [...files])
+        dropzone.simulate('drop', { dataTransfer: { files: images } })
+        setTimeout(() => {
+          expect(dropSpy.callCount).toEqual(2)
+          expect(dropSpy.lastCall.args[0]).toEqual([...images], [])
+          dropzone.simulate('drop', {
+            dataTransfer: { files: files.concat(images) }
+          })
+          setTimeout(() => {
+            expect(dropSpy.callCount).toEqual(3)
+            expect(dropSpy.lastCall.args[0]).toEqual([...images], [...files])
+            done()
+          }, 0)
+        }, 0)
+      }, 0)
     })
 
-    it('should call onDropAccepted callback if some files were accepted', () => {
+    it('should call onDropAccepted callback if some files were accepted', done => {
       const dropzone = mount(
         <Dropzone
           onDrop={dropSpy}
@@ -705,18 +724,25 @@ describe('Dropzone', () => {
         />
       )
       dropzone.simulate('drop', { dataTransfer: { files } })
-      expect(dropAcceptedSpy.callCount).toEqual(0)
-      dropzone.simulate('drop', { dataTransfer: { files: images } })
-      expect(dropAcceptedSpy.callCount).toEqual(1)
-      expect(dropAcceptedSpy.lastCall.args[0]).toEqual([...images])
-      dropzone.simulate('drop', {
-        dataTransfer: { files: files.concat(images) }
-      })
-      expect(dropAcceptedSpy.callCount).toEqual(2)
-      expect(dropAcceptedSpy.lastCall.args[0]).toEqual([...images])
+      setTimeout(() => {
+        expect(dropAcceptedSpy.callCount).toEqual(0)
+        dropzone.simulate('drop', { dataTransfer: { files: images } })
+        setTimeout(() => {
+          expect(dropAcceptedSpy.callCount).toEqual(1)
+          expect(dropAcceptedSpy.lastCall.args[0]).toEqual([...images])
+          dropzone.simulate('drop', {
+            dataTransfer: { files: files.concat(images) }
+          })
+          setTimeout(() => {
+            expect(dropAcceptedSpy.callCount).toEqual(2)
+            expect(dropAcceptedSpy.lastCall.args[0]).toEqual([...images])
+            done()
+          }, 0)
+        }, 0)
+      }, 0)
     })
 
-    it('should call onDropRejected callback if some files were rejected', () => {
+    it('should call onDropRejected callback if some files were rejected', done => {
       const dropzone = mount(
         <Dropzone
           onDrop={dropSpy}
@@ -726,15 +752,22 @@ describe('Dropzone', () => {
         />
       )
       dropzone.simulate('drop', { dataTransfer: { files } })
-      expect(dropRejectedSpy.callCount).toEqual(1)
-      expect(dropRejectedSpy.lastCall.args[0]).toEqual([...files])
-      dropzone.simulate('drop', { dataTransfer: { files: images } })
-      expect(dropRejectedSpy.callCount).toEqual(1)
-      dropzone.simulate('drop', {
-        dataTransfer: { files: files.concat(images) }
-      })
-      expect(dropRejectedSpy.callCount).toEqual(2)
-      expect(dropRejectedSpy.lastCall.args[0]).toEqual([...files])
+      setTimeout(() => {
+        expect(dropRejectedSpy.callCount).toEqual(1)
+        expect(dropRejectedSpy.lastCall.args[0]).toEqual([...files])
+        dropzone.simulate('drop', { dataTransfer: { files: images } })
+        setTimeout(() => {
+          expect(dropRejectedSpy.callCount).toEqual(1)
+          dropzone.simulate('drop', {
+            dataTransfer: { files: files.concat(images) }
+          })
+          setTimeout(() => {
+            expect(dropRejectedSpy.callCount).toEqual(2)
+            expect(dropRejectedSpy.lastCall.args[0]).toEqual([...files])
+            done()
+          }, 0)
+        }, 0)
+      }, 0)
     })
 
     it('applies the accept prop to the dropped files', done => {
@@ -942,6 +975,18 @@ describe('Dropzone', () => {
   })
 
   describe('preview', () => {
+    let getDroppedOrSelectedFilesStub
+
+    beforeAll(() => {
+      getDroppedOrSelectedFilesStub = stub(html5, 'getDroppedOrSelectedFiles').callsFake(evt =>
+        Promise.resolve(evt.dataTransfer.files)
+      )
+    })
+
+    afterAll(() => {
+      getDroppedOrSelectedFilesStub.restore()
+    })
+
     it('should generate previews for non-images', done => {
       const dropSpy = spy()
       const dropzone = mount(<Dropzone onDrop={dropSpy} />)
@@ -989,8 +1034,6 @@ describe('Dropzone', () => {
       }, 0)
     })
   })
-
-  describe('onClick', () => {})
 
   describe('onCancel', () => {
     it('should not invoke onFileDialogCancel everytime window receives focus', done => {

--- a/src/index.spec.js
+++ b/src/index.spec.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import { mount, render } from 'enzyme'
 import { spy, stub } from 'sinon'
-import * as html5 from 'html5-file-selector'
+import * as html5 from './utils/Html5FileSelector'
 import { onDocumentDragOver } from './utils'
 
 const Dropzone = require(process.env.JEST_TARGET ? process.env.JEST_TARGET : './index') // eslint-disable-line import/no-dynamic-require

--- a/src/utils/Html5FileSelector.js
+++ b/src/utils/Html5FileSelector.js
@@ -1,0 +1,144 @@
+/**
+* Html5 File Selector
+* https://github.com/quarklemotion/html5-file-selector
+* This source code is licensed under the MIT license found in the
+* LICENSE.txt file in the root directory of this source tree.
+ */
+
+const DEFAULT_FILES_TO_IGNORE = [
+  '.DS_Store', // OSX indexing file
+  'Thumbs.db' // Windows indexing file
+]
+
+function shouldIgnoreFile(file) {
+  return DEFAULT_FILES_TO_IGNORE.indexOf(file.name) >= 0
+}
+
+function traverseDirectory(entry) {
+  const reader = entry.createReader()
+  // Resolved when the entire directory is traversed
+  return new Promise(resolveDirectory => {
+    const iterationAttempts = []
+    const errorHandler = () => {}
+    function readEntries() {
+      // According to the FileSystem API spec, readEntries() must be called until
+      // it calls the callback with an empty array.
+      reader.readEntries(batchEntries => {
+        if (!batchEntries.length) {
+          // Done iterating this particular directory
+          resolveDirectory(Promise.all(iterationAttempts))
+        } else {
+          // Add a list of promises for each directory entry.  If the entry is itself
+          // a directory, then that promise won't resolve until it is fully traversed.
+          iterationAttempts.push(
+            Promise.all(
+              batchEntries.map(batchEntry => {
+                if (batchEntry.isDirectory) {
+                  return traverseDirectory(batchEntry)
+                }
+                return Promise.resolve(batchEntry)
+              })
+            )
+          )
+          // Try calling readEntries() again for the same dir, according to spec
+          readEntries()
+        }
+      }, errorHandler)
+    }
+    // initial call to recursive entry reader function
+    readEntries()
+  })
+}
+
+// package the file in an object that includes the fullPath from the file entry
+// that would otherwise be lost
+function packageFile(file, entry) {
+  return {
+    fileObject: file,
+    type: file.type ? file.type : '',
+    name: file.name,
+    size: file.size,
+    fullPath: entry ? entry.fullPath : file.name
+  }
+}
+
+function getFile(entry) {
+  return new Promise(resolve => {
+    entry.file(file => {
+      resolve(packageFile(file, entry))
+    })
+  })
+}
+
+function handleFilePromises(promises, fileList) {
+  return Promise.all(promises).then(files => {
+    files.forEach(file => {
+      if (!shouldIgnoreFile(file)) {
+        fileList.push(file)
+      }
+    })
+    return fileList
+  })
+}
+
+export function getDataTransferFiles(dataTransfer) {
+  const dataTransferFiles = []
+  const folderPromises = []
+  const filePromises = []
+  ;[].slice.call(dataTransfer.items).forEach(listItem => {
+    if (typeof listItem.webkitGetAsEntry === 'function') {
+      const entry = listItem.webkitGetAsEntry()
+
+      if (entry && entry.isDirectory) {
+        folderPromises.push(traverseDirectory(entry))
+      } else {
+        filePromises.push(getFile(entry))
+      }
+    } else {
+      dataTransferFiles.push(listItem)
+    }
+  })
+  if (folderPromises.length) {
+    const flatten = array =>
+      array.reduce(
+        (aArray, bArray) => aArray.concat(Array.isArray(bArray) ? flatten(bArray) : bArray),
+        []
+      )
+    return Promise.all(folderPromises).then(fileEntries => {
+      const flattenedEntries = flatten(fileEntries)
+      // collect async promises to convert each fileEntry into a File object
+      flattenedEntries.forEach(fileEntry => {
+        filePromises.push(getFile(fileEntry))
+      })
+      return handleFilePromises(filePromises, dataTransferFiles)
+    })
+  } else if (filePromises.length) {
+    return handleFilePromises(filePromises, dataTransferFiles)
+  }
+  return Promise.resolve(dataTransferFiles)
+}
+
+/**
+ * This function should be called from both the onDrop event from your drag/drop
+ * dropzone as well as from the HTML5 file selector input field onChange event
+ * handler.  Pass the event object from the triggered event into this function.
+ * Supports mix of files and folders dropped via drag/drop.
+ *
+ * Returns: an array of File objects, that includes all files within folders
+ *   and subfolders of the dropped/selected items.
+ */
+export function getDroppedOrSelectedFiles(event) {
+  const dataTransfer = event.dataTransfer
+  if (dataTransfer && dataTransfer.items) {
+    return getDataTransferFiles(dataTransfer).then(fileList => Promise.resolve(fileList))
+  }
+  const files = []
+  const dragDropFileList = dataTransfer && dataTransfer.files
+  const inputFieldFileList = event.target && event.target.files
+  const fileList = dragDropFileList || inputFieldFileList || []
+  // convert the FileList to a simple array of File objects
+  for (let i = 0; i < fileList.length; i += 1) {
+    files.push(packageFile(fileList[i]))
+  }
+  return Promise.resolve(files)
+}

--- a/src/utils/Html5FileSelector.js
+++ b/src/utils/Html5FileSelector.js
@@ -89,10 +89,12 @@ export function getDataTransferFiles(dataTransfer) {
     if (typeof listItem.webkitGetAsEntry === 'function') {
       const entry = listItem.webkitGetAsEntry()
 
-      if (entry && entry.isDirectory) {
-        folderPromises.push(traverseDirectory(entry))
-      } else {
-        filePromises.push(getFile(entry))
+      if (entry) {
+        if (entry.isDirectory) {
+          folderPromises.push(traverseDirectory(entry))
+        } else {
+          filePromises.push(getFile(entry))
+        }
       }
     } else {
       dataTransferFiles.push(listItem)

--- a/src/utils/Html5FileSelector.spec.js
+++ b/src/utils/Html5FileSelector.spec.js
@@ -1,0 +1,202 @@
+/**
+* Html5 File Selector
+* https://github.com/quarklemotion/html5-file-selector
+* This source code is licensed under the MIT license found in the
+* LICENSE.txt file in the root directory of this source tree.
+ */
+
+import * as Html5FileSelector from './Html5FileSelector'
+
+const MOCK_MEDIA_FILES = [
+  { type: 'image/jpg', name: 'monkey_see.jpg' },
+  { type: 'video/mp4', name: 'monkey_pod.mp4' },
+  { type: 'image/jpg', name: 'cat1.jpg' },
+  { type: 'video/mp4', name: 'cat_pile.mp4' },
+  { type: 'image/jpg', name: 'dog.jpg' },
+  { type: 'video/mp4', name: 'dog_barking.mp4' },
+  { type: 'image/jpg', name: 'giraffe.jpg' },
+  { type: 'video/mp4', name: 'giraffe_eats.mp4' },
+  { type: 'image/jpg', name: 'rabbit.jpg' },
+  { type: 'video/mp4', name: 'white_rabbit_song.mp4' }
+]
+const MOCK_INDEX_FILES = [{ type: '', name: '.DS_Store' }, { type: '', name: 'Thumbs.db' }]
+
+function fileComparator(aFile, bFile) {
+  const textA = aFile.name
+  const textB = bFile.name
+  if (textA < textB) {
+    return -1
+  } else if (textA > textB) {
+    return 1
+  }
+
+  return 0
+}
+
+function createDataTransferItemFile(file) {
+  return {
+    isDirectory: false,
+    isFile: true,
+    file: callback => callback(file)
+  }
+}
+
+function createDataTransferItemFolder(containedFiles) {
+  return {
+    isDirectory: true,
+    isFile: false,
+    createReader: () => ({
+      sentEntries: false, // not part of the actual API, just used for real API behavior mimicking
+      readEntries(callback) {
+        if (!this.sentEntries) {
+          this.sentEntries = true
+          callback(containedFiles)
+        } else {
+          callback([])
+        }
+      }
+    })
+  }
+}
+
+function topLevelEntry(entry) {
+  return {
+    webkitGetAsEntry: () => entry
+  }
+}
+
+describe('Html5FileSelector', () => {
+  describe('.getDroppedOrSelectedFiles', () => {
+    it('handles files manually selected through a HTML file picker', done => {
+      const mockSelectedFiles = MOCK_MEDIA_FILES.slice(0, 2)
+      const filesSelectedEvent = {
+        target: {
+          files: mockSelectedFiles
+        }
+      }
+
+      Html5FileSelector.getDroppedOrSelectedFiles(filesSelectedEvent).then(selectedFiles => {
+        expect(selectedFiles.map(file => file.name).join(',')).toEqual(
+          mockSelectedFiles.map(file => file.name).join(',')
+        )
+        done()
+      })
+    })
+
+    it('handles individual files dropped to a drop zone', done => {
+      const mockDataTransferItems = [
+        topLevelEntry(createDataTransferItemFile(MOCK_MEDIA_FILES[0])),
+        topLevelEntry(createDataTransferItemFile(MOCK_MEDIA_FILES[1])),
+        topLevelEntry(createDataTransferItemFile(MOCK_MEDIA_FILES[2])),
+        topLevelEntry(createDataTransferItemFile(MOCK_MEDIA_FILES[3])),
+        topLevelEntry(createDataTransferItemFile(MOCK_MEDIA_FILES[4]))
+      ]
+      const mockFilesDroppedEvent = {
+        dataTransfer: {
+          items: mockDataTransferItems
+        }
+      }
+      Html5FileSelector.getDroppedOrSelectedFiles(mockFilesDroppedEvent)
+        .then(selectedFiles => {
+          const sortedFiles = selectedFiles.sort(fileComparator)
+          expect(sortedFiles.map(file => file.name).join(',')).toEqual(
+            MOCK_MEDIA_FILES.slice(0, 5)
+              .sort(fileComparator)
+              .map(file => file.name)
+              .join(',')
+          )
+          done()
+        })
+        .catch(error => {
+          done(error)
+        })
+    })
+
+    it('returns flattened files dropped from a mix of files and multi-nested folders dropped to a drop zone', done => {
+      const mockDataTransferItems = [
+        topLevelEntry(createDataTransferItemFile(MOCK_MEDIA_FILES[0])),
+        topLevelEntry(createDataTransferItemFile(MOCK_MEDIA_FILES[1])),
+        topLevelEntry(
+          createDataTransferItemFolder([
+            createDataTransferItemFolder([
+              createDataTransferItemFile(MOCK_MEDIA_FILES[2]),
+              createDataTransferItemFile(MOCK_MEDIA_FILES[3]),
+              createDataTransferItemFile(MOCK_MEDIA_FILES[4])
+            ]),
+            createDataTransferItemFile(MOCK_MEDIA_FILES[5]),
+            createDataTransferItemFile(MOCK_MEDIA_FILES[6])
+          ])
+        ),
+        topLevelEntry(createDataTransferItemFile(MOCK_MEDIA_FILES[7])),
+        topLevelEntry(
+          createDataTransferItemFolder([
+            createDataTransferItemFile(MOCK_MEDIA_FILES[8]),
+            createDataTransferItemFile(MOCK_MEDIA_FILES[9])
+          ])
+        )
+      ]
+      const mockFilesDroppedEvent = {
+        dataTransfer: {
+          items: mockDataTransferItems
+        }
+      }
+      Html5FileSelector.getDroppedOrSelectedFiles(mockFilesDroppedEvent)
+        .then(selectedFiles => {
+          const sortedFiles = selectedFiles.sort(fileComparator)
+          expect(sortedFiles.map(file => file.name).join(',')).toEqual(
+            MOCK_MEDIA_FILES.sort(fileComparator)
+              .map(file => file.name)
+              .join(',')
+          )
+          done()
+        })
+        .catch(error => {
+          done(error)
+        })
+    })
+
+    it('ignores OS-specific indexing files', done => {
+      const mockDataTransferItems = [
+        topLevelEntry(createDataTransferItemFile(MOCK_MEDIA_FILES[0])),
+        topLevelEntry(createDataTransferItemFile(MOCK_MEDIA_FILES[1])),
+        topLevelEntry(
+          createDataTransferItemFolder([
+            createDataTransferItemFolder([
+              createDataTransferItemFile(MOCK_INDEX_FILES[0]),
+              createDataTransferItemFile(MOCK_INDEX_FILES[1]),
+              createDataTransferItemFile(MOCK_MEDIA_FILES[2])
+            ]),
+            createDataTransferItemFile(MOCK_INDEX_FILES[0]),
+            createDataTransferItemFile(MOCK_MEDIA_FILES[3])
+          ])
+        ),
+        topLevelEntry(createDataTransferItemFile(MOCK_MEDIA_FILES[4])),
+        topLevelEntry(
+          createDataTransferItemFolder([
+            createDataTransferItemFile(MOCK_INDEX_FILES[1]),
+            createDataTransferItemFile(MOCK_MEDIA_FILES[5])
+          ])
+        )
+      ]
+      const mockFilesDroppedEvent = {
+        dataTransfer: {
+          items: mockDataTransferItems
+        }
+      }
+      Html5FileSelector.getDroppedOrSelectedFiles(mockFilesDroppedEvent)
+        .then(selectedFiles => {
+          const sortedFiles = selectedFiles.sort(fileComparator)
+          expect(sortedFiles.map(file => file.name).join(',')).toEqual(
+            MOCK_MEDIA_FILES.slice(0, 6)
+              .sort(fileComparator)
+              .map(file => file.name)
+              .join(',')
+          )
+          done()
+        })
+        .catch(error => {
+          done(error)
+        })
+    })
+  })
+})

--- a/src/utils/Html5FileSelector.spec.js
+++ b/src/utils/Html5FileSelector.spec.js
@@ -67,7 +67,7 @@ function topLevelEntry(entry) {
 
 describe('Html5FileSelector', () => {
   describe('.getDroppedOrSelectedFiles', () => {
-    it('handles files manually selected through a HTML file picker', done => {
+    it('handles files manually selected through a HTML file picker', async () => {
       const mockSelectedFiles = MOCK_MEDIA_FILES.slice(0, 2)
       const filesSelectedEvent = {
         target: {
@@ -75,15 +75,13 @@ describe('Html5FileSelector', () => {
         }
       }
 
-      Html5FileSelector.getDroppedOrSelectedFiles(filesSelectedEvent).then(selectedFiles => {
-        expect(selectedFiles.map(file => file.name).join(',')).toEqual(
-          mockSelectedFiles.map(file => file.name).join(',')
-        )
-        done()
-      })
+      const selectedFiles = await Html5FileSelector.getDroppedOrSelectedFiles(filesSelectedEvent)
+      expect(selectedFiles.map(file => file.name).join(',')).toEqual(
+        mockSelectedFiles.map(file => file.name).join(',')
+      )
     })
 
-    it('handles individual files dropped to a drop zone', done => {
+    it('handles individual files dropped to a drop zone', async () => {
       const mockDataTransferItems = [
         topLevelEntry(createDataTransferItemFile(MOCK_MEDIA_FILES[0])),
         topLevelEntry(createDataTransferItemFile(MOCK_MEDIA_FILES[1])),
@@ -96,23 +94,18 @@ describe('Html5FileSelector', () => {
           items: mockDataTransferItems
         }
       }
-      Html5FileSelector.getDroppedOrSelectedFiles(mockFilesDroppedEvent)
-        .then(selectedFiles => {
-          const sortedFiles = selectedFiles.sort(fileComparator)
-          expect(sortedFiles.map(file => file.name).join(',')).toEqual(
-            MOCK_MEDIA_FILES.slice(0, 5)
-              .sort(fileComparator)
-              .map(file => file.name)
-              .join(',')
-          )
-          done()
-        })
-        .catch(error => {
-          done(error)
-        })
+      const selectedFiles = await Html5FileSelector.getDroppedOrSelectedFiles(mockFilesDroppedEvent)
+
+      const sortedFiles = selectedFiles.sort(fileComparator)
+      expect(sortedFiles.map(file => file.name).join(',')).toEqual(
+        MOCK_MEDIA_FILES.slice(0, 5)
+          .sort(fileComparator)
+          .map(file => file.name)
+          .join(',')
+      )
     })
 
-    it('returns flattened files dropped from a mix of files and multi-nested folders dropped to a drop zone', done => {
+    it('returns flattened files dropped from a mix of files and multi-nested folders dropped to a drop zone', async () => {
       const mockDataTransferItems = [
         topLevelEntry(createDataTransferItemFile(MOCK_MEDIA_FILES[0])),
         topLevelEntry(createDataTransferItemFile(MOCK_MEDIA_FILES[1])),
@@ -140,22 +133,17 @@ describe('Html5FileSelector', () => {
           items: mockDataTransferItems
         }
       }
-      Html5FileSelector.getDroppedOrSelectedFiles(mockFilesDroppedEvent)
-        .then(selectedFiles => {
-          const sortedFiles = selectedFiles.sort(fileComparator)
-          expect(sortedFiles.map(file => file.name).join(',')).toEqual(
-            MOCK_MEDIA_FILES.sort(fileComparator)
-              .map(file => file.name)
-              .join(',')
-          )
-          done()
-        })
-        .catch(error => {
-          done(error)
-        })
+      const selectedFiles = await Html5FileSelector.getDroppedOrSelectedFiles(mockFilesDroppedEvent)
+
+      const sortedFiles = selectedFiles.sort(fileComparator)
+      expect(sortedFiles.map(file => file.name).join(',')).toEqual(
+        MOCK_MEDIA_FILES.sort(fileComparator)
+          .map(file => file.name)
+          .join(',')
+      )
     })
 
-    it('ignores OS-specific indexing files', done => {
+    it('ignores OS-specific indexing files', async () => {
       const mockDataTransferItems = [
         topLevelEntry(createDataTransferItemFile(MOCK_MEDIA_FILES[0])),
         topLevelEntry(createDataTransferItemFile(MOCK_MEDIA_FILES[1])),
@@ -183,20 +171,15 @@ describe('Html5FileSelector', () => {
           items: mockDataTransferItems
         }
       }
-      Html5FileSelector.getDroppedOrSelectedFiles(mockFilesDroppedEvent)
-        .then(selectedFiles => {
-          const sortedFiles = selectedFiles.sort(fileComparator)
-          expect(sortedFiles.map(file => file.name).join(',')).toEqual(
-            MOCK_MEDIA_FILES.slice(0, 6)
-              .sort(fileComparator)
-              .map(file => file.name)
-              .join(',')
-          )
-          done()
-        })
-        .catch(error => {
-          done(error)
-        })
+      const selectedFiles = await Html5FileSelector.getDroppedOrSelectedFiles(mockFilesDroppedEvent)
+
+      const sortedFiles = selectedFiles.sort(fileComparator)
+      expect(sortedFiles.map(file => file.name).join(',')).toEqual(
+        MOCK_MEDIA_FILES.slice(0, 6)
+          .sort(fileComparator)
+          .map(file => file.name)
+          .join(',')
+      )
     })
   })
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -1114,13 +1114,6 @@ babel-register@^6.26.0, babel-register@^6.9.0:
     mkdirp "^0.5.1"
     source-map-support "^0.4.15"
 
-babel-runtime@6.11.x:
-  version "6.11.6"
-  resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.11.6.tgz#6db707fef2d49c49bfa3cb64efdb436b518b8222"
-  dependencies:
-    core-js "^2.4.0"
-    regenerator-runtime "^0.9.5"
-
 babel-runtime@^6.18.0, babel-runtime@^6.22.0, babel-runtime@^6.23.0, babel-runtime@^6.26.0, babel-runtime@^6.9.2:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.26.0.tgz#965c7058668e82b55d7bfe04ff2337bc8b5647fe"
@@ -4055,13 +4048,6 @@ html-webpack-plugin@^2.30.0:
     pretty-error "^2.0.2"
     toposort "^1.0.0"
 
-html5-file-selector@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/html5-file-selector/-/html5-file-selector-1.0.1.tgz#ec1a7f9981f93269c602c74b0ed1e4b2ac4bb9c7"
-  dependencies:
-    babel-runtime "6.11.x"
-    mime-types "2.1.x"
-
 htmlparser2@^3.9.1:
   version "3.9.2"
   resolved "https://registry.yarnpkg.com/htmlparser2/-/htmlparser2-3.9.2.tgz#1bdf87acca0f3f9e53fa4fcceb0f4b4cbb00b338"
@@ -5849,16 +5835,6 @@ miller-rabin@^4.0.0:
   version "1.29.0"
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.29.0.tgz#48d26d235589651704ac5916ca06001914266878"
 
-mime-db@~1.33.0:
-  version "1.33.0"
-  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.33.0.tgz#a3492050a5cb9b63450541e39d9788d2272783db"
-
-mime-types@2.1.x:
-  version "2.1.18"
-  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.18.tgz#6f323f60a83d11146f831ff11fd66e2fe5503bb8"
-  dependencies:
-    mime-db "~1.33.0"
-
 mime-types@^2.1.12, mime-types@~2.1.11, mime-types@~2.1.15, mime-types@~2.1.7:
   version "2.1.16"
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.16.tgz#2b858a52e5ecd516db897ac2be87487830698e23"
@@ -7365,10 +7341,6 @@ regenerator-runtime@^0.10.5:
 regenerator-runtime@^0.11.0:
   version "0.11.0"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.11.0.tgz#7e54fe5b5ccd5d6624ea6255c3473be090b802e1"
-
-regenerator-runtime@^0.9.5:
-  version "0.9.6"
-  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.9.6.tgz#d33eb95d0d2001a4be39659707c51b0cb71ce029"
 
 regenerator-transform@^0.10.0:
   version "0.10.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1114,6 +1114,13 @@ babel-register@^6.26.0, babel-register@^6.9.0:
     mkdirp "^0.5.1"
     source-map-support "^0.4.15"
 
+babel-runtime@6.11.x:
+  version "6.11.6"
+  resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.11.6.tgz#6db707fef2d49c49bfa3cb64efdb436b518b8222"
+  dependencies:
+    core-js "^2.4.0"
+    regenerator-runtime "^0.9.5"
+
 babel-runtime@^6.18.0, babel-runtime@^6.22.0, babel-runtime@^6.23.0, babel-runtime@^6.26.0, babel-runtime@^6.9.2:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.26.0.tgz#965c7058668e82b55d7bfe04ff2337bc8b5647fe"
@@ -4048,6 +4055,13 @@ html-webpack-plugin@^2.30.0:
     pretty-error "^2.0.2"
     toposort "^1.0.0"
 
+html5-file-selector@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/html5-file-selector/-/html5-file-selector-1.0.1.tgz#ec1a7f9981f93269c602c74b0ed1e4b2ac4bb9c7"
+  dependencies:
+    babel-runtime "6.11.x"
+    mime-types "2.1.x"
+
 htmlparser2@^3.9.1:
   version "3.9.2"
   resolved "https://registry.yarnpkg.com/htmlparser2/-/htmlparser2-3.9.2.tgz#1bdf87acca0f3f9e53fa4fcceb0f4b4cbb00b338"
@@ -5835,6 +5849,16 @@ miller-rabin@^4.0.0:
   version "1.29.0"
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.29.0.tgz#48d26d235589651704ac5916ca06001914266878"
 
+mime-db@~1.33.0:
+  version "1.33.0"
+  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.33.0.tgz#a3492050a5cb9b63450541e39d9788d2272783db"
+
+mime-types@2.1.x:
+  version "2.1.18"
+  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.18.tgz#6f323f60a83d11146f831ff11fd66e2fe5503bb8"
+  dependencies:
+    mime-db "~1.33.0"
+
 mime-types@^2.1.12, mime-types@~2.1.11, mime-types@~2.1.15, mime-types@~2.1.7:
   version "2.1.16"
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.16.tgz#2b858a52e5ecd516db897ac2be87487830698e23"
@@ -7341,6 +7365,10 @@ regenerator-runtime@^0.10.5:
 regenerator-runtime@^0.11.0:
   version "0.11.0"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.11.0.tgz#7e54fe5b5ccd5d6624ea6255c3473be090b802e1"
+
+regenerator-runtime@^0.9.5:
+  version "0.9.6"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.9.6.tgz#d33eb95d0d2001a4be39659707c51b0cb71ce029"
 
 regenerator-transform@^0.10.0:
   version "0.10.1"


### PR DESCRIPTION
This pull request includes code extracted from html5-file-selector and edited to keep the package size small

**What kind of change does this PR introduce?**

- [ ] bugfix
- [x] feature
- [ ] refactoring / style
- [ ] build / chore
- [ ] documentation

**Did you add tests for your changes?**

- [x] Yes, my code is well tested
- [ ] Not relevant

**If relevant, did you update the documentation?**

- [ ] Yes, I've updated the documentation
- [x] Not relevant

**Summary**

Supports dropping a folder.

**Does this PR introduce a breaking change?**
Yes, The Drop event now does not set the acceptedfiles and rejectedfiles on state.
This will affect anyone using these by providing a function as a children of Dropzone.

**Other information**
