### PR TITLE
Enable user editing of inputAttributes.style

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -374,7 +374,7 @@ class Dropzone extends React.Component {
       accept,
       disabled,
       type: 'file',
-      style: { display: 'none' },
+      style: { display: 'none', ...inputProps.style },
       multiple: supportMultiple && multiple,
       ref: this.setRefs,
       onChange: this.onDrop,


### PR DESCRIPTION
**What kind of change does this PR introduce?**

- [x] bugfix
- [ ] feature
- [ ] refactoring / style
- [ ] build / chore
- [ ] documentation

**Did you add tests for your changes?**

- [ ] Yes, my code is well tested
- [x] Not relevant

**Summary**
In #523 you said you can pass `required` to the inputProps to enable form validation. In reality this doesn't work because the input element needs to be visible to be validated, otherwise this error happens.

![screen shot 2018-05-10 at 19 13 17](https://user-images.githubusercontent.com/7217420/39883254-8e75e588-5486-11e8-8ee1-4aeac728d552.png)

All because of this line:
https://github.com/react-dropzone/react-dropzone/blob/72abe1d900fecd7784e08010e2f60bcb790c956a/src/index.js#L377

This pr allows the user to edit the style of the input element using `inputProps.style`

**Does this PR introduce a breaking change?**
No
