### PR TITLE
Primitive Dropzone with render props

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,21 +37,23 @@ class MyDropzone extends React.Component {
   render() {
     return (
       <Dropzone onDrop={this.onDrop}>
-        {
-          ({ isDragActive }) => {
-            return (
-              <div className={cx('dropzone', {
+        {({ getRootProps, getInputProps, isDragActive }) => {
+          return (
+            <div
+              {...getRootProps()}
+              className={cx('dropzone', {
                 'dropzone--isActive': isDragActive
-              })}>
+              })}
+            >
+              <input {...getInputProps()} />
               {
                 isDragActive ?
                   <p>Drop files here...</p> :
                   <p>Try dropping some files here, or click to select files to upload.</p>
               }
-              </div>
-            )
-          }
-        }
+            </div>
+          )
+        }}
       </Dropzone>
     );
   }
@@ -59,35 +61,66 @@ class MyDropzone extends React.Component {
 
 ``` 
 
-## Usage as a HOC with stateless components
+## Render Prop Function
+
+This is where you render whatever you want to based on the state of `Dropzone`.
+You can also pass it as the children prop if you prefer to do things that way
+> `<Dropzone>{/* right here*/}</Dropzone>`
+
+The properties of this object can be split into two categories as indicated
+below:
+
+### Prop Getters
+
+These functions are used to apply props to the elements that you render. This
+gives you maximum flexibility to render what, when, and wherever you like. You
+call these on the element in question (for example: `<div {...getRootProps()}`)). It's advisable to pass all your props to that function
+rather than applying them on the element yourself to avoid your props being
+overridden (or overriding the props returned). For example:
+`getRootProps({onClick(event) {console.log(event)}})`.
+
+| property          | type           | description                                                                    |
+| ----------------- | -------------- | ------------------------------------------------------------------------------ |
+| `getRootProps`    | `function({})` | Returns the props you should apply to the root drop container you render       |
+| `getInputProps`   | `function({})` | Returns the props you should apply to hidden file input you render             |
+
+### state
+
+These are values that represent the current state of Dropzone component.
+
+| property                               | type      | description                                             |
+| -------------------------------------- | --------- | --------------------------------------------------------|
+| `isDragActive`                         | `boolean` | Flag indicating whether an active drag is in progress   |
+| `isDragAccept`                         | `boolean` | Flag indicating whether the files dragged are accepted  |
+| `isDragReject`                         | `boolean` | Flag indicating whether the files dragged are rejected  |
+| `draggedFiles`                         | `array`   | List of files in active drag                            |
+| `acceptedFiles`                        | `array`   | List of accepted files in active drag                   |
+| `rejectedFiles`                        | `array`   | List of rejected files in active drag                   |
+
+### Custom refKey
+
+Both `getRootProps` and `getInputProps` accept custom `refKey` (defaulted to `ref`) as one of the attributes passed down in the parameter.
+
+This is especially useful when incorporating custom components, e.g. styled-components, in which case you will use `innerRef` as the `refKey`.
 
 ```javascript
-import React from 'react'
-import cx from 'classnames'
-import { makeDropzone } from 'react-dropzone'
+const StyledDropArea = styled.div`
+  // Some styling here
+`
 
-function MyDropzone({ isDragActive }) {
-  const classNames = cx('dropzone', {
-    isActive: isDragActive
-  })
-  return (
-    <div className={classNames}>
-      { isDragActive ?
-          <p>Drop files here...</p> :
-          <p>Try dropping some files here, or click to select files to upload.</p>
-      }
-    </div>
-  );
-}
-
-// Call HoC with your component and options as arguments
-export default makeDropzone(MyDropzone, {
-  onDrop: (acceptedFiles, rejectedFiles) => {
-    // Do something with files
-    // i.e. pre-process, upload etc.
-  } 
-})
+const Example = () => (
+  <Dropzone>
+    {({ getRootProps, getInputProps }) => (
+      <StyledDropArea {...getRootProps({ refKey: 'innerRef' })}>
+        <input {...getInputProps()} />
+        <p>Drop some files here</p>
+      </StyledDropArea>
+    )}
+  </Dropzone>
+)
 ```
+
+## onDrop prop
   
 The `onDrop` method that accepts two arguments. The first argument represents the accepted files and the second argument the rejected files.
   

--- a/examples/Accept/Readme.md
+++ b/examples/Accept/Readme.md
@@ -22,15 +22,21 @@ class Accept extends React.Component {
   render() {
     return (
       <section>
-        <div className="dropzone">
-          <Dropzone
-            accept="image/jpeg, image/png"
-            onDrop={(accepted, rejected) => { this.setState({ accepted, rejected }); }}
-          >
-            <p>Try dropping some files here, or click to select files to upload.</p>
-            <p>Only *.jpeg and *.png images will be accepted</p>
-          </Dropzone>
-        </div>
+        <Dropzone
+          accept="image/jpeg, image/png"
+          onDrop={(accepted, rejected) => { this.setState({ accepted, rejected }); }}
+        >
+          {({ getRootProps, getInputProps }) => (
+            <div
+              {...getRootProps()}
+              className="dropzone"
+            >
+              <input {...getInputProps()} />
+              <p>Try dropping some files here, or click to select files to upload.</p>
+              <p>Only *.jpeg and *.png images will be accepted</p>
+            </div>
+          )}
+        </Dropzone>
         <aside>
           <h2>Accepted files</h2>
           <ul>
@@ -63,13 +69,19 @@ Also, at this moment it's not possible to read file names (and thus, file extens
 <Dropzone
   accept=".jpeg,.png"
 >
-  {({ isDragAccept, isDragReject }) => (
-    <div>
-      {isDragAccept && "All files will be accepted"}
-      {isDragReject && "Some files will be rejected"}
-      Drop some files here...
+  {({ getRootProps, getInputProps, isDragActive, isDragAccept, isDragReject }) => (
+    <div
+      {...getRootProps()}
+      className="dropzone"
+    >
+      <input {...getInputProps()} />
+      <div>
+        {isDragAccept && "All files will be accepted"}
+        {isDragReject && "Some files will be rejected"}
+        {!isDragActive && "Drop some files here..."}
+      </div>
     </div>
-  )}   
+  )}
 </Dropzone>
 ```
 
@@ -79,15 +91,19 @@ but this one will:
 <Dropzone
   accept="image/jpeg, image/png"
 >
-  {({ isDragActive, isDragReject }) => {
-    if (isDragActive) {
-      return "All files will be accepted";
-    }
-    if (isDragReject) {
-      return "Some files will be rejected";
-    }
-    return "Dropping some files here...";
-  }}
+  {({ getRootProps, getInputProps, isDragActive, isDragAccept, isDragReject }) => (
+    <div
+      {...getRootProps()}
+      className="dropzone"
+    >
+      <input {...getInputProps()} />
+      <div>
+        {isDragAccept && "All files will be accepted"}
+        {isDragReject && "Some files will be rejected"}
+        {!isDragActive && "Drop some files here..."}
+      </div>
+    </div>
+  )}
 </Dropzone>
 ```
 

--- a/examples/Basic/Readme.md
+++ b/examples/Basic/Readme.md
@@ -4,11 +4,12 @@ This example renders a list of the dropped files.
 
 ```
 class Basic extends React.Component {
-  constructor() {
-    super()
+  constructor(props) {
+    super(props)
     this.state = { files: [] }
+    this.onDrop = this.onDrop.bind(this)
   }
-
+  
   onDrop(files) {
     this.setState({
       files
@@ -18,19 +19,17 @@ class Basic extends React.Component {
   render() {
     return (
       <section>
-        <div className="dropzone">
-          <Dropzone onDrop={this.onDrop.bind(this)}>
-            {({ getRootProps, getInputProps, isDragActive, isDragAccept, isDragReject }) => (
-              <div
-                className={`dropzone-box ${isDragAccept ? 'accept' : ''} ${isDragReject ? 'reject' : ''}`}
-                {...getRootProps({ refKey: 'innerRef' })}
-              >
-                <input {...getInputProps()} />
-                <p>Try dropping some files here, or click to select files to upload.</p>
-              </div>
-            )}
-          </Dropzone>
-        </div>
+        <Dropzone onDrop={this.onDrop}>
+          {({ getRootProps, getInputProps }) => (
+            <div
+              {...getRootProps()}
+              className="dropzone"
+            >
+              <input {...getInputProps()} />
+              <p>Try dropping some files here, or click to select files to upload.</p>
+            </div>
+          )}
+        </Dropzone>
         <aside>
           <h2>Dropped files</h2>
           <ul>

--- a/examples/Basic/Readme.md
+++ b/examples/Basic/Readme.md
@@ -20,7 +20,15 @@ class Basic extends React.Component {
       <section>
         <div className="dropzone">
           <Dropzone onDrop={this.onDrop.bind(this)}>
-            <p>Try dropping some files here, or click to select files to upload.</p>
+            {({ getRootProps, getInputProps, isDragActive, isDragAccept, isDragReject }) => (
+              <div
+                className={`dropzone-box ${isDragAccept ? 'accept' : ''} ${isDragReject ? 'reject' : ''}`}
+                {...getRootProps({ refKey: 'innerRef' })}
+              >
+                <input {...getInputProps()} />
+                <p>Try dropping some files here, or click to select files to upload.</p>
+              </div>
+            )}
           </Dropzone>
         </div>
         <aside>

--- a/examples/File Dialog/Readme.md
+++ b/examples/File Dialog/Readme.md
@@ -5,10 +5,15 @@ let dropzoneRef;
 
 <div>
   <Dropzone ref={(node) => { dropzoneRef = node; }} onDrop={(accepted, rejected) => { alert(accepted) }}>
-      <p>Drop files here.</p>
+    {({ getRootProps, getInputProps }) => (
+      <div {...getRootProps()}>
+        <input {...getInputProps()} />
+        <p>Drop files here.</p>
+      </div>
+    )}
   </Dropzone>
   <button type="button" onClick={() => { dropzoneRef.open() }}>
-      Open File Dialog
+    Open File Dialog
   </button>
 </div>
 ```

--- a/examples/Fullscreen/Readme.md
+++ b/examples/Fullscreen/Readme.md
@@ -41,8 +41,13 @@ class FullScreen extends React.Component {
         accept={accept}
         onDrop={this.onDrop.bind(this)}
       >
-        {({ isDragActive }) => (
-          <div style={{ position: 'relative' }}>
+        {({ getRootProps, getInputProps, isDragActive, isDragAccept, isDragReject }) => (
+          <div
+            {...getRootProps()}
+            style={{ position: 'relative' }}
+          >
+            <input {...getInputProps()} />
+            
             {isDragActive && <div style={overlayStyle}>Drop files...</div>}
             
             <h1>My awesome app</h1>
@@ -59,7 +64,6 @@ class FullScreen extends React.Component {
                 files.map(f => <li>{f.name} - {f.size} bytes</li>)
               }
             </ul>
-  
           </div>
         )}
       </Dropzone>

--- a/examples/Styling/Readme.md
+++ b/examples/Styling/Readme.md
@@ -21,19 +21,21 @@ const rejectStyle = {
 };
 
 <Dropzone accept="image/*">
-  {({ isDragActive, isDragAccept, isDragReject, acceptedFiles, rejectedFiles }) => {
+  {({ getRootProps, getInputProps, isDragActive, isDragAccept, isDragReject, acceptedFiles, rejectedFiles }) => {
     let styles = {...baseStyle}
     styles = isDragActive ? {...styles, ...activeStyle} : styles
-    
-    if (isDragReject) {
-      return <div style={{...styles, ...rejectStyle}}>
-        Unsupported file type...
-      </div>
-    } 
+    styles = isDragReject ? {...styles, ...rejectStyle} : styles
           
     return (
-      <div style={styles}>
-        {isDragAccept ? `Drop ${acceptedFiles.length}` : 'Drag'} files here...
+      <div 
+        {...getRootProps()}
+        style={styles}
+      >
+        <input {...getInputProps()} />
+        <div>
+          {isDragAccept ? `Drop ${acceptedFiles.length}` : 'Drag'} files here...
+        </div>
+        {isDragReject && <div>Unsupported file type...</div>}
       </div>
     )
   }}

--- a/src/__snapshots__/index.spec.js.snap
+++ b/src/__snapshots__/index.spec.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Dropzone basics should render children 1`] = `"<div class=\\"\\" style=\\"width: 200px; height: 200px; border-width: 2px; border-color: #666; border-style: dashed; border-radius: 5px;\\"><p>some content</p><input type=\\"file\\" multiple=\\"\\" style=\\"display: none;\\"></div>"`;
+exports[`Dropzone basics should render children 1`] = `"<div><input type=\\"file\\" multiple=\\"\\" autocomplete=\\"off\\" style=\\"display: none;\\"></div>"`;
 
-exports[`Dropzone document drop protection does not prevent stray drops when preventDropOnDocument is false 1`] = `"<div class=\\"\\" style=\\"width: 200px; height: 200px; border-width: 2px; border-color: #666; border-style: dashed; border-radius: 5px;\\"><input type=\\"file\\" multiple=\\"\\" style=\\"display: none;\\"></div>"`;
+exports[`Dropzone document drop protection does not prevent stray drops when preventDropOnDocument is false 1`] = `"<div><input type=\\"file\\" multiple=\\"\\" autocomplete=\\"off\\" style=\\"display: none;\\"></div>"`;
 
-exports[`Dropzone document drop protection installs hooks to prevent stray drops from taking over the browser window 1`] = `"<div class=\\"\\" style=\\"width: 200px; height: 200px; border-width: 2px; border-color: #666; border-style: dashed; border-radius: 5px;\\"><p>Content</p><input type=\\"file\\" multiple=\\"\\" style=\\"display: none;\\"></div>"`;
+exports[`Dropzone document drop protection installs hooks to prevent stray drops from taking over the browser window 1`] = `"<div><input type=\\"file\\" multiple=\\"\\" autocomplete=\\"off\\" style=\\"display: none;\\"><p>Content</p></div>"`;

--- a/src/index.js
+++ b/src/index.js
@@ -4,6 +4,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import accepts from 'attr-accept'
 import getDataTransferItems from './getDataTransferItems'
+import { composeEventHandlers } from './utils'
 
 const supportMultiple = typeof document !== 'undefined' && document && document.createElement
   ? 'multiple' in document.createElement('input')
@@ -52,7 +53,6 @@ class Dropzone extends React.Component {
       document.addEventListener('dragover', Dropzone.onDocumentDragOver, false)
       document.addEventListener('drop', this.onDocumentDrop, false)
     }
-    // this.fileInputEl.addEventListener('click', this.onInputElementClick, false)
     // Tried implementing addEventListener, but didn't work out
     document.body.onfocus = this.onFileDialogCancel
   }
@@ -63,7 +63,6 @@ class Dropzone extends React.Component {
       document.removeEventListener('dragover', Dropzone.onDocumentDragOver)
       document.removeEventListener('drop', this.onDocumentDrop)
     }
-    // this.fileInputEl.removeEventListener('click', this.onInputElementClick, false)
     // Can be replaced with removeEventListener, if addEventListener works
     document.body.onfocus = null
   }
@@ -214,12 +213,11 @@ class Dropzone extends React.Component {
     }
   }
 
+  /* eslint-disable */
   onInputElementClick(evt) {
     evt.stopPropagation()
-    if (this.props.inputProps && this.props.inputProps.onClick) {
-      this.props.inputProps.onClick()
-    }
   }
+  /* eslint-enable */
 
   onFileDialogCancel() {
     // timeout will not recognize context of this method
@@ -269,14 +267,15 @@ class Dropzone extends React.Component {
     }
   }
 
-  getInputProps({ refKey = 'ref', ...rest } = {}) {
+  getInputProps({ refKey = 'ref', onChange, onClick, ...rest } = {}) {
     const { accept, multiple, name } = this.props
     const inputProps = {
       accept,
       type: 'file',
       style: { display: 'none' },
       multiple: supportMultiple && multiple,
-      onChange: this.onDrop,
+      onChange: composeEventHandlers(onChange, this.onDrop),
+      onClick: composeEventHandlers(onClick, this.onInputElementClick),
       autoComplete: 'off',
       [refKey]: this.setInputRef
     }
@@ -361,11 +360,6 @@ Dropzone.propTypes = {
    * If false, allow dropped items to take over the current browser window
    */
   preventDropOnDocument: PropTypes.bool,
-
-  /**
-   * Pass additional attributes to the `<input type="file"/>` tag
-   */
-  inputProps: PropTypes.object,
 
   /**
    * Allow dropping multiple files

--- a/src/index.js
+++ b/src/index.js
@@ -300,7 +300,7 @@ class Dropzone extends React.Component {
   }
 
   render() {
-    const { multiple, children } = this.props
+    const { multiple, children, render } = this.props
     const { isDragActive, draggedFiles, acceptedFiles, rejectedFiles } = this.state
 
     const filesCount = draggedFiles.length
@@ -308,7 +308,8 @@ class Dropzone extends React.Component {
     const isDragAccept = filesCount > 0 && this.allFilesAccepted(draggedFiles)
     const isDragReject = filesCount > 0 && (!isDragAccept || !isMultipleAllowed)
 
-    return children({
+    const renderFn = children || render
+    return renderFn({
       getRootProps: this.getRootProps,
       getInputProps: this.getInputProps,
       isDragActive,
@@ -342,7 +343,12 @@ Dropzone.propTypes = {
    * @param {Array} acceptedFiles
    * @param {Array} rejectedFiles
    */
-  children: PropTypes.func.isRequired,
+  children: PropTypes.func,
+
+  /**
+   * Alternative render function to children prop
+   */
+  render: PropTypes.func,
 
   /**
    * Disallow clicking on the dropzone container to open file dialog

--- a/src/index.js
+++ b/src/index.js
@@ -265,17 +265,6 @@ class Dropzone extends React.Component {
     ...rest
   })
 
-  // getRootProps = ({ refKey = 'ref', ...rest } = {}) => ({
-  //   onClick: this.onClick,
-  //   onDragStart: this.onDragStart,
-  //   onDragEnter: this.onDragEnter,
-  //   onDragOver: this.onDragOver,
-  //   onDragLeave: this.onDragLeave,
-  //   onDrop: this.onDrop,
-  //   [refKey]: this.setRef,
-  //   ...rest
-  // })
-
   getInputProps = ({ refKey = 'ref', onChange, onClick, ...rest } = {}) => {
     const { accept, multiple, name } = this.props
     const inputProps = {

--- a/src/index.js
+++ b/src/index.js
@@ -22,27 +22,10 @@ class Dropzone extends React.Component {
     evt.preventDefault()
   }
 
-  constructor(props, context) {
-    super(props, context)
-    this.onClick = this.onClick.bind(this)
-    this.onDocumentDrop = this.onDocumentDrop.bind(this)
-    this.onDragStart = this.onDragStart.bind(this)
-    this.onDragEnter = this.onDragEnter.bind(this)
-    this.onDragLeave = this.onDragLeave.bind(this)
-    this.onDragOver = this.onDragOver.bind(this)
-    this.onDrop = this.onDrop.bind(this)
-    this.onFileDialogCancel = this.onFileDialogCancel.bind(this)
-    this.setRef = this.setRef.bind(this)
-    this.setInputRef = this.setInputRef.bind(this)
-    this.onInputElementClick = this.onInputElementClick.bind(this)
-    this.getRootProps = this.getRootProps.bind(this)
-    this.getInputProps = this.getInputProps.bind(this)
-    this.isFileDialogActive = false
-    this.state = {
-      draggedFiles: [],
-      acceptedFiles: [],
-      rejectedFiles: []
-    }
+  state = {
+    draggedFiles: [],
+    acceptedFiles: [],
+    rejectedFiles: []
   }
 
   componentDidMount() {
@@ -67,7 +50,7 @@ class Dropzone extends React.Component {
     document.body.onfocus = null
   }
 
-  onDocumentDrop(evt) {
+  onDocumentDrop = evt => {
     if (this.node.contains(evt.target)) {
       // if we intercepted an event for our instance, let it propagate down to the instance's onDrop handler
       return
@@ -76,13 +59,13 @@ class Dropzone extends React.Component {
     this.dragTargets = []
   }
 
-  onDragStart(evt) {
+  onDragStart = evt => {
     if (this.props.onDragStart) {
       this.props.onDragStart.call(this, evt)
     }
   }
 
-  onDragEnter(evt) {
+  onDragEnter = evt => {
     evt.preventDefault()
 
     // Count the dropzone and any children that are entered.
@@ -100,7 +83,7 @@ class Dropzone extends React.Component {
     }
   }
 
-  onDragOver(evt) {
+  onDragOver = evt => {
     // eslint-disable-line class-methods-use-this
     evt.preventDefault()
     evt.stopPropagation()
@@ -116,7 +99,7 @@ class Dropzone extends React.Component {
     return false
   }
 
-  onDragLeave(evt) {
+  onDragLeave = evt => {
     evt.preventDefault()
 
     // Only deactivate once the dropzone and all children have been left.
@@ -136,7 +119,7 @@ class Dropzone extends React.Component {
     }
   }
 
-  onDrop(evt) {
+  onDrop = evt => {
     const { onDrop, onDropAccepted, onDropRejected, multiple, disablePreview, accept } = this.props
     const fileList = getDataTransferItems(evt)
     const acceptedFiles = []
@@ -197,7 +180,7 @@ class Dropzone extends React.Component {
     })
   }
 
-  onClick(evt) {
+  onClick = evt => {
     const { onClick, disableClick } = this.props
     if (!disableClick) {
       evt.stopPropagation()
@@ -214,12 +197,12 @@ class Dropzone extends React.Component {
   }
 
   /* eslint-disable */
-  onInputElementClick(evt) {
+  onInputElementClick = evt => {
     evt.stopPropagation()
   }
   /* eslint-enable */
 
-  onFileDialogCancel() {
+  onFileDialogCancel = () => {
     // timeout will not recognize context of this method
     const { onFileDialogCancel } = this.props
     const { fileInputEl } = this
@@ -238,11 +221,11 @@ class Dropzone extends React.Component {
     }
   }
 
-  setRef(ref) {
+  setRef = ref => {
     this.node = ref
   }
 
-  setInputRef(ref) {
+  setInputRef = ref => {
     this.fileInputEl = ref
   }
 
@@ -254,20 +237,29 @@ class Dropzone extends React.Component {
     return files.every(file => fileAccepted(file, this.props.accept))
   }
 
-  getRootProps({ refKey = 'ref', ...rest } = {}) {
-    return {
-      onClick: this.onClick,
-      onDragStart: this.onDragStart,
-      onDragEnter: this.onDragEnter,
-      onDragOver: this.onDragOver,
-      onDragLeave: this.onDragLeave,
-      onDrop: this.onDrop,
-      [refKey]: this.setRef,
+  getRootProps = (
+    {
+      refKey = 'ref',
+      onClick,
+      onDragStart,
+      onDragEnter,
+      onDragOver,
+      onDragLeave,
+      onDrop,
       ...rest
-    }
-  }
+    } = {}
+  ) => ({
+    onClick: composeEventHandlers(onClick, this.onClick),
+    onDragStart: composeEventHandlers(onDragStart, this.onDragStart),
+    onDragEnter: composeEventHandlers(onDragEnter, this.onDragEnter),
+    onDragOver: composeEventHandlers(onDragOver, this.onDragOver),
+    onDragLeave: composeEventHandlers(onDragLeave, this.onDragLeave),
+    onDrop: composeEventHandlers(onDrop, this.onDrop),
+    [refKey]: this.setRef,
+    ...rest
+  })
 
-  getInputProps({ refKey = 'ref', onChange, onClick, ...rest } = {}) {
+  getInputProps = ({ refKey = 'ref', onChange, onClick, ...rest } = {}) => {
     const { accept, multiple, name } = this.props
     const inputProps = {
       accept,

--- a/src/index.js
+++ b/src/index.js
@@ -249,15 +249,32 @@ class Dropzone extends React.Component {
       ...rest
     } = {}
   ) => ({
-    onClick: composeEventHandlers(onClick, this.onClick),
-    onDragStart: composeEventHandlers(onDragStart, this.onDragStart),
-    onDragEnter: composeEventHandlers(onDragEnter, this.onDragEnter),
-    onDragOver: composeEventHandlers(onDragOver, this.onDragOver),
-    onDragLeave: composeEventHandlers(onDragLeave, this.onDragLeave),
-    onDrop: composeEventHandlers(onDrop, this.onDrop),
+    onClick: onClick ? composeEventHandlers(onClick, this.onClick) : this.onClick,
+    onDragStart: onDragStart
+      ? composeEventHandlers(onDragStart, this.onDragStart)
+      : this.onDragStart,
+    onDragEnter: onDragEnter
+      ? composeEventHandlers(onDragEnter, this.onDragEnter)
+      : this.onDragEnter,
+    onDragOver: onDragOver ? composeEventHandlers(onDragOver, this.onDragOver) : this.onDragOver,
+    onDragLeave: onDragLeave
+      ? composeEventHandlers(onDragLeave, this.onDragLeave)
+      : this.onDragLeave,
+    onDrop: onDrop ? composeEventHandlers(onDrop, this.onDrop) : this.onDrop,
     [refKey]: this.setRef,
     ...rest
   })
+
+  // getRootProps = ({ refKey = 'ref', ...rest } = {}) => ({
+  //   onClick: this.onClick,
+  //   onDragStart: this.onDragStart,
+  //   onDragEnter: this.onDragEnter,
+  //   onDragOver: this.onDragOver,
+  //   onDragLeave: this.onDragLeave,
+  //   onDrop: this.onDrop,
+  //   [refKey]: this.setRef,
+  //   ...rest
+  // })
 
   getInputProps = ({ refKey = 'ref', onChange, onClick, ...rest } = {}) => {
     const { accept, multiple, name } = this.props
@@ -287,7 +304,7 @@ class Dropzone extends React.Component {
    *
    * @public
    */
-  open() {
+  open = () => {
     this.isFileDialogActive = true
     this.fileInputEl.value = null
     this.fileInputEl.click()

--- a/src/index.spec.js
+++ b/src/index.spec.js
@@ -323,13 +323,17 @@ describe('Dropzone', () => {
         <Dropzone>
           {({ getRootProps, getInputProps }) => (
             <div {...getRootProps()}>
-              <input {...getInputProps()} onClick={inputPropsClickSpy} />
+              <input
+                {...getInputProps({
+                  onClick: inputPropsClickSpy
+                })}
+              />
             </div>
           )}
         </Dropzone>
       )
 
-      component.find('Dropzone').simulate('click')
+      component.find('input').simulate('click')
       setTimeout(() => {
         expect(inputPropsClickSpy.callCount).toEqual(1)
         done()
@@ -418,7 +422,12 @@ describe('Dropzone', () => {
     it('should set proper dragActive state on dragEnter', () => {
       const dropzone = mount(
         <Dropzone>
-          {props => <DummyChildComponent {...props} />}
+          {({ getRootProps, getInputProps, ...restProps }) => (
+            <div {...getRootProps()}>
+              <input {...getInputProps()} />
+              <DummyChildComponent {...restProps} />
+            </div>
+          )}
         </Dropzone>
       )
       const child = dropzone.find(DummyChildComponent)
@@ -431,10 +440,11 @@ describe('Dropzone', () => {
     it('should set proper dragReject state on dragEnter', () => {
       const dropzone = mount(
         <Dropzone accept="image/*">
-          {({ getRootProps, getInputProps, ...rest }) => (
-            <DummyChildComponent {...getRootProps()} {...rest}>
+          {({ getRootProps, getInputProps, ...restProps }) => (
+            <div {...getRootProps()}>
               <input {...getInputProps()} />
-            </DummyChildComponent>
+              <DummyChildComponent {...restProps} />
+            </div>
           )}
         </Dropzone>
       )
@@ -449,9 +459,10 @@ describe('Dropzone', () => {
       const dropzone = mount(
         <Dropzone accept="image/*" multiple={false}>
           {({ getRootProps, getInputProps, ...rest }) => (
-            <DummyChildComponent {...getRootProps()} {...rest}>
+            <div {...getRootProps()}>
               <input {...getInputProps()} />
-            </DummyChildComponent>
+              <DummyChildComponent {...rest} />
+            </div>
           )}
         </Dropzone>
       )
@@ -466,9 +477,10 @@ describe('Dropzone', () => {
       const dropzone = mount(
         <Dropzone accept="image/*" multiple={false}>
           {({ getRootProps, getInputProps, ...rest }) => (
-            <DummyChildComponent {...getRootProps()} {...rest}>
+            <div {...getRootProps()}>
               <input {...getInputProps()} />
-            </DummyChildComponent>
+              <DummyChildComponent {...rest} />
+            </div>
           )}
         </Dropzone>
       )
@@ -483,9 +495,10 @@ describe('Dropzone', () => {
       const dropzone = mount(
         <Dropzone accept="image/*">
           {({ getRootProps, getInputProps, ...rest }) => (
-            <DummyChildComponent {...getRootProps()} {...rest}>
+            <div {...getRootProps()}>
               <input {...getInputProps()} />
-            </DummyChildComponent>
+              <DummyChildComponent {...rest} />
+            </div>
           )}
         </Dropzone>
       )
@@ -579,7 +592,12 @@ describe('Dropzone', () => {
           onDropAccepted={dropAcceptedSpy}
           onDropRejected={dropRejectedSpy}
         >
-          {props => <DummyChildComponent {...props} />}
+          {({ getRootProps, getInputProps, ...restProps }) => (
+            <div {...getRootProps()}>
+              <input {...getInputProps()} />
+              <DummyChildComponent {...restProps} />
+            </div>
+          )}
         </Dropzone>
       )
       const child = dropzone.find(DummyChildComponent)
@@ -1144,10 +1162,10 @@ describe('Dropzone', () => {
             onDropRejected={outerDropRejectedSpy}
             accept="image/*"
           >
-            {({ getRootProps, getInputProps }) => (
+            {({ getRootProps, getInputProps, ...restProps }) => (
               <div {...getRootProps()}>
                 <input {...getInputProps()} />
-                <InnerDropzone />
+                <InnerDropzone {...restProps} />
               </div>
             )}
           </Dropzone>

--- a/src/index.spec.js
+++ b/src/index.spec.js
@@ -36,66 +36,58 @@ describe('Dropzone', () => {
     it('should render children', () => {
       const dropzone = mount(
         <Dropzone>
-          <p>some content</p>
+          {({ getRootProps, getInputProps }) => (
+            <div {...getRootProps()}>
+              <input {...getInputProps()} />
+            </div>
+          )}
         </Dropzone>
       )
       expect(dropzone.html()).toMatchSnapshot()
     })
 
-    it('should render an input HTML element', () => {
+    it('sets ref properly', () => {
       const dropzone = mount(
         <Dropzone>
-          <p>some content</p>
+          {({ getRootProps, getInputProps }) => (
+            <div {...getRootProps()}>
+              <input {...getInputProps()} />
+            </div>
+          )}
         </Dropzone>
       )
-      expect(dropzone.find('input').length).toEqual(1)
-    })
-
-    it('sets ref properly', () => {
-      const dropzone = mount(<Dropzone />)
       expect(dropzone.instance().fileInputEl).not.toBeUndefined()
       expect(dropzone.instance().fileInputEl.tagName).toEqual('INPUT')
     })
 
-    it('renders dynamic props on the root element', () => {
-      const component = mount(<Dropzone hidden aria-hidden title="Dropzone" />)
-      expect(component.html()).toContain('aria-hidden="true"')
-      expect(component.html()).toContain('hidden=""')
-      expect(component.html()).toContain('title="Dropzone"')
-    })
-
-    it('renders dynamic props on the input element', () => {
-      const component = mount(<Dropzone inputProps={{ id: 'hiddenFileInput' }} />)
-      expect(component.find('input').html()).toContain('id="hiddenFileInput"')
-    })
-
     it('applies the accept prop to the child input', () => {
-      const component = render(<Dropzone className="my-dropzone" accept="image/jpeg" />)
+      const component = render(
+        <Dropzone accept="image/jpeg">
+          {({ getRootProps, getInputProps }) => (
+            <div className="my-dropzone" {...getRootProps()}>
+              <input {...getInputProps()} />
+            </div>
+          )}
+        </Dropzone>
+      )
       expect(component.find('.my-dropzone').attr()).not.toContain('accept')
       expect(Object.keys(component.find('input').attr())).toContain('accept')
       expect(component.find('input').attr('accept')).toEqual('image/jpeg')
     })
 
     it('applies the name prop to the child input', () => {
-      const component = render(<Dropzone className="my-dropzone" name="test-file-input" />)
+      const component = render(
+        <Dropzone name="test-file-input">
+          {({ getRootProps, getInputProps }) => (
+            <div className="my-dropzone" {...getRootProps()}>
+              <input {...getInputProps()} />
+            </div>
+          )}
+        </Dropzone>
+      )
       expect(component.find('.my-dropzone').attr()).not.toContain('name')
       expect(Object.keys(component.find('input').attr())).toContain('name')
       expect(component.find('input').attr('name')).toEqual('test-file-input')
-    })
-
-    it('should render children function', () => {
-      const content = <p>some content</p>
-      const dropzone = mount(
-        <Dropzone>
-          {content}
-        </Dropzone>
-      )
-      const dropzoneWithFunction = mount(
-        <Dropzone>
-          {() => content}
-        </Dropzone>
-      )
-      expect(dropzoneWithFunction.html()).toEqual(dropzone.html())
     })
   })
 
@@ -126,7 +118,16 @@ describe('Dropzone', () => {
     }
 
     it('installs hooks to prevent stray drops from taking over the browser window', () => {
-      dropzone = mount(<Dropzone><p>Content</p></Dropzone>)
+      dropzone = mount(
+        <Dropzone>
+          {({ getRootProps, getInputProps }) => (
+            <div {...getRootProps()}>
+              <input {...getInputProps()} />
+              <p>Content</p>
+            </div>
+          )}
+        </Dropzone>
+      )
       expect(dropzone.html()).toMatchSnapshot()
       expect(document.addEventListener.callCount).toEqual(2)
       addEventCalls = collectEventListenerCalls(document.addEventListener.args)
@@ -165,7 +166,15 @@ describe('Dropzone', () => {
     })
 
     it('does not prevent stray drops when preventDropOnDocument is false', () => {
-      dropzone = mount(<Dropzone preventDropOnDocument={false} />)
+      dropzone = mount(
+        <Dropzone preventDropOnDocument={false}>
+          {({ getRootProps, getInputProps }) => (
+            <div {...getRootProps()}>
+              <input {...getInputProps()} />
+            </div>
+          )}
+        </Dropzone>
+      )
       expect(dropzone.html()).toMatchSnapshot()
       expect(document.addEventListener.callCount).toEqual(0)
 
@@ -176,7 +185,15 @@ describe('Dropzone', () => {
 
   describe('onClick', () => {
     it('should call `open` method', done => {
-      const dropzone = mount(<Dropzone />)
+      const dropzone = mount(
+        <Dropzone>
+          {({ getRootProps, getInputProps }) => (
+            <div {...getRootProps()}>
+              <input {...getInputProps()} />
+            </div>
+          )}
+        </Dropzone>
+      )
       spy(dropzone.instance(), 'open')
       dropzone.simulate('click')
       setTimeout(() => {
@@ -186,7 +203,15 @@ describe('Dropzone', () => {
     })
 
     it('should not call `open` if disableClick prop is true', () => {
-      const dropzone = mount(<Dropzone disableClick />)
+      const dropzone = mount(
+        <Dropzone disableClick>
+          {({ getRootProps, getInputProps }) => (
+            <div {...getRootProps()}>
+              <input {...getInputProps()} />
+            </div>
+          )}
+        </Dropzone>
+      )
       spy(dropzone.instance(), 'open')
       dropzone.simulate('click')
       expect(dropzone.instance().open.callCount).toEqual(0)
@@ -194,7 +219,15 @@ describe('Dropzone', () => {
 
     it('should call `onClick` callback if provided', done => {
       const clickSpy = spy()
-      const dropzone = mount(<Dropzone onClick={clickSpy} />)
+      const dropzone = mount(
+        <Dropzone onClick={clickSpy}>
+          {({ getRootProps, getInputProps }) => (
+            <div {...getRootProps()}>
+              <input {...getInputProps()} />
+            </div>
+          )}
+        </Dropzone>
+      )
       spy(dropzone.instance(), 'open')
       dropzone.simulate('click')
       setTimeout(() => {
@@ -205,7 +238,15 @@ describe('Dropzone', () => {
     })
 
     it('should reset the value of input', () => {
-      const dropzone = mount(<Dropzone />)
+      const dropzone = mount(
+        <Dropzone>
+          {({ getRootProps, getInputProps }) => (
+            <div {...getRootProps()}>
+              <input {...getInputProps()} />
+            </div>
+          )}
+        </Dropzone>
+      )
       expect(dropzone.render().find('input').attr('value')).toBeUndefined()
       expect(dropzone.render().find('input').attr('value', 10)).not.toBeUndefined()
       dropzone.simulate('click')
@@ -213,7 +254,15 @@ describe('Dropzone', () => {
     })
 
     it('should trigger click even on the input', done => {
-      const dropzone = mount(<Dropzone />)
+      const dropzone = mount(
+        <Dropzone>
+          {({ getRootProps, getInputProps }) => (
+            <div {...getRootProps()}>
+              <input {...getInputProps()} />
+            </div>
+          )}
+        </Dropzone>
+      )
       const clickSpy = spy(dropzone.instance().fileInputEl, 'click')
       dropzone.simulate('click')
       dropzone.simulate('click')
@@ -228,7 +277,13 @@ describe('Dropzone', () => {
       const onClickInnerSpy = spy()
       const component = mount(
         <div onClick={onClickOuterSpy}>
-          <Dropzone onClick={onClickInnerSpy} />
+          <Dropzone onClick={onClickInnerSpy}>
+            {({ getRootProps, getInputProps }) => (
+              <div {...getRootProps()}>
+                <input {...getInputProps()} />
+              </div>
+            )}
+          </Dropzone>
         </div>
       )
 
@@ -248,7 +303,13 @@ describe('Dropzone', () => {
       const onClickOuterSpy = spy()
       const component = mount(
         <div onClick={onClickOuterSpy}>
-          <Dropzone disableClick />
+          <Dropzone disableClick>
+            {({ getRootProps, getInputProps }) => (
+              <div {...getRootProps()}>
+                <input {...getInputProps()} />
+              </div>
+            )}
+          </Dropzone>
         </div>
       )
 
@@ -258,7 +319,15 @@ describe('Dropzone', () => {
 
     it('should invoke inputProps onClick if provided', done => {
       const inputPropsClickSpy = spy()
-      const component = mount(<Dropzone inputProps={{ onClick: inputPropsClickSpy }} />)
+      const component = mount(
+        <Dropzone>
+          {({ getRootProps, getInputProps }) => (
+            <div {...getRootProps()}>
+              <input {...getInputProps()} onClick={inputPropsClickSpy} />
+            </div>
+          )}
+        </Dropzone>
+      )
 
       component.find('Dropzone').simulate('click')
       setTimeout(() => {
@@ -280,7 +349,13 @@ describe('Dropzone', () => {
           onDragEnter={dragEnterSpy}
           onDragOver={dragOverSpy}
           onDragLeave={dragLeaveSpy}
-        />
+        >
+          {({ getRootProps, getInputProps }) => (
+            <div {...getRootProps()}>
+              <input {...getInputProps()} />
+            </div>
+          )}
+        </Dropzone>
       )
       component.simulate('dragStart')
       component.simulate('dragEnter', { dataTransfer: { items: files } })
@@ -297,11 +372,13 @@ describe('Dropzone', () => {
       const dragEnterSpy = spy()
       const dragLeaveSpy = spy()
       const component = mount(
-        <Dropzone
-          onDragStart={dragStartSpy}
-          onDragEnter={dragEnterSpy}
-          onDragLeave={dragLeaveSpy}
-        />
+        <Dropzone onDragStart={dragStartSpy} onDragEnter={dragEnterSpy} onDragLeave={dragLeaveSpy}>
+          {({ getRootProps, getInputProps }) => (
+            <div {...getRootProps()}>
+              <input {...getInputProps()} />
+            </div>
+          )}
+        </Dropzone>
       )
 
       // Using Proxy we'll emulate IE throwing when setting dataTransfer.dropEffect
@@ -354,7 +431,11 @@ describe('Dropzone', () => {
     it('should set proper dragReject state on dragEnter', () => {
       const dropzone = mount(
         <Dropzone accept="image/*">
-          {props => <DummyChildComponent {...props} />}
+          {({ getRootProps, getInputProps, ...rest }) => (
+            <DummyChildComponent {...getRootProps()} {...rest}>
+              <input {...getInputProps()} />
+            </DummyChildComponent>
+          )}
         </Dropzone>
       )
       const child = dropzone.find(DummyChildComponent)
@@ -367,7 +448,11 @@ describe('Dropzone', () => {
     it('should set proper dragAccept state if multiple is false', () => {
       const dropzone = mount(
         <Dropzone accept="image/*" multiple={false}>
-          {props => <DummyChildComponent {...props} />}
+          {({ getRootProps, getInputProps, ...rest }) => (
+            <DummyChildComponent {...getRootProps()} {...rest}>
+              <input {...getInputProps()} />
+            </DummyChildComponent>
+          )}
         </Dropzone>
       )
       const child = dropzone.find(DummyChildComponent)
@@ -380,7 +465,11 @@ describe('Dropzone', () => {
     it('should set proper dragAccept state if multiple is false', () => {
       const dropzone = mount(
         <Dropzone accept="image/*" multiple={false}>
-          {props => <DummyChildComponent {...props} />}
+          {({ getRootProps, getInputProps, ...rest }) => (
+            <DummyChildComponent {...getRootProps()} {...rest}>
+              <input {...getInputProps()} />
+            </DummyChildComponent>
+          )}
         </Dropzone>
       )
       const child = dropzone.find(DummyChildComponent)
@@ -393,7 +482,11 @@ describe('Dropzone', () => {
     it('should set proper dragActive state if accept prop changes mid-drag', () => {
       const dropzone = mount(
         <Dropzone accept="image/*">
-          {props => <DummyChildComponent {...props} />}
+          {({ getRootProps, getInputProps, ...rest }) => (
+            <DummyChildComponent {...getRootProps()} {...rest}>
+              <input {...getInputProps()} />
+            </DummyChildComponent>
+          )}
         </Dropzone>
       )
       const child = dropzone.find(DummyChildComponent)
@@ -411,15 +504,14 @@ describe('Dropzone', () => {
     it('should expose state to children', () => {
       const dropzone = mount(
         <Dropzone accept="image/*">
-          {({ isDragActive, isDragAccept, isDragReject }) => {
-            if (isDragReject) {
-              return `${isDragActive && 'Active but'} Reject`
-            }
-            if (isDragAccept) {
-              return `${isDragActive && 'Active and'} Accept`
-            }
-            return 'Empty'
-          }}
+          {({ getRootProps, getInputProps, isDragActive, isDragAccept, isDragReject }) => (
+            <div {...getRootProps()}>
+              <input {...getInputProps()} />
+              {isDragReject && `${isDragActive && 'Active but'} Reject`}
+              {isDragAccept && `${isDragActive && 'Active and'} Accept`}
+              {!isDragActive && 'Empty'}
+            </div>
+          )}
         </Dropzone>
       )
       expect(dropzone.text()).toEqual('Empty')
@@ -434,15 +526,16 @@ describe('Dropzone', () => {
       const ChildComponent = () => <p>Child component content</p>
       const dropzone = mount(
         <Dropzone>
-          {({ isDragAccept, isDragReject }) => {
-            if (isDragReject) {
-              return 'Rejected'
-            }
-            if (isDragAccept) {
-              return <DragActiveComponent isDragAccept={isDragAccept} isDragReject={isDragReject} />
-            }
-            return <ChildComponent isDragAccept={isDragAccept} isDragReject={isDragReject} />
-          }}
+          {({ getRootProps, getInputProps, isDragActive, isDragAccept, isDragReject }) => (
+            <div {...getRootProps()}>
+              <input {...getInputProps()} />
+              {isDragReject && 'Rejected'}
+              {isDragAccept &&
+                <DragActiveComponent isDragAccept={isDragAccept} isDragReject={isDragReject} />}
+              {!isDragActive &&
+                <ChildComponent isDragAccept={isDragAccept} isDragReject={isDragReject} />}
+            </div>
+          )}
         </Dropzone>
       )
       const child = dropzone.find(ChildComponent)
@@ -499,21 +592,45 @@ describe('Dropzone', () => {
     })
 
     it('should add valid files to rejected files on a multple drop when multiple false', () => {
-      const dropzone = mount(<Dropzone accept="image/*" onDrop={dropSpy} multiple={false} />)
+      const dropzone = mount(
+        <Dropzone accept="image/*" onDrop={dropSpy} multiple={false}>
+          {({ getRootProps, getInputProps }) => (
+            <div {...getRootProps()}>
+              <input {...getInputProps()} />
+            </div>
+          )}
+        </Dropzone>
+      )
       dropzone.simulate('drop', { dataTransfer: { files: images } })
       const rejected = dropSpy.firstCall.args[0]
       expect(rejected.length).toEqual(1)
     })
 
     it('should add invalid files to rejected when multiple is false', () => {
-      const dropzone = mount(<Dropzone accept="image/*" onDrop={dropSpy} multiple={false} />)
+      const dropzone = mount(
+        <Dropzone accept="image/*" onDrop={dropSpy} multiple={false}>
+          {({ getRootProps, getInputProps }) => (
+            <div {...getRootProps()}>
+              <input {...getInputProps()} />
+            </div>
+          )}
+        </Dropzone>
+      )
       dropzone.simulate('drop', { dataTransfer: { files: images.concat(files) } })
       const rejected = dropSpy.firstCall.args[1]
       expect(rejected.length).toEqual(2)
     })
 
     it('should allow single files to be dropped if multiple is false', () => {
-      const dropzone = mount(<Dropzone accept="image/*" onDrop={dropSpy} multiple={false} />)
+      const dropzone = mount(
+        <Dropzone accept="image/*" onDrop={dropSpy} multiple={false}>
+          {({ getRootProps, getInputProps }) => (
+            <div {...getRootProps()}>
+              <input {...getInputProps()} />
+            </div>
+          )}
+        </Dropzone>
+      )
 
       dropzone.simulate('drop', { dataTransfer: { files: [images[0]] } })
       const [accepted, rejected] = dropSpy.firstCall.args
@@ -522,7 +639,15 @@ describe('Dropzone', () => {
     })
 
     it('should take all dropped files if multiple is true', () => {
-      const dropzone = mount(<Dropzone onDrop={dropSpy} multiple />)
+      const dropzone = mount(
+        <Dropzone onDrop={dropSpy} multiple>
+          {({ getRootProps, getInputProps }) => (
+            <div {...getRootProps()}>
+              <input {...getInputProps()} />
+            </div>
+          )}
+        </Dropzone>
+      )
       dropzone.simulate('drop', { dataTransfer: { files: images } })
       expect(dropSpy.firstCall.args[0]).toHaveLength(2)
       expect(dropSpy.firstCall.args[0][0].name).toEqual(images[0].name)
@@ -530,7 +655,15 @@ describe('Dropzone', () => {
     })
 
     it('should set this.isFileDialogActive to false', () => {
-      const dropzone = mount(<Dropzone />)
+      const dropzone = mount(
+        <Dropzone>
+          {({ getRootProps, getInputProps }) => (
+            <div {...getRootProps()}>
+              <input {...getInputProps()} />
+            </div>
+          )}
+        </Dropzone>
+      )
       dropzone.instance().isFileDialogActive = true
       dropzone.simulate('drop', { dataTransfer: { files } })
       expect(dropzone.instance().isFileDialogActive).toEqual(false)
@@ -543,7 +676,13 @@ describe('Dropzone', () => {
           onDropAccepted={dropAcceptedSpy}
           onDropRejected={dropRejectedSpy}
           accept="image/*"
-        />
+        >
+          {({ getRootProps, getInputProps }) => (
+            <div {...getRootProps()}>
+              <input {...getInputProps()} />
+            </div>
+          )}
+        </Dropzone>
       )
       dropzone.simulate('drop', { dataTransfer: { files } })
       expect(dropSpy.callCount).toEqual(1)
@@ -563,7 +702,13 @@ describe('Dropzone', () => {
           onDropAccepted={dropAcceptedSpy}
           onDropRejected={dropRejectedSpy}
           accept="image/*"
-        />
+        >
+          {({ getRootProps, getInputProps }) => (
+            <div {...getRootProps()}>
+              <input {...getInputProps()} />
+            </div>
+          )}
+        </Dropzone>
       )
       dropzone.simulate('drop', { dataTransfer: { files } })
       expect(dropAcceptedSpy.callCount).toEqual(0)
@@ -582,7 +727,13 @@ describe('Dropzone', () => {
           onDropAccepted={dropAcceptedSpy}
           onDropRejected={dropRejectedSpy}
           accept="image/*"
-        />
+        >
+          {({ getRootProps, getInputProps }) => (
+            <div {...getRootProps()}>
+              <input {...getInputProps()} />
+            </div>
+          )}
+        </Dropzone>
       )
       dropzone.simulate('drop', { dataTransfer: { files } })
       expect(dropRejectedSpy.callCount).toEqual(1)
@@ -601,7 +752,13 @@ describe('Dropzone', () => {
           onDropAccepted={dropAcceptedSpy}
           onDropRejected={dropRejectedSpy}
           accept="image/*"
-        />
+        >
+          {({ getRootProps, getInputProps }) => (
+            <div {...getRootProps()}>
+              <input {...getInputProps()} />
+            </div>
+          )}
+        </Dropzone>
       )
       dropzone.simulate('drop', { dataTransfer: { files } })
       expect(dropSpy.callCount).toEqual(1)
@@ -619,7 +776,13 @@ describe('Dropzone', () => {
           onDropAccepted={dropAcceptedSpy}
           onDropRejected={dropRejectedSpy}
           accept="image/*"
-        />
+        >
+          {({ getRootProps, getInputProps }) => (
+            <div {...getRootProps()}>
+              <input {...getInputProps()} />
+            </div>
+          )}
+        </Dropzone>
       )
 
       dropzone.simulate('drop', { dataTransfer: { files: images } })
@@ -638,7 +801,13 @@ describe('Dropzone', () => {
           onDropAccepted={dropAcceptedSpy}
           onDropRejected={dropRejectedSpy}
           accept="image/*"
-        />
+        >
+          {({ getRootProps, getInputProps }) => (
+            <div {...getRootProps()}>
+              <input {...getInputProps()} />
+            </div>
+          )}
+        </Dropzone>
       )
       const bogusImages = [
         {
@@ -663,7 +832,13 @@ describe('Dropzone', () => {
           onDrop={dropSpy}
           onDropAccepted={dropAcceptedSpy}
           onDropRejected={dropRejectedSpy}
-        />
+        >
+          {({ getRootProps, getInputProps }) => (
+            <div {...getRootProps()}>
+              <input {...getInputProps()} />
+            </div>
+          )}
+        </Dropzone>
       )
       dropzone.simulate('drop', { dataTransfer: { files: files.concat(images) } })
       expect(dropSpy.callCount).toEqual(1)
@@ -681,7 +856,13 @@ describe('Dropzone', () => {
           onDropAccepted={dropAcceptedSpy}
           onDropRejected={dropRejectedSpy}
           maxSize={1111}
-        />
+        >
+          {({ getRootProps, getInputProps }) => (
+            <div {...getRootProps()}>
+              <input {...getInputProps()} />
+            </div>
+          )}
+        </Dropzone>
       )
 
       dropzone.simulate('drop', { dataTransfer: { files } })
@@ -700,7 +881,13 @@ describe('Dropzone', () => {
           onDropAccepted={dropAcceptedSpy}
           onDropRejected={dropRejectedSpy}
           maxSize={1111}
-        />
+        >
+          {({ getRootProps, getInputProps }) => (
+            <div {...getRootProps()}>
+              <input {...getInputProps()} />
+            </div>
+          )}
+        </Dropzone>
       )
       dropzone.simulate('drop', { dataTransfer: { files: images } })
       expect(dropSpy.callCount).toEqual(1)
@@ -718,7 +905,13 @@ describe('Dropzone', () => {
           onDropAccepted={dropAcceptedSpy}
           onDropRejected={dropRejectedSpy}
           minSize={1112}
-        />
+        >
+          {({ getRootProps, getInputProps }) => (
+            <div {...getRootProps()}>
+              <input {...getInputProps()} />
+            </div>
+          )}
+        </Dropzone>
       )
       dropzone.simulate('drop', { dataTransfer: { files } })
       expect(dropSpy.callCount).toEqual(1)
@@ -736,7 +929,13 @@ describe('Dropzone', () => {
           onDropAccepted={dropAcceptedSpy}
           onDropRejected={dropRejectedSpy}
           minSize={1112}
-        />
+        >
+          {({ getRootProps, getInputProps }) => (
+            <div {...getRootProps()}>
+              <input {...getInputProps()} />
+            </div>
+          )}
+        </Dropzone>
       )
       dropzone.simulate('drop', { dataTransfer: { files: images } })
       expect(dropSpy.callCount).toEqual(1)
@@ -753,7 +952,13 @@ describe('Dropzone', () => {
           onDrop={dropSpy}
           onDropAccepted={dropAcceptedSpy}
           onDropRejected={dropRejectedSpy}
-        />
+        >
+          {({ getRootProps, getInputProps }) => (
+            <div {...getRootProps()}>
+              <input {...getInputProps()} />
+            </div>
+          )}
+        </Dropzone>
       )
       dropzone.simulate('drop', { dataTransfer: { files: files.concat(images) } })
       expect(dropSpy.callCount).toEqual(1)
@@ -768,7 +973,15 @@ describe('Dropzone', () => {
   describe('preview', () => {
     it('should generate previews for non-images', () => {
       const dropSpy = spy()
-      const dropzone = mount(<Dropzone onDrop={dropSpy} />)
+      const dropzone = mount(
+        <Dropzone onDrop={dropSpy}>
+          {({ getRootProps, getInputProps }) => (
+            <div {...getRootProps()}>
+              <input {...getInputProps()} />
+            </div>
+          )}
+        </Dropzone>
+      )
       dropzone.simulate('drop', { dataTransfer: { files } })
       expect(Object.keys(dropSpy.firstCall.args[0][0])).toContain('preview')
       expect(dropSpy.firstCall.args[0][0].preview).toContain('data://file1.pdf')
@@ -776,7 +989,15 @@ describe('Dropzone', () => {
 
     it('should generate previews for images', () => {
       const dropSpy = spy()
-      const dropzone = mount(<Dropzone onDrop={dropSpy} />)
+      const dropzone = mount(
+        <Dropzone onDrop={dropSpy}>
+          {({ getRootProps, getInputProps }) => (
+            <div {...getRootProps()}>
+              <input {...getInputProps()} />
+            </div>
+          )}
+        </Dropzone>
+      )
       dropzone.simulate('drop', { dataTransfer: { files: images } })
       expect(Object.keys(dropSpy.firstCall.args[0][0])).toContain('preview')
       expect(dropSpy.firstCall.args[0][0].preview).toContain('data://cats.gif')
@@ -784,7 +1005,15 @@ describe('Dropzone', () => {
 
     it('should not throw error when preview cannot be created', () => {
       const dropSpy = spy()
-      const dropzone = mount(<Dropzone onDrop={dropSpy} />)
+      const dropzone = mount(
+        <Dropzone onDrop={dropSpy}>
+          {({ getRootProps, getInputProps }) => (
+            <div {...getRootProps()}>
+              <input {...getInputProps()} />
+            </div>
+          )}
+        </Dropzone>
+      )
 
       dropzone.simulate('drop', { dataTransfer: { files: ['bad_val'] } })
 
@@ -793,7 +1022,15 @@ describe('Dropzone', () => {
 
     it('should not generate previews if disablePreview is true', () => {
       const dropSpy = spy()
-      const dropzone = mount(<Dropzone disablePreview onDrop={dropSpy} />)
+      const dropzone = mount(
+        <Dropzone disablePreview onDrop={dropSpy}>
+          {({ getRootProps, getInputProps }) => (
+            <div {...getRootProps()}>
+              <input {...getInputProps()} />
+            </div>
+          )}
+        </Dropzone>
+      )
       dropzone.simulate('drop', { dataTransfer: { files: images } })
       dropzone.simulate('drop', { dataTransfer: { files } })
       expect(dropSpy.callCount).toEqual(2)
@@ -807,7 +1044,15 @@ describe('Dropzone', () => {
   describe('onCancel', () => {
     it('should not invoke onFileDialogCancel everytime window receives focus', done => {
       const onCancelSpy = spy()
-      mount(<Dropzone id="on-cancel-example" onFileDialogCancel={onCancelSpy} />)
+      mount(
+        <Dropzone onFileDialogCancel={onCancelSpy}>
+          {({ getRootProps, getInputProps }) => (
+            <div id="on-cancel-example" {...getRootProps()}>
+              <input {...getInputProps()} />
+            </div>
+          )}
+        </Dropzone>
+      )
       // Simulated DOM event - onfocus
       document.body.addEventListener('focus', () => {})
       const evt = document.createEvent('HTMLEvents')
@@ -823,7 +1068,13 @@ describe('Dropzone', () => {
     it('should invoke onFileDialogCancel when window receives focus via cancel button', done => {
       const onCancelSpy = spy()
       const component = mount(
-        <Dropzone className="dropzone-content" onFileDialogCancel={onCancelSpy} />
+        <Dropzone onFileDialogCancel={onCancelSpy}>
+          {({ getRootProps, getInputProps }) => (
+            <div className="dropzone-content" {...getRootProps()}>
+              <input {...getInputProps()} />
+            </div>
+          )}
+        </Dropzone>
       )
 
       // Test / invoke the click event
@@ -867,11 +1118,14 @@ describe('Dropzone', () => {
         onDropRejected={innerDropRejectedSpy}
         accept="image/*"
       >
-        {({ isDragActive, isDragReject }) => {
-          if (isDragReject) return <InnerDragRejected />
-          if (isDragActive) return <InnerDragAccepted />
-          return <p>No drag</p>
-        }}
+        {({ getRootProps, getInputProps, isDragAccept, isDragReject, isDragActive }) => (
+          <div {...getRootProps()}>
+            <input {...getInputProps()} />
+            {isDragReject && <InnerDragRejected />}
+            {isDragAccept && <InnerDragAccepted />}
+            {!isDragActive && <p>No drag</p>}
+          </div>
+        )}
       </Dropzone>
     )
 
@@ -890,7 +1144,12 @@ describe('Dropzone', () => {
             onDropRejected={outerDropRejectedSpy}
             accept="image/*"
           >
-            {props => <InnerDropzone {...props} />}
+            {({ getRootProps, getInputProps }) => (
+              <div {...getRootProps()}>
+                <input {...getInputProps()} />
+                <InnerDropzone />
+              </div>
+            )}
           </Dropzone>
         )
         innerDropzone = outerDropzone.find(InnerDropzone)
@@ -936,7 +1195,15 @@ describe('Dropzone', () => {
 
   describe('behavior', () => {
     it('does not throw an error when html is dropped instead of files and multiple is false', () => {
-      const dropzone = mount(<Dropzone multiple={false} />)
+      const dropzone = mount(
+        <Dropzone multiple={false}>
+          {({ getRootProps, getInputProps }) => (
+            <div {...getRootProps()}>
+              <input {...getInputProps()} />
+            </div>
+          )}
+        </Dropzone>
+      )
 
       const fn = () => dropzone.simulate('drop', { dataTransfer: { files: [] } })
       expect(fn).not.toThrow()

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,0 +1,18 @@
+/* eslint-disable */
+/**
+ * This is intended to be used to compose event handlers
+ * They are executed in order until one of them calls
+ * `event.preventDefault()`. Not sure this is the best
+ * way to do this, but it seems legit...
+ * @param {Function} fns the event hanlder functions
+ * @return {Function} the event handler to add to an element
+ */
+export function composeEventHandlers(...fns) {
+  return (event, ...args) =>
+    fns.some(fn => {
+      if (fn) {
+        fn(event, ...args)
+      }
+      return event.defaultPrevented
+    })
+}

--- a/src/utils.js
+++ b/src/utils.js
@@ -10,9 +10,7 @@
 export function composeEventHandlers(...fns) {
   return (event, ...args) =>
     fns.some(fn => {
-      if (fn) {
-        fn(event, ...args)
-      }
-      return event.defaultPrevented
+      fn && fn(event, ...args)
+      return event.preventDropzoneDefault
     })
 }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

- [ ] bugfix
- [x] feature
- [x] refactoring / style
- [x] build / chore
- [x] documentation

**Did you add tests for your changes?**

- [x] Yes, my code is well tested
- [ ] Not relevant

**If relevant, did you update the documentation?**

- [x] Yes, I've updated the documentation
- [ ] Not relevant

**Summary**
Picking up removal of style management done by @okonet's. Refactored Dropzone to use render props, giving flexibility to users to implement their own styles in userland.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**
Yes it does. It changes the render signature of Dropzone.
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**
Merging this to https://github.com/react-dropzone/react-dropzone/pull/468 for further review.