### PR TITLE
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -47,7 +47,9 @@ class Dropzone extends React.Component {
       document.addEventListener('dragover', onDocumentDragOver, false)
       document.addEventListener('drop', this.onDocumentDrop, false)
     }
-    this.fileInputEl.addEventListener('click', this.onInputElementClick, false)
+    if (this.fileInputEl != null) {
+      this.fileInputEl.addEventListener('click', this.onInputElementClick, false)
+    }
     window.addEventListener('focus', this.onFileDialogCancel, false)
   }
 


### PR DESCRIPTION
**What kind of change does this PR introduce?**

- [x] bugfix
- [ ] feature
- [ ] refactoring / style
- [ ] build / chore
- [ ] documentation

**Did you add tests for your changes?**

- [ ] Yes, my code is well tested
- [x] Not relevant

**If relevant, did you update the documentation?**

- [ ] Yes, I've updated the documentation
- [x] Not relevant

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

This change fixes potential issues with SSR, similarly to #537

For example, here's an error I got without this change, in a project
based on https://github.com/kriasoft/react-starter-kit:

    Error: Uncaught [TypeError: Cannot read property 'addEventListener' of null]
        at reportException (/home/josephfrazier/workspace/reported-web/node_modules/jsdom/lib/jsdom/living/helpers/runtime-script-errors.js:66:24)
        at invokeEventListeners (/home/josephfrazier/workspace/reported-web/node_modules/jsdom/lib/jsdom/living/events/EventTarget-impl.js:209:9)
        at HTMLUnknownElementImpl._dispatch (/home/josephfrazier/workspace/reported-web/node_modules/jsdom/lib/jsdom/living/events/EventTarget-impl.js:119:9)
        at HTMLUnknownElementImpl.dispatchEvent (/home/josephfrazier/workspace/reported-web/node_modules/jsdom/lib/jsdom/living/events/EventTarget-impl.js:82:17)
        at HTMLUnknownElementImpl.dispatchEvent (/home/josephfrazier/workspace/reported-web/node_modules/jsdom/lib/jsdom/living/nodes/HTMLElement-impl.js:30:27)
        at HTMLUnknownElement.dispatchEvent (/home/josephfrazier/workspace/reported-web/node_modules/jsdom/lib/jsdom/living/generated/EventTarget.js:157:21)
        at Object.invokeGuardedCallbackDev (/home/josephfrazier/workspace/reported-web/node_modules/react-test-renderer/cjs/react-test-renderer.development.js:1937:16)
        at invokeGuardedCallback (/home/josephfrazier/workspace/reported-web/node_modules/react-test-renderer/cjs/react-test-renderer.development.js:1986:29)
        at commitRoot (/home/josephfrazier/workspace/reported-web/node_modules/react-test-renderer/cjs/react-test-renderer.development.js:7681:7)
        at completeRoot (/home/josephfrazier/workspace/reported-web/node_modules/react-test-renderer/cjs/react-test-renderer.development.js:8650:34) TypeError: Cannot read property 'addEventListener' of null
        at t.value (/home/josephfrazier/workspace/reported-web/node_modules/react-dropzone/dist/webpack:/src/index.js:50:48)

**Does this PR introduce a breaking change?**
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

No

**Other information**