### PR TITLE
Refactor: Replace sinon with jest mock functions

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,8 @@
     ]
   },
   "jest": {
-    "setupTestFrameworkScriptFile": "<rootDir>/testSetup.js"
+    "setupTestFrameworkScriptFile": "<rootDir>/testSetup.js",
+    "clearMocks": true
   },
   "keywords": [
     "react-component",

--- a/package.json
+++ b/package.json
@@ -122,7 +122,6 @@
     "rollup-plugin-commonjs": "^9.1.3",
     "rollup-plugin-node-resolve": "^3.3.0",
     "rollup-plugin-uglify": "^3.0.0",
-    "sinon": "^3.2.1",
     "size-limit": "^0.19.2",
     "webpack-blocks": "^1.0.0"
   },

--- a/src/index.spec.js
+++ b/src/index.spec.js
@@ -1047,20 +1047,22 @@ describe('Dropzone', () => {
   })
 
   describe('nested Dropzone component behavior', () => {
-    let outerDropSpy
-    let outerDropAcceptedSpy
-    let outerDropRejectedSpy
-    let innerDropSpy
-    let innerDropAcceptedSpy
-    let innerDropRejectedSpy
+    const expectedEvent = expect.anything()
+    const onOuterDrop = jest.fn()
+    const onOuterDropAccepted = jest.fn()
+    const onOuterDropRejected = jest.fn()
+
+    const onInnerDrop = jest.fn()
+    const onInnerDropAccepted = jest.fn()
+    const onInnerDropRejected = jest.fn()
 
     const InnerDragAccepted = () => <p>Accepted</p>
     const InnerDragRejected = () => <p>Rejected</p>
     const InnerDropzone = () => (
       <Dropzone
-        onDrop={innerDropSpy}
-        onDropAccepted={innerDropAcceptedSpy}
-        onDropRejected={innerDropRejectedSpy}
+        onDrop={onInnerDrop}
+        onDropAccepted={onInnerDropAccepted}
+        onDropRejected={onInnerDropRejected}
         accept="image/*"
       >
         {({ isDragActive, isDragReject }) => {
@@ -1089,17 +1091,11 @@ describe('Dropzone', () => {
       })
 
       it('accepts the drop on the inner dropzone', async () => {
-        outerDropSpy = spy()
-        outerDropAcceptedSpy = spy()
-        outerDropRejectedSpy = spy()
-        innerDropSpy = spy()
-        innerDropAcceptedSpy = spy()
-        innerDropRejectedSpy = spy()
         const outerDropzone = mount(
           <Dropzone
-            onDrop={outerDropSpy}
-            onDropAccepted={outerDropAcceptedSpy}
-            onDropRejected={outerDropRejectedSpy}
+            onDrop={onOuterDrop}
+            onDropAccepted={onOuterDropAccepted}
+            onDropRejected={onOuterDropRejected}
             accept="image/*"
           >
             {props => <InnerDropzone {...props} />}
@@ -1112,49 +1108,42 @@ describe('Dropzone', () => {
         const updatedOuterDropzone = await flushPromises(outerDropzone)
         const innerDropzone = updatedOuterDropzone.find(InnerDropzone)
 
-        expect(innerDropSpy.callCount).toEqual(1)
-        expect(innerDropSpy.firstCall.args[0]).toHaveLength(2)
-        expect(innerDropSpy.firstCall.args[1]).toHaveLength(1)
-        expect(innerDropAcceptedSpy.callCount).toEqual(1)
-        expect(innerDropAcceptedSpy.firstCall.args[0]).toHaveLength(2)
-        expect(innerDropRejectedSpy.callCount).toEqual(1)
-        expect(innerDropRejectedSpy.firstCall.args[0]).toHaveLength(1)
-        expect(innerDropzone.find(InnerDragAccepted).exists()).toEqual(false)
-        expect(innerDropzone.find(InnerDragRejected).exists()).toEqual(false)
+        expect(onInnerDrop).toHaveBeenCalledTimes(1)
+        expect(onInnerDrop).toHaveBeenCalledWith(images, files, expectedEvent)
+        expect(onInnerDropAccepted).toHaveBeenCalledTimes(1)
+        expect(onInnerDropAccepted).toHaveBeenCalledWith(images, expectedEvent)
+        expect(onInnerDropRejected).toHaveBeenCalledTimes(1)
+        expect(onInnerDropRejected).toHaveBeenCalledWith(files, expectedEvent)
+
+        expect(innerDropzone.find(InnerDragAccepted)).not.toExist()
+        expect(innerDropzone.find(InnerDragRejected)).not.toExist()
       })
 
       it('also accepts the drop on the outer dropzone', async () => {
-        outerDropSpy = spy()
-        outerDropAcceptedSpy = spy()
-        outerDropRejectedSpy = spy()
-        innerDropSpy = spy()
-        innerDropAcceptedSpy = spy()
-        innerDropRejectedSpy = spy()
         const outerDropzone = mount(
           <Dropzone
-            onDrop={outerDropSpy}
-            onDropAccepted={outerDropAcceptedSpy}
-            onDropRejected={outerDropRejectedSpy}
+            onDrop={onOuterDrop}
+            onDropAccepted={onOuterDropAccepted}
+            onDropRejected={onOuterDropRejected}
             accept="image/*"
           >
             {props => <InnerDropzone {...props} />}
           </Dropzone>
         )
 
-        outerDropzone.find(InnerDropzone).simulate('drop', {
+        outerDropzone.simulate('drop', {
           dataTransfer: { files: files.concat(images) }
         })
         const updatedOuterDropzone = await flushPromises(outerDropzone)
 
         const innerDropzone = updatedOuterDropzone.find(InnerDropzone)
 
-        expect(outerDropSpy.callCount).toEqual(1)
-        expect(outerDropSpy.firstCall.args[0]).toHaveLength(2)
-        expect(outerDropSpy.firstCall.args[1]).toHaveLength(1)
-        expect(outerDropAcceptedSpy.callCount).toEqual(1)
-        expect(outerDropAcceptedSpy.firstCall.args[0]).toHaveLength(2)
-        expect(outerDropRejectedSpy.callCount).toEqual(1)
-        expect(outerDropRejectedSpy.firstCall.args[0]).toHaveLength(1)
+        expect(onOuterDrop).toHaveBeenCalledTimes(1)
+        expect(onOuterDrop).toHaveBeenCalledWith(images, files, expectedEvent)
+        expect(onOuterDropAccepted).toHaveBeenCalledTimes(1)
+        expect(onOuterDropAccepted).toHaveBeenCalledWith(images, expectedEvent)
+        expect(onOuterDropRejected).toHaveBeenCalledTimes(1)
+        expect(onOuterDropRejected).toHaveBeenCalledWith(files, expectedEvent)
         expect(innerDropzone).toHaveProp('isDragActive', false)
         expect(innerDropzone).toHaveProp('isDragReject', false)
       })

--- a/src/index.spec.js
+++ b/src/index.spec.js
@@ -852,39 +852,63 @@ describe('Dropzone', () => {
   })
 
   describe('preview', () => {
+    const expectedEvent = expect.anything()
+
     it('should generate previews for non-images', async () => {
-      const dropSpy = spy()
-      const dropzone = mount(<Dropzone onDrop={dropSpy} />)
+      const onDrop = jest.fn()
+      const dropzone = mount(<Dropzone onDrop={onDrop} />)
       await dropzone.simulate('drop', { dataTransfer: { files } })
-      expect(Object.keys(dropSpy.firstCall.args[0][0])).toContain('preview')
-      expect(dropSpy.firstCall.args[0][0].preview).toContain('data://file1.pdf')
+      expect(onDrop).toHaveBeenCalledWith(
+        expect.arrayContaining([expect.objectContaining({ preview: 'data://file1.pdf' })]),
+        [],
+        expectedEvent
+      )
     })
 
     it('should generate previews for images', async () => {
-      const dropSpy = spy()
-      const dropzone = mount(<Dropzone onDrop={dropSpy} />)
+      const onDrop = jest.fn()
+      const dropzone = mount(<Dropzone onDrop={onDrop} />)
       await dropzone.simulate('drop', { dataTransfer: { files: images } })
-      expect(Object.keys(dropSpy.firstCall.args[0][0])).toContain('preview')
-      expect(dropSpy.firstCall.args[0][0].preview).toContain('data://cats.gif')
+      expect(onDrop).toHaveBeenCalledWith(
+        expect.arrayContaining([expect.objectContaining({ preview: 'data://cats.gif' })]),
+        [],
+        expectedEvent
+      )
     })
 
     it('should not throw error when preview cannot be created', async () => {
-      const dropSpy = spy()
-      const dropzone = mount(<Dropzone onDrop={dropSpy} />)
+      const onDrop = jest.fn()
+      const onConsoleError = jest.fn()
+      jest.spyOn(console, 'error').mockImplementationOnce(onConsoleError)
 
+      const dropzone = mount(<Dropzone onDrop={onDrop} />)
       await dropzone.simulate('drop', { dataTransfer: { files: ['bad_val'] } })
 
-      expect(Object.keys(dropSpy.firstCall.args[1][0])).not.toContain('preview')
+      expect(onConsoleError).toHaveBeenCalled()
+      expect(onDrop).not.toHaveBeenCalledWith(
+        expect.arrayContaining([expect.objectContaining({ preview: expect.anything() })]),
+        [],
+        expectedEvent
+      )
     })
 
     it('should not generate previews if disablePreview is true', async () => {
-      const dropSpy = spy()
-      const dropzone = mount(<Dropzone disablePreview onDrop={dropSpy} />)
+      const onDrop = jest.fn()
+      const dropzone = mount(<Dropzone disablePreview onDrop={onDrop} />)
       await dropzone.simulate('drop', { dataTransfer: { files: images } })
+      expect(onDrop).not.toHaveBeenCalledWith(
+        expect.arrayContaining([expect.objectContaining({ preview: expect.anything() })]),
+        [],
+        expectedEvent
+      )
+      onDrop.mockClear()
+
       await dropzone.simulate('drop', { dataTransfer: { files } })
-      expect(dropSpy.callCount).toEqual(2)
-      expect(Object.keys(dropSpy.firstCall.args[0][0])).not.toContain('preview')
-      expect(Object.keys(dropSpy.lastCall.args[0][0])).not.toContain('preview')
+      expect(onDrop).not.toHaveBeenCalledWith(
+        expect.arrayContaining([expect.objectContaining({ preview: expect.anything() })]),
+        [],
+        expectedEvent
+      )
     })
   })
 

--- a/src/index.spec.js
+++ b/src/index.spec.js
@@ -3,7 +3,6 @@
 
 import React from 'react'
 import { mount, render } from 'enzyme'
-import { spy } from 'sinon'
 import { onDocumentDragOver } from './utils'
 
 const flushPromises = wrapper =>
@@ -1085,28 +1084,22 @@ describe('Dropzone', () => {
       expect(fn).not.toThrow()
     })
 
-    it('does not allow actions when disabled props is true', done => {
+    it('does not allow actions when disabled props is true', () => {
       const dropzone = mount(<Dropzone disabled />)
 
-      spy(dropzone.instance(), 'open')
+      const open = jest.spyOn(dropzone.instance(), 'open')
       dropzone.simulate('click')
-      setTimeout(() => {
-        expect(dropzone.instance().open.callCount).toEqual(0)
-        done()
-      }, 0)
+      expect(open).not.toHaveBeenCalled()
     })
 
-    it('when toggle disabled props, Dropzone works as expected', done => {
+    it('when toggle disabled props, Dropzone works as expected', () => {
       const dropzone = mount(<Dropzone disabled />)
-      spy(dropzone.instance(), 'open')
+      const open = jest.spyOn(dropzone.instance(), 'open')
 
       dropzone.setProps({ disabled: false })
 
       dropzone.simulate('click')
-      setTimeout(() => {
-        expect(dropzone.instance().open.callCount).toEqual(1)
-        done()
-      }, 0)
+      expect(open).toHaveBeenCalled()
     })
   })
 })

--- a/src/index.spec.js
+++ b/src/index.spec.js
@@ -203,33 +203,27 @@ describe('Dropzone', () => {
   })
 
   describe('onClick', () => {
-    it('should call `open` method', done => {
+    it('should call `open` method', () => {
       const dropzone = mount(<Dropzone />)
-      spy(dropzone.instance(), 'open')
+      const open = jest.spyOn(dropzone.instance(), 'open')
       dropzone.simulate('click')
-      setTimeout(() => {
-        expect(dropzone.instance().open.callCount).toEqual(1)
-        done()
-      }, 0)
+      expect(open).toHaveBeenCalled()
     })
 
     it('should not call `open` if disableClick prop is true', () => {
       const dropzone = mount(<Dropzone disableClick />)
-      spy(dropzone.instance(), 'open')
+      const open = jest.spyOn(dropzone.instance(), 'open')
       dropzone.simulate('click')
-      expect(dropzone.instance().open.callCount).toEqual(0)
+      expect(open).not.toHaveBeenCalled()
     })
 
-    it('should call `onClick` callback if provided', done => {
-      const clickSpy = spy()
-      const dropzone = mount(<Dropzone onClick={clickSpy} />)
-      spy(dropzone.instance(), 'open')
+    it('should call `onClick` callback if provided', () => {
+      const onClick = jest.fn()
+      const dropzone = mount(<Dropzone onClick={onClick} />)
+      const open = jest.spyOn(dropzone.instance(), 'open')
       dropzone.simulate('click')
-      setTimeout(() => {
-        expect(dropzone.instance().open.callCount).toEqual(1)
-        expect(clickSpy.callCount).toEqual(1)
-        done()
-      }, 0)
+      expect(open).toHaveBeenCalled()
+      expect(onClick).toHaveBeenCalled()
     })
 
     it('should reset the value of input', () => {
@@ -255,59 +249,53 @@ describe('Dropzone', () => {
       ).toBeUndefined()
     })
 
-    it('should trigger click even on the input', done => {
+    it('should trigger click even on the input', () => {
       const dropzone = mount(<Dropzone />)
-      const clickSpy = spy(dropzone.instance().fileInputEl, 'click')
+      const onFileInputClick = jest.spyOn(dropzone.instance().fileInputEl, 'click')
       dropzone.simulate('click')
       dropzone.simulate('click')
-      setTimeout(() => {
-        expect(clickSpy.callCount).toEqual(2)
-        done()
-      }, 0)
+      expect(onFileInputClick).toHaveBeenCalledTimes(2)
     })
 
     it('should not invoke onClick on the wrapper', () => {
-      const onClickOuterSpy = spy()
-      const onClickInnerSpy = spy()
+      const onClickOuter = jest.fn()
+      const onClickInner = jest.fn()
       const component = mount(
-        <div onClick={onClickOuterSpy}>
-          <Dropzone onClick={onClickInnerSpy} />
+        <div onClick={onClickOuter}>
+          <Dropzone onClick={onClickInner} />
         </div>
       )
 
       component.simulate('click')
-      expect(onClickOuterSpy.callCount).toEqual(1)
-      expect(onClickInnerSpy.callCount).toEqual(0)
+      expect(onClickOuter).toHaveBeenCalled()
+      expect(onClickInner).not.toHaveBeenCalled()
 
-      onClickOuterSpy.reset()
-      onClickInnerSpy.reset()
+      onClickOuter.mockClear()
+      onClickInner.mockClear()
 
       component.find(Dropzone).simulate('click')
-      expect(onClickOuterSpy.callCount).toEqual(0)
-      expect(onClickInnerSpy.callCount).toEqual(1)
+      expect(onClickOuter).not.toHaveBeenCalled()
+      expect(onClickInner).toHaveBeenCalled()
     })
 
     it('should invoke onClick on the wrapper if disableClick is set', () => {
-      const onClickOuterSpy = spy()
+      const onClick = jest.fn()
       const component = mount(
-        <div onClick={onClickOuterSpy}>
+        <div onClick={onClick}>
           <Dropzone disableClick />
         </div>
       )
 
       component.find(Dropzone).simulate('click')
-      expect(onClickOuterSpy.callCount).toEqual(1)
+      expect(onClick).toHaveBeenCalled()
     })
 
-    it('should invoke inputProps onClick if provided', done => {
-      const inputPropsClickSpy = spy()
-      const component = mount(<Dropzone inputProps={{ onClick: inputPropsClickSpy }} />)
+    it('should invoke inputProps onClick if provided', () => {
+      const onClick = jest.fn()
+      const component = mount(<Dropzone inputProps={{ onClick }} />)
 
       component.simulate('click')
-      setTimeout(() => {
-        expect(inputPropsClickSpy.callCount).toEqual(1)
-        done()
-      }, 0)
+      expect(onClick).toHaveBeenCalled()
     })
   })
 

--- a/src/index.spec.js
+++ b/src/index.spec.js
@@ -915,66 +915,61 @@ describe('Dropzone', () => {
   describe('onClick', () => {})
 
   describe('onCancel', () => {
-    it('should not invoke onFileDialogCancel everytime window receives focus', done => {
-      const onCancelSpy = spy()
-      mount(<Dropzone id="on-cancel-example" onFileDialogCancel={onCancelSpy} />)
+    beforeEach(() => {
+      jest.useFakeTimers(true)
+    })
+
+    afterEach(() => {
+      jest.useFakeTimers(false)
+    })
+
+    it('should not invoke onFileDialogCancel everytime window receives focus', () => {
+      const onFileDialogCancel = jest.fn()
+      mount(<Dropzone id="on-cancel-example" onFileDialogCancel={onFileDialogCancel} />)
       // Simulated DOM event - onfocus
       document.body.addEventListener('focus', () => {})
       const evt = document.createEvent('HTMLEvents')
       evt.initEvent('focus', false, true)
       document.body.dispatchEvent(evt)
-      // setTimeout to match the event callback from actual Component
-      setTimeout(() => {
-        expect(onCancelSpy.callCount).toEqual(0)
-        done()
-      }, 300)
+      jest.runAllTimers()
+      expect(onFileDialogCancel).not.toHaveBeenCalled()
     })
 
-    it('should invoke onFileDialogCancel when window receives focus via cancel button', done => {
-      const onCancelSpy = spy()
+    it('should invoke onFileDialogCancel when window receives focus via cancel button', () => {
+      const onFileDialogCancel = jest.fn()
       const component = mount(
-        <Dropzone className="dropzone-content" onFileDialogCancel={onCancelSpy} />
+        <Dropzone className="dropzone-content" onFileDialogCancel={onFileDialogCancel} />
       )
 
       // Test / invoke the click event
-      spy(component.instance(), 'open')
+      const open = jest.spyOn(component.instance(), 'open')
       component.simulate('click')
 
-      setTimeout(() => {
-        expect(component.instance().open.callCount).toEqual(1)
+      expect(open).toHaveBeenCalled()
 
-        // Simulated DOM event - onfocus
-        window.addEventListener('focus', () => {})
-        const evt = document.createEvent('HTMLEvents')
-        evt.initEvent('focus', false, true)
-        window.dispatchEvent(evt)
+      // Simulated DOM event - onfocus
+      window.addEventListener('focus', () => {})
+      const evt = document.createEvent('HTMLEvents')
+      evt.initEvent('focus', false, true)
+      window.dispatchEvent(evt)
 
-        // setTimeout to match the event callback from actual Component
-        setTimeout(() => {
-          expect(onCancelSpy.callCount).toEqual(1)
-          done()
-        }, 300)
-      }, 0)
+      jest.runAllTimers()
+      expect(onFileDialogCancel).toHaveBeenCalled()
     })
 
-    it('should restore isFileDialogActive to false after the FileDialog was closed', done => {
+    it('should restore isFileDialogActive to false after the FileDialog was closed', () => {
       const component = mount(<Dropzone />)
 
-      spy(component.instance(), 'open')
       component.simulate('click')
 
-      setTimeout(() => {
-        expect(component.instance().isFileDialogActive).toEqual(true)
+      expect(component.instance().isFileDialogActive).toEqual(true)
 
-        const evt = document.createEvent('HTMLEvents')
-        evt.initEvent('focus', false, true)
-        window.dispatchEvent(evt)
+      const evt = document.createEvent('HTMLEvents')
+      evt.initEvent('focus', false, true)
+      window.dispatchEvent(evt)
 
-        setTimeout(() => {
-          expect(component.instance().isFileDialogActive).toEqual(false)
-          done()
-        }, 300)
-      }, 0)
+      jest.runAllTimers()
+      expect(component.instance().isFileDialogActive).toEqual(false)
     })
   })
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3345,7 +3345,7 @@ detect-port-alt@1.1.6:
     address "^1.0.1"
     debug "^2.6.0"
 
-diff@^3.1.0, diff@^3.2.0:
+diff@^3.2.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/diff/-/diff-3.3.0.tgz#056695150d7aa93237ca7e378ac3b1682b7963b9"
 
@@ -4553,12 +4553,6 @@ form-data@~2.3.1, form-data@~2.3.2:
     asynckit "^0.4.0"
     combined-stream "1.0.6"
     mime-types "^2.1.12"
-
-formatio@1.2.0, formatio@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/formatio/-/formatio-1.2.0.tgz#f3b2167d9068c4698a8d51f4f760a39a54d818eb"
-  dependencies:
-    samsam "1.x"
 
 forwarded@~0.1.2:
   version "0.1.2"
@@ -6657,10 +6651,6 @@ jsx-ast-utils@^2.0.1:
   dependencies:
     array-includes "^3.0.3"
 
-just-extend@^1.1.22:
-  version "1.1.22"
-  resolved "https://registry.yarnpkg.com/just-extend/-/just-extend-1.1.22.tgz#3330af756cab6a542700c64b2e4e4aa062d52fff"
-
 killable@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/killable/-/killable-1.0.0.tgz#da8b84bd47de5395878f95d64d02f2449fe05e6b"
@@ -7120,14 +7110,6 @@ logalot@^2.0.0:
 loglevel@^1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/loglevel/-/loglevel-1.4.1.tgz#95b383f91a3c2756fd4ab093667e4309161f2bcd"
-
-lolex@^1.6.0:
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/lolex/-/lolex-1.6.0.tgz#3a9a0283452a47d7439e72731b9e07d7386e49f6"
-
-lolex@^2.1.2:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/lolex/-/lolex-2.1.2.tgz#2694b953c9ea4d013e5b8bfba891c991025b2629"
 
 long@4.0.0:
   version "4.0.0"
@@ -7634,10 +7616,6 @@ nanomatch@^1.2.9:
     snapdragon "^0.8.1"
     to-regex "^3.0.1"
 
-native-promise-only@^0.8.1:
-  version "0.8.1"
-  resolved "https://registry.yarnpkg.com/native-promise-only/-/native-promise-only-0.8.1.tgz#20a318c30cb45f71fe7adfbf7b21c99c1472ef11"
-
 natural-compare@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
@@ -7675,15 +7653,6 @@ next-tick@1:
 nice-try@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.4.tgz#d93962f6c52f2c1558c0fbda6d512819f1efe1c4"
-
-nise@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/nise/-/nise-1.0.1.tgz#0da92b10a854e97c0f496f6c2845a301280b3eef"
-  dependencies:
-    formatio "^1.2.0"
-    just-extend "^1.1.22"
-    lolex "^1.6.0"
-    path-to-regexp "^1.7.0"
 
 node-dir@^0.1.10:
   version "0.1.17"
@@ -8397,12 +8366,6 @@ path-parse@^1.0.5:
 path-to-regexp@0.1.7:
   version "0.1.7"
   resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-0.1.7.tgz#df604178005f522f15eb4490e7247a1bfaa67f8c"
-
-path-to-regexp@^1.7.0:
-  version "1.7.0"
-  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-1.7.0.tgz#59fde0f435badacba103a84e9d3bc64e96b9937d"
-  dependencies:
-    isarray "0.0.1"
 
 path-type@^1.0.0:
   version "1.1.0"
@@ -9906,10 +9869,6 @@ safe-regex@^1.1.0:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
 
-samsam@1.x, samsam@^1.1.3:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/samsam/-/samsam-1.2.1.tgz#edd39093a3184370cb859243b2bdf255e7d8ea67"
-
 sane@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/sane/-/sane-2.0.0.tgz#99cb79f21f4a53a69d4d0cd957c2db04024b8eb2"
@@ -10146,20 +10105,6 @@ shellwords@^0.1.1:
 signal-exit@^3.0.0, signal-exit@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.2.tgz#b5fdc08f1287ea1178628e415e25132b73646c6d"
-
-sinon@^3.2.1:
-  version "3.2.1"
-  resolved "https://registry.yarnpkg.com/sinon/-/sinon-3.2.1.tgz#d8adabd900730fd497788a027049c64b08be91c2"
-  dependencies:
-    diff "^3.1.0"
-    formatio "1.2.0"
-    lolex "^2.1.2"
-    native-promise-only "^0.8.1"
-    nise "^1.0.1"
-    path-to-regexp "^1.7.0"
-    samsam "^1.1.3"
-    text-encoding "0.6.4"
-    type-detect "^4.0.0"
 
 sisteransi@^0.1.1:
   version "0.1.1"
@@ -10757,10 +10702,6 @@ test-exclude@^4.2.1:
     read-pkg-up "^1.0.1"
     require-main-filename "^1.0.1"
 
-text-encoding@0.6.4:
-  version "0.6.4"
-  resolved "https://registry.yarnpkg.com/text-encoding/-/text-encoding-0.6.4.tgz#e399a982257a276dae428bb92845cb71bdc26d19"
-
 text-extensions@^1.0.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/text-extensions/-/text-extensions-1.5.0.tgz#d1cb2d14b5d0bc45bfdca8a08a473f68c7eb0cbc"
@@ -10992,10 +10933,6 @@ type-check@~0.3.2:
   resolved "https://registry.yarnpkg.com/type-check/-/type-check-0.3.2.tgz#5884cab512cf1d355e3fb784f30804b2b520db72"
   dependencies:
     prelude-ls "~1.1.2"
-
-type-detect@^4.0.0:
-  version "4.0.3"
-  resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-4.0.3.tgz#0e3f2670b44099b0b46c284d136a7ef49c74c2ea"
 
 type-detect@^4.0.8:
   version "4.0.8"


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

- [ ] bugfix
- [ ] feature
- [x] refactoring / style
- [ ] build / chore
- [ ] documentation

**Did you add tests for your changes?**

- [x] Yes, my code is well tested
- [ ] Not relevant

**If relevant, did you update the documentation?**

- [ ] Yes, I've updated the documentation
- [x] Not relevant

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
This PR will clean up some potentially leaky spies by using jests built in mock functions, which can be reset in between tests automatically. It will also remove sinon as a dependency. 

**Does this PR introduce a breaking change?**
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->
No

**Other information**
see https://github.com/react-dropzone/react-dropzone/pull/645#issuecomment-415094186