### PR TITLE
fix: persist synthetic event

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -97,6 +97,8 @@ class Dropzone extends React.Component {
       this.dragTargets.push(evt.target)
     }
 
+    evt.persist()
+
     Promise.resolve(this.props.getDataTransferItems(evt)).then(draggedFiles => {
       this.setState({
         isDragActive: true, // Do not rely on files for the drag state. It doesn't work in Safari.
@@ -173,6 +175,8 @@ class Dropzone extends React.Component {
       isDragActive: false,
       draggedFiles: []
     })
+
+    evt.persist()
 
     Promise.resolve(getDataTransferItems(evt)).then(fileList => {
       const acceptedFiles = []

--- a/src/index.js
+++ b/src/index.js
@@ -162,6 +162,9 @@ class Dropzone extends React.Component {
 
     // Stop default browser behavior
     evt.preventDefault()
+    
+    // Persist event for later usage
+    evt.persist()
 
     // Reset the counter along with the drag on a drop.
     this.dragTargets = []
@@ -175,8 +178,6 @@ class Dropzone extends React.Component {
       isDragActive: false,
       draggedFiles: []
     })
-
-    evt.persist()
 
     Promise.resolve(getDataTransferItems(evt)).then(fileList => {
       const acceptedFiles = []

--- a/src/index.js
+++ b/src/index.js
@@ -162,7 +162,7 @@ class Dropzone extends React.Component {
 
     // Stop default browser behavior
     evt.preventDefault()
-    
+
     // Persist event for later usage
     evt.persist()
 


### PR DESCRIPTION
**What kind of change does this PR introduce?**

- [x] bugfix
- [ ] feature
- [ ] refactoring / style
- [ ] build / chore
- [ ] documentation

**Did you add tests for your changes?**

- [ ] Yes, my code is well tested
- [ ] Not relevant
- [x] Don't know how

**If relevant, did you update the documentation?**

- [ ] Yes, I've updated the documentation
- [x] Not relevant

**Summary**

Since v4.3 the event passed to the handler is not reusable anymore, because some work is done with it before. To prevent this `evt.persist()` is called.

Fixes #646 

**Does this PR introduce a breaking change?**
no

**Other information**
I don't really know how to test this.