### PR TITLE
Mark children as optional in the typings

### DIFF
--- a/typings/react-dropzone.d.ts
+++ b/typings/react-dropzone.d.ts
@@ -52,7 +52,7 @@ export type DropzoneProps = Omit<React.HTMLProps<HTMLDivElement>, "onDrop"> & {
   onDropAccepted?: DropFileEventHandler;
   onDropRejected?: DropFileEventHandler;
   onFileDialogCancel?: () => void;
-  children: React.ReactNode | DropzoneRenderFunction;
+  children?: React.ReactNode | DropzoneRenderFunction;
 };
 
 export default class Dropzone extends Component<DropzoneProps> {

--- a/typings/tests/basic.tsx
+++ b/typings/tests/basic.tsx
@@ -80,3 +80,6 @@ class Basic2 extends React.Component {
     );
   }
 }
+
+// verify that all props are optional
+const allPropsOptional = <Dropzone/>


### PR DESCRIPTION
They're marked as required, but the `propTypes` only mark it as optional. One of them is wrong :)

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

- [x] bugfix
- [ ] feature
- [ ] refactoring / style
- [ ] build / chore
- [ ] documentation

**Did you add tests for your changes?**

- [x] Yes, my code is well tested
- [ ] Not relevant

**If relevant, did you update the documentation?**

- [ ] Yes, I've updated the documentation
- [x] Not relevant

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
When used with TypeScript it's currently required for `DropZone` to have a child, even if that child is just `{undefined}`.

**Does this PR introduce a breaking change?**
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->
No

**Other information**
