### PR TITLE
fix: set accepted/rejected files state on drop

### DIFF
--- a/examples/Styling/Readme.md
+++ b/examples/Styling/Readme.md
@@ -4,20 +4,21 @@ By default, the Dropzone component picks up some default styling to get you star
 
 By providing a function that returns the component's children you can not only style Dropzone appropriately but also render appropriate content.
 
-```
+```jsx
 <Dropzone
   accept="image/png"
 >
-  {({ isDragActive, isDragReject, acceptedFiles, rejectedFiles }) => {
-    if (isDragActive) {
+  {({ isDragAccept, isDragReject, acceptedFiles, rejectedFiles }) => {
+    if (acceptedFiles.length || rejectedFiles.length) {
+      return `Accepted ${acceptedFiles.length}, rejected ${rejectedFiles.length} files`;
+    }
+    if (isDragAccept) {
       return "This file is authorized";
     }
     if (isDragReject) {
       return "This file is not authorized";
     }
-    return acceptedFiles.length || rejectedFiles.length
-      ? `Accepted ${acceptedFiles.length}, rejected ${rejectedFiles.length} files`
-      : "Try dropping some files.";
+    return "Try dropping some files.";
   }}
 </Dropzone>
 ```

--- a/src/index.js
+++ b/src/index.js
@@ -222,6 +222,9 @@ class Dropzone extends React.Component {
         onDropAccepted.call(this, acceptedFiles, evt)
       }
 
+      // Update `acceptedFiles` and `rejectedFiles` state
+      // This will make children render functions receive the appropriate
+      // values
       this.setState({ acceptedFiles, rejectedFiles })
     })
   }

--- a/src/index.js
+++ b/src/index.js
@@ -221,6 +221,8 @@ class Dropzone extends React.Component {
       if (acceptedFiles.length > 0 && onDropAccepted) {
         onDropAccepted.call(this, acceptedFiles, evt)
       }
+
+      this.setState({ acceptedFiles, rejectedFiles })
     })
   }
 

--- a/src/index.spec.js
+++ b/src/index.spec.js
@@ -615,6 +615,21 @@ describe('Dropzone', () => {
     const onDropAccepted = jest.fn()
     const onDropRejected = jest.fn()
 
+    it('should update the acceptedFiles/rejectedFiles state', async () => {
+      let dropzone = mount(
+        <Dropzone accept="image/*">{props => <DummyChildComponent {...props} />}</Dropzone>
+      )
+      dropzone.simulate('drop', { dataTransfer: { files } })
+      dropzone = await flushPromises(dropzone)
+      expect(dropzone.find(DummyChildComponent)).toHaveProp('acceptedFiles', [])
+      expect(dropzone.find(DummyChildComponent)).toHaveProp('rejectedFiles', files)
+
+      dropzone.simulate('drop', { dataTransfer: { files: images } })
+      dropzone = await flushPromises(dropzone)
+      expect(dropzone.find(DummyChildComponent)).toHaveProp('acceptedFiles', images)
+      expect(dropzone.find(DummyChildComponent)).toHaveProp('rejectedFiles', [])
+    })
+
     it('should reset the dragActive/dragReject state', async () => {
       let dropzone = mount(<Dropzone>{props => <DummyChildComponent {...props} />}</Dropzone>)
       dropzone.simulate('dragEnter', { dataTransfer: { files } })


### PR DESCRIPTION
**What kind of change does this PR introduce?**

- [x] bugfix
- [ ] feature
- [ ] refactoring / style
- [ ] build / chore
- [x] documentation

**Did you add tests for your changes?**

- [x] Yes, my code is well tested
- [ ] Not relevant

**If relevant, did you update the documentation?**

- [x] Yes, I've updated the documentation
- [ ] Not relevant

**Summary**

Fixes https://github.com/react-dropzone/react-dropzone/issues/647.

If using a render function as a child of `Dropzone`, the `acceptedFiles`/`rejectedFiles` properties were always passed as `[]` and were never updated. The reason for the bug is explained [in the issue above](https://github.com/react-dropzone/react-dropzone/issues/647#issuecomment-423863500) and reproduced here:

> `renderChildren` is [calling the render function passing in a shallow copy of its inner `this.state`](https://github.com/react-dropzone/react-dropzone/blob/master/src/index.js#L296); however, while [initialized as empty arrays](https://github.com/react-dropzone/react-dropzone/blob/master/src/index.js#L36) (`[]`), neither `acceptedFiles` nor `rejectedFiles` are ever updated in the state.
> [This here](https://github.com/react-dropzone/react-dropzone/commit/71a54adc77071079214d2a0b3e987a52cdb95be3#diff-1fdf421c05c1140f6d71444ea2b27638L201) is the faulty commit, which landed in [`v4.3.0`](https://github.com/react-dropzone/react-dropzone/blob/v4.3.0/src/index.js).

Additionally, this also fixes a bad related example on the docs under `examples/Styling/Readme.md` - noted [in the original issue](https://github.com/react-dropzone/react-dropzone/issues/647#issuecomment-423862600) as well.

**Does this PR introduce a breaking change?**
It doesn't.