### PR TITLE
fix: pass event to user-supplied inputProps {onClick}

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -263,7 +263,7 @@ class Dropzone extends React.Component {
   onInputElementClick(evt) {
     evt.stopPropagation()
     if (this.props.inputProps && this.props.inputProps.onClick) {
-      this.props.inputProps.onClick()
+      this.props.inputProps.onClick(evt)
     }
   }
 

--- a/src/index.spec.js
+++ b/src/index.spec.js
@@ -295,7 +295,7 @@ describe('Dropzone', () => {
       const component = mount(<Dropzone inputProps={{ onClick }} />)
 
       component.simulate('click')
-      expect(onClick).toHaveBeenCalled()
+      expect(onClick).toHaveBeenCalledWith(expect.any(MouseEvent))
     })
   })
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

- [X] bugfix
- [ ] feature
- [ ] refactoring / style
- [ ] build / chore
- [ ] documentation

**Did you add tests for your changes?**

- [ ] Yes, my code is well tested
- [X] Not relevant

**If relevant, did you update the documentation?**

- [ ] Yes, I've updated the documentation
- [X] Not relevant

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
We encountered an issue that was described here, #40, that describes attempting to load the same file twice (the data has changed). The use-case where we encountered this was a user uploaded a file, but the rejected it due to formatting issues. The file input doesn't discard the target state so uploaded the correct file moments later does not trigger any handles such as `onDrop`, etc....

Summary of changes:

1. Update that event is passed to `onClick` prop handler inside of
`onInputElementClick`
2. Update `'should invoke inputProps onClick if provided'` testcase to
verify that function is now called with a MouseEvent object


**Does this PR introduce a breaking change?**
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->
No, this PR updates the application to match the documentation for `onClick`

**Other information**
- No docs were added or updated because it was a bugfix to make the code _match_ the current documentation 
- A single testcase was updated to verify that the a user supplied `onClick` handler now receives a `MouseEvent` object