### PR TITLE
fix: call setState before callbacks

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -222,22 +222,22 @@ class Dropzone extends React.Component {
         rejectedFiles.push(...acceptedFiles.splice(0))
       }
 
-      if (onDrop) {
-        onDrop.call(this, acceptedFiles, rejectedFiles, evt)
-      }
-
-      if (rejectedFiles.length > 0 && onDropRejected) {
-        onDropRejected.call(this, rejectedFiles, evt)
-      }
-
-      if (acceptedFiles.length > 0 && onDropAccepted) {
-        onDropAccepted.call(this, acceptedFiles, evt)
-      }
-
       // Update `acceptedFiles` and `rejectedFiles` state
       // This will make children render functions receive the appropriate
       // values
-      this.setState({ acceptedFiles, rejectedFiles })
+      this.setState({ acceptedFiles, rejectedFiles }, () => {
+        if (onDrop) {
+          onDrop.call(this, acceptedFiles, rejectedFiles, evt)
+        }
+
+        if (rejectedFiles.length > 0 && onDropRejected) {
+          onDropRejected.call(this, rejectedFiles, evt)
+        }
+
+        if (acceptedFiles.length > 0 && onDropAccepted) {
+          onDropAccepted.call(this, acceptedFiles, evt)
+        }
+      })
     })
   }
 

--- a/src/index.spec.js
+++ b/src/index.spec.js
@@ -1292,4 +1292,19 @@ describe('Dropzone', () => {
       expect(props.onDrop).not.toHaveBeenCalled()
     })
   })
+
+  it('should not set state after onDrop callbacks', async () => {
+    const onDrop = () => {
+      jest.resetAllMocks()
+    }
+    let dropzone = mount(
+      <Dropzone accept="image/*" onDrop={onDrop}>
+        {props => <DummyChildComponent {...props} />}
+      </Dropzone>
+    )
+    const setState = jest.spyOn(dropzone.instance(), 'setState')
+    dropzone.simulate('drop', { dataTransfer: { files: images } })
+    dropzone = await flushPromises(dropzone)
+    expect(setState).not.toHaveBeenCalled()
+  })
 })


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

- [x] bugfix
- [ ] feature
- [ ] refactoring / style
- [ ] build / chore
- [ ] documentation

**Did you add tests for your changes?**

- [ ] Yes, my code is well tested
- [x] Not relevant

**If relevant, did you update the documentation?**

- [ ] Yes, I've updated the documentation
- [x] Not relevant

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
A potential fix for: https://github.com/react-dropzone/react-dropzone/issues/689

**Does this PR introduce a breaking change?**
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->
Nope

**Other information**