### PR TITLE
feat: add open() to child func props (#691)

### DIFF
--- a/examples/FileDialog/Readme.md
+++ b/examples/FileDialog/Readme.md
@@ -1,15 +1,33 @@
-You can programmatically invoke default OS file prompt. In order to do that you'll have to set the ref on your `Dropzone` instance and call the instance `open` method.
-
 **Please note**, that for security reasons most browsers require popups and dialogues to originate from a direct user interaction (i.e. click). If you are calling `dropzoneRef.open()` asynchronously, there’s a good chance it’s going to be blocked by the browser. So if you are calling `dropzoneRef.open()` asynchronously, be sure there is no more than *1000ms* delay between user interaction and `dropzoneRef.open()` call. Due to the lack of official docs on this (at least we haven’t found any. If you know one, feel free to open PR), there is no guarantee that **allowed delay duration** will not be changed in later browser versions. Since implementations may differ between different browsers, avoid calling open asynchronously if possible.
 
+You can programmatically invoke default OS file prompt. There are two ways to do that. The first is to provide a function as the child for `Dropzone` to access the `open` method as a parameter. The second way is to set the ref on your `Dropzone` instance and call the instance `open` method.
+
+##### Open programmatically by Child Function
+
 ```
-let dropzoneRef;
+<Dropzone onDrop={files => alert(JSON.stringify(files))} disableClick>
+  {({ open }) => (
+    <React.Fragment>
+      <button type="button" onClick={() => open()}>
+        Open File Dialog
+      </button>
+
+      <p>Drop files here.</p>
+    </React.Fragment>
+  )}
+</Dropzone>
+```
+
+##### Open programmatically by Ref
+
+```
+const dropzoneRef = React.createRef();
 
 <div>
-  <Dropzone ref={(node) => { dropzoneRef = node; }} onDrop={(accepted, rejected) => { alert(accepted) }}>
+  <Dropzone ref={dropzoneRef} onDrop={(accepted, rejected) => { alert(JSON.stringify(accepted)) }}>
       <p>Drop files here.</p>
   </Dropzone>
-  <button type="button" onClick={() => { dropzoneRef.open() }}>
+  <button type="button" onClick={() => { dropzoneRef.current.open() }}>
       Open File Dialog
   </button>
 </div>

--- a/src/index.js
+++ b/src/index.js
@@ -27,6 +27,7 @@ class Dropzone extends React.Component {
     this.onDrop = this.onDrop.bind(this)
     this.onFileDialogCancel = this.onFileDialogCancel.bind(this)
     this.onInputElementClick = this.onInputElementClick.bind(this)
+    this.open = this.open.bind(this)
 
     this.setRef = this.setRef.bind(this)
     this.setRefs = this.setRefs.bind(this)
@@ -313,7 +314,8 @@ class Dropzone extends React.Component {
         ...this.state,
         isDragActive,
         isDragAccept,
-        isDragReject
+        isDragReject,
+        open: this.open
       })
     }
     return children

--- a/src/index.spec.js
+++ b/src/index.spec.js
@@ -663,6 +663,23 @@ describe('Dropzone', () => {
     })
   })
 
+  it('should expose open func to children', () => {
+    const subject = mount(
+      <Dropzone disableClick>
+        {({ open }) => (
+          <button type="button" onClick={open}>
+            Open
+          </button>
+        )}
+      </Dropzone>
+    )
+
+    const click = jest.spyOn(subject.instance().fileInputEl, 'click')
+    subject.find('button').simulate('click')
+
+    expect(click).toHaveBeenCalled()
+  })
+
   describe('onDrop', () => {
     const expectedEvent = expect.anything()
     const onDrop = jest.fn()

--- a/typings/react-dropzone.d.ts
+++ b/typings/react-dropzone.d.ts
@@ -26,6 +26,7 @@ type DropzoneRenderArgs = {
   isDragActive: boolean;
   isDragAccept: boolean;
   isDragReject: boolean;
+  open: () => void;
 };
 
 export type DropzoneRenderFunction = (x: DropzoneRenderArgs) => JSX.Element;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

- [ ] bugfix
- [x] feature
- [ ] refactoring / style
- [ ] build / chore
- [ ] documentation

**Did you add tests for your changes?**

- [x] Yes, my code is well tested
- [ ] Not relevant

**If relevant, did you update the documentation?**

- [x] Yes, I've updated the documentation
- [ ] Not relevant

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
If you are rendering a Dropzone using a child function, you can open the file dialog programmatically without having to also add a ref.

<!-- Try to link to an open issue for more information. -->
https://github.com/react-dropzone/react-dropzone/issues/691

**Does this PR introduce a breaking change?**
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->
No

**Other information**
I updated the TypeScript definition, though I've never used TypeScript before so I just guessed on the syntax. Hopefully someone with more experience can take a look at it and see if that is correct?