### PR TITLE
docs: add missing key to fullscreen example

### DIFF
--- a/examples/Basic/Readme.md
+++ b/examples/Basic/Readme.md
@@ -67,7 +67,7 @@ class Basic extends React.Component {
           <h2>Dropped files</h2>
           <ul>
             {
-              this.state.files.map(f => <li>{f.name} - {f.size} bytes</li>)
+              this.state.files.map(f => <li key={f.name}>{f.name} - {f.size} bytes</li>)
             }
           </ul>
         </aside>

--- a/examples/Fullscreen/Readme.md
+++ b/examples/Fullscreen/Readme.md
@@ -71,7 +71,7 @@ class FullScreen extends React.Component {
           <h2>Dropped files</h2>
           <ul>
             {
-              files.map(f => <li>{f.name} - {f.size} bytes</li>)
+              files.map((file, index) => <li key={index}>{file.name} - {file.size} bytes</li>)
             }
           </ul>
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

- [ ] bugfix
- [ ] feature
- [ ] refactoring / style
- [ ] build / chore
- [x] documentation

**Did you add tests for your changes?**

- [ ] Yes, my code is well tested
- [x] Not relevant

**If relevant, did you update the documentation?**

- [x] Yes, I've updated the documentation
- [ ] Not relevant

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
When attaching files to the Fullscreen example, you would get console warnings due to missing `key` props on the dropped files list items.
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->
No

**Other information**
None