### PR TITLE
fix: improve drag type detection and fix styling in Safari

### DIFF
--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -41,14 +41,12 @@ export function allFilesAccepted(files, accept) {
   return files.every(file => fileAccepted(file, accept))
 }
 
-export function isFileList(items) {
-  // Returns true only for items that are File objects or DataTransferItem of kind 'file',
-  // See https://developer.mozilla.org/en-US/docs/Web/API/DataTransferItem for details
-  return (
-    Array.isArray(items) &&
-    items.length > 0 &&
-    (Array.prototype.every.call(items, item => item instanceof File) ||
-      Array.prototype.every.call(items, isKindFile))
+export function isDragDataWithFiles(evt) {
+  // https://developer.mozilla.org/en-US/docs/Web/API/DataTransfer/types
+  // https://developer.mozilla.org/en-US/docs/Web/API/HTML_Drag_and_Drop_API/Recommended_drag_types#file
+  return Array.prototype.every.call(
+    evt.dataTransfer.types,
+    type => type === 'Files' || type === 'application/x-moz-file'
   )
 }
 

--- a/src/utils/index.spec.js
+++ b/src/utils/index.spec.js
@@ -1,4 +1,4 @@
-import { getDataTransferItems, isIeOrEdge, isFileList } from './'
+import { getDataTransferItems, isIeOrEdge, isDragDataWithFiles } from './'
 
 const files = [
   {
@@ -17,20 +17,6 @@ const files = [
     type: 'image/jpeg'
   }
 ]
-
-const nonFileItems = [
-  {
-    kind: 'string',
-    type: 'text/plain'
-  }
-]
-
-const json = JSON.stringify({
-  ping: true
-})
-const file = new File([json], 'test.json', {
-  type: 'application/json'
-})
 
 const fileItems = [
   {
@@ -138,12 +124,22 @@ describe('isIeOrEdge', () => {
   })
 })
 
-describe('isFileList', () => {
-  it('should only return true for an Array of File objects or DataTransferItem of kind file', () => {
-    expect(isFileList([file])).toBe(true)
-    expect(isFileList(fileItems)).toBe(true)
-    expect(isFileList(nonFileItems)).toBe(false)
-    expect(isFileList([])).toBe(false)
-    expect(isFileList(null)).toBe(false)
+describe('isDragDataWithFiles()', () => {
+  it('should return true if every dragged type is a file', () => {
+    expect(isDragDataWithFiles({ dataTransfer: { types: ['Files'] } })).toBe(true)
+    expect(isDragDataWithFiles({ dataTransfer: { types: ['application/x-moz-file'] } })).toBe(true)
+    expect(
+      isDragDataWithFiles({
+        dataTransfer: { types: ['Files', 'application/x-moz-file'] }
+      })
+    ).toBe(true)
+    expect(isDragDataWithFiles({ dataTransfer: { types: ['text/plain'] } })).toBe(false)
+    expect(isDragDataWithFiles({ dataTransfer: { types: ['text/html'] } })).toBe(false)
+    expect(isDragDataWithFiles({ dataTransfer: { types: ['Files', 'text/html'] } })).toBe(false)
+    expect(
+      isDragDataWithFiles({
+        dataTransfer: { types: ['application/x-moz-file', 'text/html'] }
+      })
+    ).toBe(false)
   })
 })

--- a/src/utils/styles.js
+++ b/src/utils/styles.js
@@ -1,15 +1,16 @@
 export default {
+  active: {
+    borderStyle: 'solid',
+    backgroundColor: '#eee'
+  },
+  accepted: {
+    borderStyle: 'solid',
+    borderColor: '#6c6',
+    backgroundColor: '#eee'
+  },
   rejected: {
     borderStyle: 'solid',
     borderColor: '#c66',
-    backgroundColor: '#eee'
-  },
-  disabled: {
-    opacity: 0.5
-  },
-  active: {
-    borderStyle: 'solid',
-    borderColor: '#6c6',
     backgroundColor: '#eee'
   },
   default: {
@@ -19,5 +20,8 @@ export default {
     borderColor: '#666',
     borderStyle: 'dashed',
     borderRadius: 5
+  },
+  disabled: {
+    opacity: 0.5
   }
 }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

- [x] bugfix
- [ ] feature
- [ ] refactoring / style
- [ ] build / chore
- [ ] documentation

**Did you add tests for your changes?**

- [x] Yes, my code is well tested
- [ ] Not relevant

**If relevant, did you update the documentation?**

- [ ] Yes, I've updated the documentation
- [x] Not relevant

**Summary**
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
We currently rely on getting the data transfer data to detect what kind of data is being dragged. While that works in Chrome, Firefox and Edge, it does not work in Safari.

Hence this PR which uses [{types}](https://developer.mozilla.org/en-US/docs/Web/API/DataTransfer/types) to do the data type detection.

And a few other things:
- apply different active styling when file type cannot be inferred (to avoid confusion, reported in https://github.com/react-dropzone/react-dropzone/issues/668)
- cleanup some of the tests

**Does this PR introduce a breaking change?**
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->
No.

**Other information**
