### PR TITLE
fix: fix types for getDataTransferItems()

### DIFF
--- a/typings/react-dropzone.d.ts
+++ b/typings/react-dropzone.d.ts
@@ -48,7 +48,7 @@ export type DropzoneProps = Omit<React.HTMLProps<HTMLDivElement>, "onDrop" | "re
   onDropAccepted?: DropFileEventHandler;
   onDropRejected?: DropFileEventHandler;
   onFileDialogCancel?(): void;
-  getDataTransferItems?(event: React.DragEvent<HTMLDivElement> | DragEvent): Promise<Array<File | DataTransferItem>>;
+  getDataTransferItems?(event: React.DragEvent<HTMLDivElement> | DragEvent | React.ChangeEvent<HTMLInputElement> | Event): Promise<Array<File | DataTransferItem>>;
   children?: React.ReactNode | DropzoneRenderFunction;
   ref?: React.Ref<Dropzone>;
 };

--- a/typings/tests/plugin.tsx
+++ b/typings/tests/plugin.tsx
@@ -1,7 +1,7 @@
 import React, {Component} from "react";
 import Dropzone from "../../";
 
-export class TestReactEvt extends Component {
+export class TestReactDragEvt extends Component {
   getFiles = async (evt: React.DragEvent<HTMLDivElement>) => {
     const files = Array.from(evt.dataTransfer.files);
     return files;
@@ -35,9 +35,44 @@ export class TestDataTransferItems extends Component {
   }
 }
 
-export class TestNativeEvt extends Component {
+export class TestNativeDragEventEvt extends Component {
   getFiles = async (evt: DragEvent) => {
     const files = Array.from(evt.dataTransfer.files);
+    return files;
+  }
+
+  render() {
+    return (
+      <div>
+        <Dropzone getDataTransferItems={this.getFiles}>
+          Hi
+        </Dropzone>
+      </div>
+    );
+  }
+}
+
+export class TestChangeEvt extends Component {
+  getFiles = async (evt: React.ChangeEvent<HTMLInputElement>) => {
+    const files = Array.from(evt.target.files);
+    return files;
+  }
+
+  render() {
+    return (
+      <div>
+        <Dropzone getDataTransferItems={this.getFiles}>
+          Hi
+        </Dropzone>
+      </div>
+    );
+  }
+}
+
+
+export class TestNativeEvt extends Component {
+  getFiles = async (evt: Event) => {
+    const files = Array.from((evt.target as HTMLInputElement).files);
     return files;
   }
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

- [x] bugfix
- [ ] feature
- [ ] refactoring / style
- [ ] build / chore
- [ ] documentation

**Did you add tests for your changes?**

- [x] Yes, my code is well tested
- [ ] Not relevant

**If relevant, did you update the documentation?**

- [ ] Yes, I've updated the documentation
- [x] Not relevant

**Summary**
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
`getDataTransferItems()` can also be called with a change event that originated from an `<input>`, this PR adds the proper types to reflect that.

**Does this PR introduce a breaking change?**
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->
No.

**Other information**
