### PR TITLE
fix: fix on file select dialog close behaviour

### DIFF
--- a/examples/Basic/Readme.md
+++ b/examples/Basic/Readme.md
@@ -13,11 +13,20 @@ class Basic extends React.Component {
     });
   }
 
+  onCancel() {
+    this.setState({
+      files: []
+    });
+  }
+
   render() {
     return (
       <section>
         <div className="dropzone">
-          <Dropzone onDrop={this.onDrop.bind(this)}>
+          <Dropzone
+            onDrop={this.onDrop.bind(this)}
+            onFileDialogCancel={this.onCancel.bind(this)}
+          >
             <p>Try dropping some files here, or click to select files to upload.</p>
           </Dropzone>
         </div>

--- a/src/index.js
+++ b/src/index.js
@@ -280,11 +280,11 @@ class Dropzone extends React.Component {
 
           if (!files.length) {
             this.isFileDialogActive = false
-          }
-        }
 
-        if (typeof onFileDialogCancel === 'function') {
-          onFileDialogCancel()
+            if (typeof onFileDialogCancel === 'function') {
+              onFileDialogCancel()
+            }
+          }
         }
       }, 300)
     }

--- a/src/index.spec.js
+++ b/src/index.spec.js
@@ -1062,7 +1062,23 @@ describe('Dropzone', () => {
       expect(onFileDialogCancel).not.toHaveBeenCalled()
     })
 
-    it('should invoke onFileDialogCancel when window receives focus via cancel button', () => {
+    it('should not invoke onFileDialogCancel if input does not exist', () => {
+      const onFileDialogCancel = jest.fn()
+      const component = mount(
+        <Dropzone id="on-cancel-example" onFileDialogCancel={onFileDialogCancel} />
+      )
+
+      component.instance().setRefs(null)
+
+      document.body.addEventListener('focus', () => {})
+      const evt = document.createEvent('HTMLEvents')
+      evt.initEvent('focus', false, true)
+      document.body.dispatchEvent(evt)
+      jest.runAllTimers()
+      expect(onFileDialogCancel).not.toHaveBeenCalled()
+    })
+
+    it('should invoke onFileDialogCancel when window receives focus via cancel button and there were no files selected', () => {
       const onFileDialogCancel = jest.fn()
       const component = mount(
         <Dropzone className="dropzone-content" onFileDialogCancel={onFileDialogCancel} />
@@ -1082,6 +1098,34 @@ describe('Dropzone', () => {
 
       jest.runAllTimers()
       expect(onFileDialogCancel).toHaveBeenCalled()
+    })
+
+    it('should not invoke onFileDialogCancel when window receives focus via cancel button and there were files selected', () => {
+      const onFileDialogCancel = jest.fn()
+      const component = mount(
+        <Dropzone className="dropzone-content" onFileDialogCancel={onFileDialogCancel} />
+      )
+
+      // Test / invoke the click event
+      const open = jest.spyOn(component.instance(), 'open')
+      component.simulate('click')
+
+      expect(open).toHaveBeenCalled()
+
+      const input = component.find('input').getDOMNode()
+
+      Object.defineProperty(input, 'files', {
+        value: images
+      })
+
+      // Simulated DOM event - onfocus
+      window.addEventListener('focus', () => {})
+      const evt = document.createEvent('HTMLEvents')
+      evt.initEvent('focus', false, true)
+      window.dispatchEvent(evt)
+
+      jest.runAllTimers()
+      expect(onFileDialogCancel).not.toHaveBeenCalled()
     })
 
     it('should restore isFileDialogActive to false after the FileDialog was closed', () => {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

- [x] bugfix
- [ ] feature
- [ ] refactoring / style
- [ ] build / chore
- [ ] documentation

**Did you add tests for your changes?**

- [x] Yes, my code is well tested
- [ ] Not relevant

**If relevant, did you update the documentation?**

- [x] Yes, I've updated the documentation
- [ ] Not relevant

**Summary**
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
Do not invoke `{onFileDialogCancel}` cb if no files were selected when the file selection dialog is closed (fix for #652).

**Does this PR introduce a breaking change?**
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->
No.

**Other information**
