### PR TITLE
refactor: remove file preview and close #705

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@
 # react-dropzone
 
 [![npm](https://img.shields.io/npm/v/react-dropzone.svg)](https://www.npmjs.com/package/react-dropzone)
-[![Build Status](https://travis-ci.org/react-dropzone/react-dropzone.svg?branch=master)](https://travis-ci.org/react-dropzone/react-dropzone) 
-[![codecov](https://codecov.io/gh/react-dropzone/react-dropzone/branch/master/graph/badge.svg)](https://codecov.io/gh/react-dropzone/react-dropzone) 
-[![OpenCollective](https://opencollective.com/react-dropzone/backers/badge.svg)](#backers) 
+[![Build Status](https://travis-ci.org/react-dropzone/react-dropzone.svg?branch=master)](https://travis-ci.org/react-dropzone/react-dropzone)
+[![codecov](https://codecov.io/gh/react-dropzone/react-dropzone/branch/master/graph/badge.svg)](https://codecov.io/gh/react-dropzone/react-dropzone)
+[![OpenCollective](https://opencollective.com/react-dropzone/backers/badge.svg)](#backers)
 [![OpenCollective](https://opencollective.com/react-dropzone/sponsors/badge.svg)](#sponsors)
 
 Simple HTML5-compliant drag'n'drop zone for files built with React.js.
@@ -37,15 +37,15 @@ Import `Dropzone` in your React component:
 
 ```javascript static
 import Dropzone from 'react-dropzone'
-``` 
-  
+```
+
   and specify the `onDrop` method that accepts two arguments. The first argument represents the accepted files and the second argument the rejected files.
-  
+
 ```javascript static
 function onDrop(acceptedFiles, rejectedFiles) {
   // do stuff with files...
 }
-``` 
+```
 
 Files accepted or rejected based on `accept` prop. This must be a valid [MIME type](http://www.iana.org/assignments/media-types/media-types.xhtml) according to [input element specification](https://www.w3.org/wiki/HTML/Elements/input/file).
 
@@ -88,10 +88,6 @@ onDrop: acceptedFiles => {
 
 See https://react-dropzone.netlify.com/#proptypes
 
-### Word of caution when working with previews
-
-*Important*: `react-dropzone` doesn't manage dropped files. You need to destroy the object URL yourself whenever you don't need the `preview` by calling `window.URL.revokeObjectURL(file.preview);` to avoid memory leaks.
-
 ### Testing
 
 *Important*: `react-dropzone` makes its drag'n'drop callbacks asynchronous to enable promise based getDataTransfer functions. In order to properly test this, you may want to utilize a helper function to run all promises like this:
@@ -112,7 +108,7 @@ it('tests drag state', async () => {
   })
   await flushPromises(dropzone)
   dropzone.update()
-  
+
   const child = updatedDropzone.find(DummyChildComponent)
   expect(child).toHaveProp('isDragActive', true)
   expect(child).toHaveProp('isDragAccept', false)

--- a/examples/Previews/Readme.md
+++ b/examples/Previews/Readme.md
@@ -1,0 +1,94 @@
+Starting with version 7.0.0, the `{preview}` property generation on the [File](https://developer.mozilla.org/en-US/docs/Web/API/File) objects and the `{disablePreview}` property on the `<Dropzone>` have been removed.
+
+If you need need the `{preview}`, it can be easily achieved in the `onDrop()` callback:
+
+```jsx harmony
+const thumbsContainer = {
+  display: 'flex',
+  flexDirection: 'row',
+  flexWrap: 'wrap',
+  marginTop: 16
+};
+
+const thumb = {
+  display: 'inline-flex',
+  borderRadius: 2,
+  border: '1px solid #eaeaea',
+  marginBottom: 8,
+  marginRight: 8,
+  width: 100,
+  height: 100,
+  padding: 4,
+  boxSizing: 'border-box'
+};
+
+const thumbInner = {
+  display: 'flex',
+  minWidth: 0,
+  overflow: 'hidden'
+}
+
+const img = {
+  display: 'block',
+  width: 'auto',
+  height: '100%'
+};
+
+class DropzoneWithPreview extends React.Component {
+  constructor() {
+    super()
+    this.state = {
+      files: []
+    };
+  }
+
+  onDrop(files) {
+    this.setState({
+      files: files.map(file => ({
+        ...file,
+        preview: URL.createObjectURL(file)
+      }))
+    });
+  }
+
+  componentWillUnmount() {
+    // Make sure to revoke the data uris to avoid memory leaks
+    const {files} = this.state;
+    for (let i = files.length; i >= 0; i--) {
+      const file = files[0];
+      URL.revokeObjectURL(file.preview);
+    }
+  }
+
+  render() {
+    const {files} = this.state;
+
+    const thumbs = files.map(file => (
+      <div style={thumb}>
+        <div style={thumbInner}>
+          <img
+            src={file.preview}
+            style={img}
+          />
+        </div>
+      </div>
+    ));
+
+    return (
+      <section>
+        <div className="dropzone">
+          <Dropzone
+            accept="image/*"
+            onDrop={this.onDrop.bind(this)}
+          />
+        </div>
+        <aside style={thumbsContainer}>
+          {thumbs}
+        </aside>
+      </section>
+    );
+  }
+}
+
+<DropzoneWithPreview />
+```

--- a/package.json
+++ b/package.json
@@ -47,7 +47,11 @@
   },
   "jest": {
     "setupTestFrameworkScriptFile": "<rootDir>/testSetup.js",
-    "clearMocks": true
+    "clearMocks": true,
+    "coveragePathIgnorePatterns": [
+      "/node_modules/",
+      "<rootDir>/testSetup.js"
+    ]
   },
   "keywords": [
     "react-component",

--- a/src/index.js
+++ b/src/index.js
@@ -168,7 +168,6 @@ class Dropzone extends React.Component {
       onDropAccepted,
       onDropRejected,
       multiple,
-      disablePreview,
       accept,
       getDataTransferItems
     } = this.props
@@ -202,10 +201,6 @@ class Dropzone extends React.Component {
         }
 
         fileList.forEach(file => {
-          if (!disablePreview) {
-            file.preview = window.URL.createObjectURL(file) // eslint-disable-line no-param-reassign
-          }
-
           if (
             fileAccepted(file, accept) &&
             fileMatchSize(file, this.props.maxSize, this.props.minSize)
@@ -435,7 +430,6 @@ class Dropzone extends React.Component {
     const {
       acceptedFiles,
       preventDropOnDocument,
-      disablePreview,
       disableClick,
       onDropAccepted,
       onDropRejected,
@@ -503,11 +497,6 @@ Dropzone.propTypes = {
    * Enable/disable the dropzone entirely
    */
   disabled: PropTypes.bool,
-
-  /**
-   * Enable/disable preview generation
-   */
-  disablePreview: PropTypes.bool,
 
   /**
    * If false, allow dropped items to take over the current browser window
@@ -646,7 +635,6 @@ Dropzone.propTypes = {
 Dropzone.defaultProps = {
   preventDropOnDocument: true,
   disabled: false,
-  disablePreview: false,
   disableClick: false,
   inputProps: {},
   multiple: true,

--- a/src/index.spec.js
+++ b/src/index.spec.js
@@ -1041,51 +1041,6 @@ describe('Dropzone', () => {
     })
   })
 
-  describe('preview', () => {
-    const expectedEvent = expect.anything()
-
-    it('should generate previews for non-images', async () => {
-      const onDrop = jest.fn()
-      const dropzone = mount(<Dropzone onDrop={onDrop} />)
-      await dropzone.simulate('drop', createDtWithFiles(files))
-      expect(onDrop).toHaveBeenCalledWith(
-        expect.arrayContaining([expect.objectContaining({ preview: 'data://file1.pdf' })]),
-        [],
-        expectedEvent
-      )
-    })
-
-    it('should generate previews for images', async () => {
-      const onDrop = jest.fn()
-      const dropzone = mount(<Dropzone onDrop={onDrop} />)
-      await dropzone.simulate('drop', createDtWithFiles(images))
-      expect(onDrop).toHaveBeenCalledWith(
-        expect.arrayContaining([expect.objectContaining({ preview: 'data://cats.gif' })]),
-        [],
-        expectedEvent
-      )
-    })
-
-    it('should not generate previews if disablePreview is true', async () => {
-      const onDrop = jest.fn()
-      const dropzone = mount(<Dropzone disablePreview onDrop={onDrop} />)
-      await dropzone.simulate('drop', createDtWithFiles(images))
-      expect(onDrop).not.toHaveBeenCalledWith(
-        expect.arrayContaining([expect.objectContaining({ preview: expect.anything() })]),
-        [],
-        expectedEvent
-      )
-      onDrop.mockClear()
-
-      await dropzone.simulate('drop', createDtWithFiles(files))
-      expect(onDrop).not.toHaveBeenCalledWith(
-        expect.arrayContaining([expect.objectContaining({ preview: expect.anything() })]),
-        [],
-        expectedEvent
-      )
-    })
-  })
-
   describe('onCancel', () => {
     beforeEach(() => {
       jest.useFakeTimers(true)

--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -38,6 +38,10 @@ module.exports = {
           content: 'examples/Accept/Readme.md'
         },
         {
+          name: 'Previews',
+          content: 'examples/Previews/Readme.md'
+        },
+        {
           name: 'Nested Dropzone',
           content: 'examples/Nesting/Readme.md'
         },

--- a/testSetup.js
+++ b/testSetup.js
@@ -6,9 +6,3 @@ const Adapter = require('enzyme-adapter-react-16')
 require('jest-enzyme')
 
 Enzyme.configure({ adapter: new Adapter() })
-
-global.window.URL = {
-  createObjectURL: function createObjectURL(arg) {
-    return `data://${arg.name}`
-  }
-}

--- a/typings/react-dropzone.d.ts
+++ b/typings/react-dropzone.d.ts
@@ -1,23 +1,20 @@
 import * as React from "react";
-
-export interface FileWithPreview extends File {
-  preview?: string;
-}
+import {func} from "prop-types";
 
 export type DropFileEventHandler = (
-  acceptedOrRejected: FileWithPreview[],
+  acceptedOrRejected: File[],
   event: React.DragEvent<HTMLDivElement>
 ) => void;
 export type DropFilesEventHandler = (
-  accepted: FileWithPreview[],
-  rejected: FileWithPreview[],
+  accepted: File[],
+  rejected: File[],
   event: React.DragEvent<HTMLDivElement>
 ) => void;
 
 type DropzoneRenderArgs = {
-  draggedFiles: FileWithPreview[];
-  acceptedFiles: FileWithPreview[];
-  rejectedFiles: FileWithPreview[];
+  draggedFiles: File[];
+  acceptedFiles: File[];
+  rejectedFiles: File[];
   isDragActive: boolean;
   isDragAccept: boolean;
   isDragReject: boolean;
@@ -31,7 +28,6 @@ type Omit<T, K> = Pick<T, Exclude<keyof T, K>>;
 export type DropzoneProps = Omit<React.HTMLProps<HTMLDivElement>, "onDrop" | "ref"> & {
   disableClick?: boolean;
   disabled?: boolean;
-  disablePreview?: boolean;
   preventDropOnDocument?: boolean;
   inputProps?: React.InputHTMLAttributes<HTMLInputElement>;
   maxSize?: number;
@@ -48,7 +44,7 @@ export type DropzoneProps = Omit<React.HTMLProps<HTMLDivElement>, "onDrop" | "re
   onDropAccepted?: DropFileEventHandler;
   onDropRejected?: DropFileEventHandler;
   onFileDialogCancel?(): void;
-  getDataTransferItems?(event: React.DragEvent<HTMLDivElement> | DragEvent | React.ChangeEvent<HTMLInputElement> | Event): Promise<Array<File | DataTransferItem>>;
+  getDataTransferItems?(event: React.DragEvent<HTMLDivElement> | React.ChangeEvent<HTMLInputElement> | DragEvent | Event): Promise<Array<File | DataTransferItem>>;
   children?: React.ReactNode | DropzoneRenderFunction;
   ref?: React.Ref<Dropzone>;
 };

--- a/typings/tests/all.tsx
+++ b/typings/tests/all.tsx
@@ -40,7 +40,6 @@ class Test extends React.Component {
           minSize={2000}
           maxSize={Infinity}
           preventDropOnDocument
-          disablePreview
           disableClick
           disabled
           multiple={false}


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

- [ ] bugfix
- [ ] feature
- [x] refactoring / style
- [ ] build / chore
- [ ] documentation

**Did you add tests for your changes?**

- [x] Yes, my code is well tested
- [ ] Not relevant

**If relevant, did you update the documentation?**

- [x] Yes, I've updated the documentation
- [ ] Not relevant

**Summary**
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
Remove the preview generation for files.

The dropzone should not be responsible for enhancing the File object with whatever the user needs. The user is free to manipulate the File objects as they wish after the `onDrop()` callback emits them.

**Does this PR introduce a breaking change?**
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->
Yes. The `{preview}` property on the File object will no longer be generated. And the `{disablePreview}` property on the Dropzone is also removed.

Creating previews can easily be achieved in the `onDrop()` callback:
```js
class MyZone extends React.Component {
  onDrop = files => {
    this.setState({
      files: files.map(file => ({
        ...file,
        preview: URL.createObjectURL(file)
      }))
    });
  }

  cleanup = () => {
    // Revoke data uris when done using the previews
    const {files} = this.state;

    for (const file of files) {
      URL.revokeObjectURL(file.preview);
    }
  }

  render() {
    return (
      <Dropzone onDrop={this.onDrop} />
    );
  }
}
```

**Other information**

@okonet I haven't added any plugins for this as that would have further implications.

We would need to export other things besides the default dropzone, which means we need to change the rollup build so that it doesn't log warnings in two possible ways:

- no default exports, which means that we export the Dropzone as a named export so that users would `import {Dropzone} from 'dropzone'`
- export other things alongside the default Dropzone export and disable the warning in Rollup, but that's a bad practice as mentioned at [rollupjs.org#exporting](https://rollupjs.org/guide/en#exporting)

Furthermore, we still need to ask the users to remember to revoke the data uris. So I think it's better to let the users handle this on theirs side if they need it.
