### PR TITLE
docs: replace spread operator with Object.assign in preview example, s…

### DIFF
--- a/examples/Previews/Readme.md
+++ b/examples/Previews/Readme.md
@@ -44,20 +44,13 @@ class DropzoneWithPreview extends React.Component {
 
   onDrop(files) {
     this.setState({
-      files: files.map(file => ({
-        ...file,
-        preview: URL.createObjectURL(file)
-      }))
+      files: files.map(file => Object.assign(file, {preview: URL.createObjectURL(file)}))
     });
   }
 
   componentWillUnmount() {
     // Make sure to revoke the data uris to avoid memory leaks
-    const {files} = this.state;
-    for (let i = files.length; i >= 0; i--) {
-      const file = files[0];
-      URL.revokeObjectURL(file.preview);
-    }
+    this.state.files.forEach(f => URL.revokeObjectURL(f.preview))
   }
 
   render() {


### PR DESCRIPTION
…implify cWU function

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

- [ ] bugfix
- [ ] feature
- [ ] refactoring / style
- [ ] build / chore
- [x] documentation

**Did you add tests for your changes?**

- [ ] Yes, my code is well tested
- [x] Not relevant

**If relevant, did you update the documentation?**

- [x] Yes, I've updated the documentation
- [ ] Not relevant

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
Documentation example for adding preview to File object does not work. Using spread operator for File object does not pick up the non-enumerable properties of File object. Using Object.assign to add the preview property does work. 
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**
