### PR TITLE
fix: allow drag drop while file select dialog is opened

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -95,15 +95,6 @@ class Dropzone extends React.Component {
     evt.preventDefault()
     evt.persist()
 
-    try {
-      // The file dialog on Chrome allows users to drag files from the dialog onto
-      // the dropzone, causing the browser the crash when the file dialog is closed.
-      // A drop effect of 'none' prevents the file from being dropped
-      evt.dataTransfer.dropEffect = this.isFileDialogActive ? 'none' : 'copy' // eslint-disable-line no-param-reassign
-    } catch (err) {
-      // continue regardless of error
-    }
-
     if (this.props.onDragOver && isDragDataWithFiles(evt)) {
       this.props.onDragOver.call(this, evt)
     }

--- a/src/index.spec.js
+++ b/src/index.spec.js
@@ -751,67 +751,6 @@ describe('Dropzone', () => {
       expect(props.onDragLeave).toHaveBeenCalled()
     })
 
-    it('should guard dropEffect in onDragOver for IE', async () => {
-      const props = {
-        onDragStart: jest.fn(),
-        onDragEnter: jest.fn(),
-        onDragLeave: jest.fn()
-      }
-      const component = mount(
-        <Dropzone {...props}>
-          {({ getRootProps, getInputProps }) => (
-            <div {...getRootProps()}>
-              <input {...getInputProps()} />
-            </div>
-          )}
-        </Dropzone>
-      )
-
-      // Using Proxy we'll emulate IE throwing when setting dataTransfer.dropEffect
-      const eventProxy = {
-        persist() {},
-        preventDefault() {},
-        stopPropagation() {},
-        dataTransfer: new Proxy(
-          {},
-          {
-            set: (target, prop) => {
-              switch (prop) {
-                case 'dropEffect':
-                  throw new Error('IE does not support setting {dropEffect}')
-                default:
-                  break
-              }
-            }
-          }
-        )
-      }
-
-      // And using then we'll call the onDragOver with the proxy instead of event
-      const instance = component.instance()
-      const componentOnDragOver = instance.onDragOver
-      const onDragOver = jest
-        .spyOn(instance, 'onDragOver')
-        .mockImplementation(() => componentOnDragOver(eventProxy))
-
-      component.simulate('dragStart', createDtWithFiles(files))
-      await flushPromises(component)
-      expect(props.onDragStart).toHaveBeenCalled()
-
-      component.simulate('dragEnter', createDtWithFiles(files))
-      await flushPromises(component)
-      expect(props.onDragEnter).toHaveBeenCalled()
-
-      component.simulate('dragLeave', createDtWithFiles(files))
-      await flushPromises(component)
-      expect(props.onDragLeave).toHaveBeenCalled()
-
-      // It should not throw the error
-      component.simulate('dragOver', createDtWithFiles(files))
-      await flushPromises(component)
-      expect(onDragOver).not.toThrow()
-    })
-
     it('should not call onDrag* if there are no files', async () => {
       const props = {
         onDragStart: jest.fn(),


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

- [x] bugfix
- [ ] feature
- [ ] refactoring / style
- [ ] build / chore
- [ ] documentation

**Did you add tests for your changes?**

- [ ] Yes, my code is well tested
- [x] Not relevant

**If relevant, did you update the documentation?**

- [ ] Yes, I've updated the documentation
- [x] Not relevant

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
It seems that drag and drop while the file select dialog is opened does not crash in Chrome anymore. So I reverted the current fix as it seems to confuse some users (see https://github.com/react-dropzone/react-dropzone/issues/723).


**Does this PR introduce a breaking change?**
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->
No.

**Other information**
