### PR TITLE
feat: add {disableKeyDown} prop to disable open file dialog on keydown

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -275,7 +275,8 @@ class Dropzone extends React.Component {
   }
 
   onKeyDown = evt => {
-    const { onKeyDown } = this.props
+    const { onKeyDown, disableKeyDown } = this.props
+
     if (!this.node.isEqualNode(evt.target)) {
       return
     }
@@ -284,7 +285,7 @@ class Dropzone extends React.Component {
       onKeyDown.call(this, evt)
     }
 
-    if (!isDefaultPrevented(evt) && (evt.keyCode === 32 || evt.keyCode === 13)) {
+    if (!disableKeyDown && !isDefaultPrevented(evt) && (evt.keyCode === 32 || evt.keyCode === 13)) {
       evt.preventDefault()
       this.open()
     }
@@ -438,6 +439,11 @@ Dropzone.propTypes = {
    * Disallow clicking on the dropzone container to open file dialog
    */
   disableClick: PropTypes.bool,
+
+  /**
+   * Do not open the file dialog when SPACE or ENTER is detected on the dropzone
+   */
+  disableKeyDown: PropTypes.bool,
 
   /**
    * Enable/disable the dropzone entirely

--- a/src/index.spec.js
+++ b/src/index.spec.js
@@ -657,6 +657,25 @@ describe('Dropzone', () => {
       expect(open).not.toHaveBeenCalled()
     })
 
+    it('does not react to keydown if component has {disableKeyDown} prop', async () => {
+      const dropzone = mount(
+        <Dropzone disableKeyDown>
+          {({ getRootProps, getInputProps }) => (
+            <div {...getRootProps()}>
+              <input {...getInputProps()} />
+            </div>
+          )}
+        </Dropzone>
+      )
+      const open = jest.spyOn(dropzone.instance(), 'open')
+      dropzone.simulate('keydown', {
+        keyCode: 32,
+        defaultPrevented: false,
+        preventDefault() {}
+      })
+      expect(open).not.toHaveBeenCalled()
+    })
+
     it('does not react to keydown if component is not in focus', async () => {
       const dropzone = mount(
         <Dropzone>


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

- [ ] bugfix
- [x] feature
- [ ] refactoring / style
- [ ] build / chore
- [ ] documentation

**Did you add tests for your changes?**

- [x] Yes, my code is well tested
- [ ] Not relevant

**If relevant, did you update the documentation?**

- [ ] Yes, I've updated the documentation
- [x] Not relevant

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
Allow users to disable opening the file dialog on keydown (space/enter) when the dropzone is in focus using a `{disableKeyDown}` prop on the `<Dropzone>`.

**Does this PR introduce a breaking change?**
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->
No.

**Other information**
