### PR TITLE
fix: remove {onDragStart} prop

### DIFF
--- a/examples/Nesting/Readme.md
+++ b/examples/Nesting/Readme.md
@@ -63,7 +63,6 @@ class NestedDropzone extends React.Component {
       <section>
         <div className="dropzone">
           <Dropzone
-            onDragStart={this.createDragHandler('dragstart', 'parent')}
             onDragEnter={this.createDragHandler('dragenter', 'parent')}
             onDragOver={this.createDragHandler('dragover', 'parent')}
             onDragLeave={this.createDragHandler('dragleave', 'parent')}
@@ -72,7 +71,6 @@ class NestedDropzone extends React.Component {
             {({getRootProps, getInputProps}) => (
               <div {...getRootProps()} style={parentStyle}>
                 <Dropzone
-                  onDragStart={this.createDragHandler('dragstart', 'child')}
                   onDragEnter={this.createDragHandler('dragenter', 'child')}
                   onDragOver={this.createDragHandler('dragover', 'child')}
                   onDragLeave={this.createDragHandler('dragleave', 'child')}

--- a/src/index.js
+++ b/src/index.js
@@ -57,13 +57,6 @@ class Dropzone extends React.Component {
     this.dragTargets = []
   }
 
-  onDragStart = evt => {
-    evt.persist()
-    if (this.props.onDragStart && isDragDataWithFiles(evt)) {
-      this.props.onDragStart.call(this, evt)
-    }
-  }
-
   onDragEnter = evt => {
     evt.preventDefault()
 
@@ -304,7 +297,6 @@ class Dropzone extends React.Component {
     onFocus,
     onBlur,
     onClick,
-    onDragStart,
     onDragEnter,
     onDragOver,
     onDragLeave,
@@ -320,9 +312,6 @@ class Dropzone extends React.Component {
     onBlur: this.composeHandler(onBlur ? composeEventHandlers(onBlur, this.onBlur) : this.onBlur),
     onClick: this.composeHandler(
       onClick ? composeEventHandlers(onClick, this.onClick) : this.onClick
-    ),
-    onDragStart: this.composeHandler(
-      onDragStart ? composeEventHandlers(onDragStart, this.onDragStart) : this.onDragStart
     ),
     onDragEnter: this.composeHandler(
       onDragEnter ? composeEventHandlers(onDragEnter, this.onDragEnter) : this.onDragEnter
@@ -543,11 +532,6 @@ Dropzone.propTypes = {
    * onDropRejected callback
    */
   onDropRejected: PropTypes.func,
-
-  /**
-   * onDragStart callback
-   */
-  onDragStart: PropTypes.func,
 
   /**
    * onDragEnter callback

--- a/src/index.spec.js
+++ b/src/index.spec.js
@@ -126,7 +126,6 @@ describe('Dropzone', () => {
         onKeyDown: jest.fn(),
         onFocus: jest.fn(),
         onBlur: jest.fn(),
-        onDragStart: jest.fn(),
         onDragEnter: jest.fn(),
         onDragOver: jest.fn(),
         onDragLeave: jest.fn(),
@@ -154,10 +153,6 @@ describe('Dropzone', () => {
 
       dropzone.simulate('keydown')
       expect(rootProps.onKeyDown).toHaveBeenCalled()
-
-      await dropzone.simulate('dragStart', evt)
-      await flushPromises(dropzone)
-      expect(rootProps.onDragStart).toHaveBeenCalled()
 
       await dropzone.simulate('dragEnter', evt)
       await flushPromises(dropzone)
@@ -775,7 +770,6 @@ describe('Dropzone', () => {
   describe('drag-n-drop', async () => {
     it('should override onDrag* methods', async () => {
       const props = {
-        onDragStart: jest.fn(),
         onDragEnter: jest.fn(),
         onDragOver: jest.fn(),
         onDragLeave: jest.fn()
@@ -789,10 +783,6 @@ describe('Dropzone', () => {
           )}
         </Dropzone>
       )
-
-      await component.simulate('dragStart', createDtWithFiles(files))
-      await flushPromises(component)
-      expect(props.onDragStart).toHaveBeenCalled()
 
       await component.simulate('dragEnter', createDtWithFiles(files))
       await flushPromises(component)
@@ -809,7 +799,6 @@ describe('Dropzone', () => {
 
     it('should not call onDrag* if there are no files', async () => {
       const props = {
-        onDragStart: jest.fn(),
         onDragEnter: jest.fn(),
         onDragOver: jest.fn(),
         onDragLeave: jest.fn(),
@@ -827,10 +816,6 @@ describe('Dropzone', () => {
           )}
         </Dropzone>
       )
-
-      await component.simulate('dragStart', createDtWithTextTypes())
-      await flushPromises(component)
-      expect(props.onDragStart).not.toHaveBeenCalled()
 
       await component.simulate('dragEnter', createDtWithTextTypes())
       await flushPromises(component)
@@ -853,7 +838,6 @@ describe('Dropzone', () => {
 
     it('should call onDrag* if the DataTransfer has files but cannot access the data', async () => {
       const props = {
-        onDragStart: jest.fn(),
         onDragEnter: jest.fn(),
         onDragOver: jest.fn(),
         onDragLeave: jest.fn(),
@@ -871,10 +855,6 @@ describe('Dropzone', () => {
           )}
         </Dropzone>
       )
-
-      await component.simulate('dragStart', createDtWithFiles([]))
-      await flushPromises(component)
-      expect(props.onDragStart).toHaveBeenCalled()
 
       await component.simulate('dragEnter', createDtWithFiles([]))
       await flushPromises(component)
@@ -1931,7 +1911,6 @@ describe('Dropzone', () => {
     it('uses the provided plugin fn for getting the files', async () => {
       const props = {
         getDataTransferItems: evt => fromEvent(evt),
-        onDragStart: jest.fn(),
         onDragEnter: jest.fn(),
         onDragOver: jest.fn(),
         onDragLeave: jest.fn(),
@@ -1953,10 +1932,6 @@ describe('Dropzone', () => {
         type: 'application/json'
       })
       const files = [file]
-
-      await dropzone.simulate('dragStart', createDtWithFiles(files))
-      await flushPromises(dropzone)
-      expect(props.onDragStart).toHaveBeenCalled()
 
       await dropzone.simulate('dragEnter', createDtWithFiles(files))
       await flushPromises(dropzone)
@@ -1990,7 +1965,6 @@ describe('Dropzone', () => {
     it('ignores the plugin result if it does not comply with the expected type signature', async () => {
       const props = {
         getDataTransferItems: evt => Promise.resolve(evt.dataTransfer.items),
-        onDragStart: jest.fn(),
         onDragEnter: jest.fn(),
         onDragOver: jest.fn(),
         onDragLeave: jest.fn(),
@@ -2017,10 +1991,6 @@ describe('Dropzone', () => {
         }
       ]
       const types = ['text/plain']
-
-      await dropzone.simulate('dragStart', createDtWithItems(items, types))
-      await flushPromises(dropzone)
-      expect(props.onDragStart).not.toHaveBeenCalled()
 
       await dropzone.simulate('dragEnter', createDtWithItems(items, types))
       await flushPromises(dropzone)

--- a/typings/react-dropzone.d.ts
+++ b/typings/react-dropzone.d.ts
@@ -62,7 +62,6 @@ type PropTypes = "accept"
   | "onFocus"
   | "onBlur"
   | "onKeyDown"
-  | "onDragStart"
   | "onDragEnter"
   | "onDragOver"
   | "onDragLeave";

--- a/typings/tests/all.tsx
+++ b/typings/tests/all.tsx
@@ -16,7 +16,6 @@ export default class Test extends React.Component {
         <Dropzone
           onDrop={(acceptedFiles, rejectedFiles, event) =>
             console.log(acceptedFiles, rejectedFiles, event)}
-          onDragStart={event => console.log(event)}
           onDragEnter={event => console.log(event)}
           onDragOver={event => console.log(event)}
           onDragLeave={event => console.log(event)}

--- a/typings/tests/events.tsx
+++ b/typings/tests/events.tsx
@@ -9,7 +9,6 @@ export class Events extends React.Component {
           <Dropzone
             onDrop={(acceptedFiles, rejectedFiles, event) =>
               console.log(acceptedFiles, rejectedFiles, event)}
-            onDragStart={event => console.log(event)}
             onDragEnter={event => console.log(event)}
             onDragOver={event => console.log(event)}
             onDragLeave={event => console.log(event)}


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

- [x] bugfix
- [ ] feature
- [x] refactoring / style
- [ ] build / chore
- [ ] documentation

**Did you add tests for your changes?**

- [x] Yes, my code is well tested
- [ ] Not relevant

**If relevant, did you update the documentation?**

- [ ] Yes, I've updated the documentation
- [x] Not relevant

**Summary**
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
{onDragStart} was removed as it is never invoked during the drag 'n' drop of files. This event is only triggered for elements that are being dragged.

**Does this PR introduce a breaking change?**
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->
Yes. The `{onDragStart}` property is removed.
It will only affect users that added this cb by mistake as in practice it is never invoked.

**Other information**
Using `refactor` type in commit does not seem to make a release, so I used the `fix` type.