### PR TITLE
Allow a composite component to be a direct child

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,7 +78,8 @@
   ],
   "license": "MIT",
   "peerDependencies": {
-    "react": ">=0.14.0"
+    "react": ">=0.14.0",
+    "react-dom": ">=0.14.0"
   },
   "dependencies": {
     "attr-accept": "^1.1.3",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -5,6 +5,7 @@ const uglify = require('rollup-plugin-uglify')
 
 const umdGlobals = {
   react: 'React',
+  'react-dom': 'ReactDOM',
   'prop-types': 'PropTypes'
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,7 @@
 /* eslint prefer-template: 0 */
 
 import React from 'react'
+import { findDOMNode } from 'react-dom'
 import { fromEvent } from 'file-selector'
 import PropTypes from 'prop-types'
 import {
@@ -360,12 +361,14 @@ class Dropzone extends React.Component {
     }
   }
 
-  setNodeRef = node => {
-    this.node = node
+  setNodeRef = ref => {
+    // eslint-disable-next-line react/no-find-dom-node
+    this.node = ref ? findDOMNode(ref) : undefined
   }
 
-  setInputRef = input => {
-    this.input = input
+  setInputRef = ref => {
+    // eslint-disable-next-line react/no-find-dom-node
+    this.input = ref ? findDOMNode(ref) : undefined
   }
 
   /**


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

- [x] bugfix
- [ ] feature
- [ ] refactoring / style
- [ ] build / chore
- [ ] documentation

**Did you add tests for your changes?**

- [ ] Yes, my code is well tested
- [ ] Not relevant

**If relevant, did you update the documentation?**

- [ ] Yes, I've updated the documentation
- [x] Not relevant

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
The problem is that you can't add a composite component as a direct child (render prop) of the Dropzone component. The existing code assumes a primitive component (div, p, ...etc) and thus treats it's instance (using ref) as a dom element. This precludes the use of something like [React Native Web](https://github.com/necolas/react-native-web) or even a simple hand-rolled component.
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->
There is no breaking change introduced by this PR

**Other information**
