### PR TITLE
Fix server-side rendering

### DIFF
--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -1,6 +1,9 @@
 import accepts from 'attr-accept'
 
-export const supportMultiple = 'multiple' in document.createElement('input')
+export const supportMultiple =
+  typeof document !== 'undefined' && document && document.createElement
+    ? 'multiple' in document.createElement('input')
+    : true
 
 // Firefox versions prior to 53 return a bogus MIME type for every file drag, so dragovers with
 // that MIME type will always be accepted


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

- [x] bugfix
- [ ] feature
- [ ] refactoring / style
- [ ] build / chore
- [ ] documentation

**Did you add tests for your changes?**

- [ ] Yes, my code is well tested
- [x] Not relevant

**If relevant, did you update the documentation?**

- [ ] Yes, I've updated the documentation
- [x] Not relevant

**Summary**

I am using `react-dropzone` in a Next.js application. After upgrading to version 10, I started getting this error.

![Screen Shot 2019-03-12 at 11 37 53 AM](https://user-images.githubusercontent.com/14926950/54194461-9b351b00-44bc-11e9-8987-d60c29de6a71.png)

After looking through the diff, I noticed that check about `document` existence in utils was for some reason removed. After putting it back, everything started working again.
 