### PR TITLE
fix: fix typings for {ref} and close #798

### DIFF
--- a/typings/react-dropzone.d.ts
+++ b/typings/react-dropzone.d.ts
@@ -1,6 +1,6 @@
 import * as React from "react";
 
-export default function Dropzone(props: DropzoneProps): JSX.Element;
+export default function Dropzone(props: DropzoneProps & React.RefAttributes<DropzoneRef>): JSX.Element;
 export function useDropzone(options?: DropzoneOptions): DropzoneState;
 
 export interface DropzoneProps extends DropzoneOptions {
@@ -22,7 +22,7 @@ export type DropzoneOptions = Pick<React.HTMLProps<HTMLElement>, PropTypes> & {
 
 export type DropEvent = React.DragEvent<HTMLElement> | React.ChangeEvent<HTMLInputElement> | DragEvent | Event;
 
-export type DropzoneState = {
+export type DropzoneState = DropzoneRef & {
   isFocused: boolean;
   isDragActive: boolean;
   isDragAccept: boolean;
@@ -35,8 +35,11 @@ export type DropzoneState = {
   inputRef: React.RefObject<HTMLInputElement>;
   getRootProps(props?: DropzoneRootProps): DropzoneRootProps;
   getInputProps(props?: DropzoneInputProps): DropzoneInputProps;
-  open(): void;
 };
+
+export interface DropzoneRef {
+  open(): void;
+}
 
 export interface DropzoneRootProps extends React.HTMLAttributes<HTMLElement> {
   refKey?: string;

--- a/typings/tests/refs.tsx
+++ b/typings/tests/refs.tsx
@@ -1,0 +1,18 @@
+import React, {createRef} from "react";
+import Dropzone, {DropzoneRef} from "../../";
+
+const ref = createRef<DropzoneRef>()
+
+export const dropzone = (
+  <Dropzone ref={ref}>
+    {({getRootProps, getInputProps}) => (
+      <div {...getRootProps()}>
+        <input {...getInputProps()} />
+        <p>Drop some files here.</p>
+        <button type="button" onClick={ref.current.open}>
+          Open file dialog
+        </button>
+      </div>
+    )}
+  </Dropzone>
+);


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

- [x] bugfix
- [ ] feature
- [ ] refactoring / style
- [ ] build / chore
- [ ] documentation

**Did you add tests for your changes?**

- [x] Yes, my code is well tested
- [ ] Not relevant

**If relevant, did you update the documentation?**

- [ ] Yes, I've updated the documentation
- [x] Not relevant

**Summary**
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
I missed adding typings for `{ref}` on the `<Dropzone>` component in one of the previous PRs. This PR fixes that.

**Does this PR introduce a breaking change?**
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->
No.

**Other information**
