### PR TITLE
feat: add {noClick}, {noKeyboard}, {noDrag} and {noDragEventsBubbling}

### DIFF
--- a/examples/events/README.md
+++ b/examples/events/README.md
@@ -1,160 +1,9 @@
-Custom event handlers provided in `getRootProps()` (e.g. `onClick`), will be invoked before the dropzone handlers.
-
-Therefore, if you'd like to prevent the default behaviour for: `onClick` and `onKeyDown` (open the file dialog), `onFocus` and `onBlur` (sets the `isFocused` state) and drag events; use the `stopPropagation()` fn on the event:
-
-```jsx harmony
-import React, {useCallback, useReducer} from 'react';
-import {useDropzone} from 'react-dropzone';
-
-const initialEvtsState = {
-  preventFocus: true,
-  preventClick: true,
-  preventKeyDown: true,
-  preventDrag: true,
-  files: []
-};
-
-function Events(props) {
-  const [state, dispatch] = useReducer(reducer, initialEvtsState);
-  const myRootProps = computeRootProps(state);
-  const createToggleHandler = type => () => dispatch({type});
-
-  const onDrop = useCallback(files => dispatch({
-    type: 'setFiles',
-    payload: files
-  }), []);
-
-  const {getRootProps, getInputProps, isFocused} = useDropzone({onDrop});
-  const files = state.files.map(file => <li key={file.path}>{file.path}</li>);
-
-  const options = ['preventFocus', 'preventClick', 'preventKeyDown', 'preventDrag'].map(key => (
-    <div key={key}>
-      <input
-        id={key}
-        type="checkbox"
-        onChange={createToggleHandler(key)}
-        checked={state[key]}
-      />
-      <label htmlFor={key}>
-        {key}
-      </label>
-    </div>
-  ));
-
-  return (
-    <section>
-      <aside>
-        {options}
-      </aside>
-      <div {...getRootProps(myRootProps)}>
-        <input {...getInputProps()} />
-        <p>{getDesc(state)} (<em>{isFocused ? 'focused' : 'not focused'}</em>)</p>
-      </div>
-      <aside>
-        <h4>Files</h4>
-        <ul>{files}</ul>
-      </aside>
-    </section>
-  );
-}
-
-function computeRootProps(state) {
-  const props = {};
-
-  if (state.preventFocus) {
-    Object.assign(props, {
-      onFocus: event => event.stopPropagation(),
-      onBlur: event => event.stopPropagation()
-    });
-  }
-
-  if (state.preventClick) {
-    Object.assign(props, {onClick: event => event.stopPropagation()});
-  }
-
-  if (state.preventKeyDown) {
-    Object.assign(props, {
-      onKeyDown: event => {
-        if (event.keyCode === 32 || event.keyCode === 13) {
-          event.stopPropagation();
-        }
-      }
-    });
-  }
-
-  if (state.preventDrag) {
-    ['onDragEnter', 'onDragOver', 'onDragLeave', 'onDrop'].forEach(evtName => {
-      Object.assign(props, {
-        [evtName]: event => event.stopPropagation()
-      });
-    });
-  }
-
-  return props;
-}
-
-function getDesc(state) {
-  if (state.preventClick && state.preventKeyDown && state.preventDrag) {
-    return `Dropzone will not respond to any events`;
-  } else if (state.preventClick && state.preventKeyDown) {
-    return `Drag 'n' drop files here`;
-  } else if (state.preventClick && state.preventDrag) {
-    return `Press SPACE/ENTER to open the file dialog`;
-  } else if (state.preventKeyDown && state.preventDrag) {
-    return `Click to open the file dialog`;
-  } else if (state.preventClick) {
-    return `Drag 'n' drop files here or press SPACE/ENTER to open the file dialog`;
-  } else if (state.preventKeyDown) {
-    return `Drag 'n' drop files here or click to open the file dialog`;
-  } else if (state.preventDrag) {
-    return `Click/press SPACE/ENTER to open the file dialog`;
-  }
-  return `Drag 'n' drop files here or click/press SPACE/ENTER to open the file dialog`;
-}
-
-function reducer(state, action) {
-  switch (action.type) {
-    case 'preventFocus':
-      return {
-        ...state,
-        preventFocus: !state.preventFocus
-      };
-    case 'preventClick':
-      return {
-        ...state,
-        preventClick: !state.preventClick
-      };
-    case 'preventKeyDown':
-      return {
-        ...state,
-        preventKeyDown: !state.preventKeyDown
-      };
-    case 'preventDrag':
-      return {
-        ...state,
-        preventDrag: !state.preventDrag
-      };
-    case 'setFiles':
-      return {
-        ...state,
-        files: action.payload
-      };
-    default:
-      return state;
-  }
-}
-
-<Events />
-```
-
-This sort of behavior can come in handy when you need to nest dropzone components and prevent any drag events from the child propagate to the parent:
-
+If you'd like to prevent drag events propagation from the child to parent, you can use the `{noDragEventsBubbling}` property on the child:
 ```jsx harmony
 import React, {useCallback, useMemo, useReducer} from 'react';
 import {useDropzone} from 'react-dropzone';
 
 const initialParentState = {
-  preventDrag: true,
   parent: {},
   child: {}
 };
@@ -179,36 +28,12 @@ const childStyle = {
 
 function Parent(props) {
   const [state, dispatch] = useReducer(parentReducer, initialParentState);
-  const {preventDrag} = state;
-  const togglePreventDrag = useCallback(() => dispatch({type: 'preventDrag'}), []);
   const dropzoneProps = useMemo(() => computeDropzoneProps({dispatch}, 'parent'), [dispatch]);
-
   const {getRootProps} = useDropzone(dropzoneProps);
-
-  const childProps = useMemo(() => ({
-    preventDrag,
-    dispatch
-  }), [
-    preventDrag,
-    dispatch
-  ]);
+  const childProps = useMemo(() => ({dispatch}), [dispatch]);
 
   return (
     <section>
-      <aside>
-        <div>
-          <input
-            id="toggleDrag"
-            type="checkbox"
-            onChange={togglePreventDrag}
-            checked={preventDrag}
-          />
-          <label htmlFor="toggleDrag">
-            preventDrag
-          </label>
-        </div>
-      </aside>
-      <br />
       <div {...getRootProps({style: parentStyle})}>
         <Child {...childProps} />
       </div>
@@ -221,8 +46,10 @@ function Parent(props) {
 }
 
 function Child(props) {
-  const dropzoneProps = useMemo(() => computeDropzoneProps(props, 'child'), [
-    props.preventDrag,
+  const dropzoneProps = useMemo(() => ({
+    ...computeDropzoneProps(props, 'child'),
+    noDragEventsBubbling: true
+  }), [
     props.dispatch
   ]);
   const {getRootProps} = useDropzone(dropzoneProps);
@@ -238,11 +65,6 @@ function Child(props) {
 
 function parentReducer(state, action) {
   switch (action.type) {
-    case 'preventDrag':
-      return {
-        ...state,
-        preventDrag: !state.preventDrag
-      };
     case 'onDragEnter':
     case 'onDragOver':
     case 'onDragLeave':
@@ -274,9 +96,6 @@ function computeDropzoneProps(props, node) {
     Object.assign(rootProps, {
       [type]: (...args) => {
         const event = type === 'onDrop' ? args.pop() : args.shift();
-        if (props.preventDrag) {
-          event.stopPropagation();
-        }
         props.dispatch({
           type,
           payload: {node}
@@ -292,4 +111,129 @@ function computeDropzoneProps(props, node) {
 <Parent />
 ```
 
-Note that the sort of behavior illustrated above can lead to some confusion. For example, the `onDragLeave` callback of the parent will not be called if the callback for the same event is invoked on the child. This happens because we invoked `stopPropagation()` on the event from the child.
+Note that internally we use `event.stopPropagation()` to achieve the behavior illustrated above, but this comes with its own [drawbacks](https://javascript.info/bubbling-and-capturing#stopping-bubbling).
+
+If you'd like to selectively turn off the default dropzone behavior for `onClick`, `onKeyDown` (both open the file dialog), `onFocus` and `onBlur` (sets the `isFocused` state) and drag events; use the `{noClick}`, `{noKeyboard}` and `{noDrag}` properties:
+```jsx harmony
+import React, {useCallback, useReducer} from 'react';
+import {useDropzone} from 'react-dropzone';
+
+const initialEvtsState = {
+  noClick: true,
+  noKeyboard: true,
+  noDrag: true,
+  files: []
+};
+
+function Events(props) {
+  const [state, dispatch] = useReducer(reducer, initialEvtsState);
+  const createToggleHandler = type => () => dispatch({type});
+
+  const onDrop = useCallback(files => dispatch({
+    type: 'setFiles',
+    payload: files
+  }), []);
+
+  const {getRootProps, getInputProps, isFocused} = useDropzone({...state, onDrop});
+  const files = state.files.map(file => <li key={file.path}>{file.path}</li>);
+
+  const options = ['noClick', 'noKeyboard', 'noDrag'].map(key => (
+    <div key={key}>
+      <input
+        id={key}
+        type="checkbox"
+        onChange={createToggleHandler(key)}
+        checked={state[key]}
+      />
+      <label htmlFor={key}>
+        {key}
+      </label>
+    </div>
+  ));
+
+  return (
+    <section>
+      <aside>
+        {options}
+      </aside>
+      <div {...getRootProps()}>
+        <input {...getInputProps()} />
+        <p>{getDesc(state)} (<em>{isFocused ? 'focused' : 'not focused'}</em>)</p>
+      </div>
+      <aside>
+        <h4>Files</h4>
+        <ul>{files}</ul>
+      </aside>
+    </section>
+  );
+}
+
+
+function getDesc(state) {
+  if (state.noClick && state.noKeyboard && state.noDrag) {
+    return `Dropzone will not respond to any events`;
+  } else if (state.noClick && state.noKeyboard) {
+    return `Drag 'n' drop files here`;
+  } else if (state.noClick && state.noDrag) {
+    return `Press SPACE/ENTER to open the file dialog`;
+  } else if (state.noKeyboard && state.noDrag) {
+    return `Click to open the file dialog`;
+  } else if (state.noClick) {
+    return `Drag 'n' drop files here or press SPACE/ENTER to open the file dialog`;
+  } else if (state.noKeyboard) {
+    return `Drag 'n' drop files here or click to open the file dialog`;
+  } else if (state.noDrag) {
+    return `Click/press SPACE/ENTER to open the file dialog`;
+  }
+  return `Drag 'n' drop files here or click/press SPACE/ENTER to open the file dialog`;
+}
+
+function reducer(state, action) {
+  switch (action.type) {
+    case 'noClick':
+      return {
+        ...state,
+        noClick: !state.noClick
+      };
+    case 'noKeyboard':
+      return {
+        ...state,
+        noKeyboard: !state.noKeyboard
+      };
+    case 'noDrag':
+      return {
+        ...state,
+        noDrag: !state.noDrag
+      };
+    case 'setFiles':
+      return {
+        ...state,
+        files: action.payload
+      };
+    default:
+      return state;
+  }
+}
+
+<Events />
+```
+
+Keep in mind that if you provide your own callback handlers as well and use `event.stopPropagation()`, it will prevent the default dropzone behavior:
+```jsx harmony
+import React from 'react';
+import Dropzone from 'react-dropzone';
+
+// Note that there will be nothing logged when files are dropped
+<Dropzone onDrop={files => console.log(files)}>
+  {({getRootProps, getInputProps}) => (
+    <div
+      {...getRootProps({
+        onDrop: event => event.stopPropagation()
+      })}
+    >
+      <input {...getInputProps()} />
+      <p>Drag 'n' drop some files here, or click to select files</p>
+    </div>
+  )}
+</Dropzone>
+```

--- a/examples/file-dialog/README.md
+++ b/examples/file-dialog/README.md
@@ -11,19 +11,14 @@ import React from 'react';
 import {useDropzone} from 'react-dropzone';
 
 function Dropzone(props) {
-  const {getRootProps, getInputProps, open} = useDropzone();
-  const rootProps = getRootProps({
+  const {getRootProps, getInputProps, open} = useDropzone({
     // Disable click and keydown behavior
-    onClick: event => event.stopPropagation(),
-    onKeyDown: event => {
-      if (event.keyCode === 32 || event.keyCode === 13) {
-        event.stopPropagation();
-      }
-    }
+    noClick: true,
+    noKeyboard: true
   });
 
   return (
-    <div {...rootProps}>
+    <div {...getRootProps()}>
       <input {...getInputProps()} />
       <p>Drag 'n' drop some files here</p>
       <button type="button" onClick={open}>
@@ -43,26 +38,24 @@ import React, {createRef} from 'react';
 import Dropzone from 'react-dropzone';
 
 const dropzoneRef = createRef();
+const openDialog = () => {
+  // Note that the ref is set async,
+  // so it might be null at some point 
+  if (dropzoneRef.current) {
+    dropzoneRef.current.open()
+  }
+};
 
-<Dropzone ref={dropzoneRef}>
+// Disable click and keydown behavior on the <Dropzone>
+<Dropzone ref={dropzoneRef} noClick noKeyboard>
   {({getRootProps, getInputProps}) => {
-    const rootProps = getRootProps({
-      // Disable click and keydown behavior
-      onClick: event => event.stopPropagation(),
-      onKeyDown: event => {
-        if (event.keyCode === 32 || event.keyCode === 13) {
-          event.stopPropagation();
-        }
-      }
-    });
-
     return (
-      <div {...rootProps}>
+      <div {...getRootProps()}>
         <input {...getInputProps()} />
         <p>Drag 'n' drop some files here</p>
         <button
           type="button"
-          onClick={dropzoneRef.current ? dropzoneRef.current.open : null}
+          onClick={openDialog}
         >
           Open File Dialog
         </button>

--- a/typings/react-dropzone.d.ts
+++ b/typings/react-dropzone.d.ts
@@ -12,6 +12,10 @@ export type DropzoneOptions = Pick<React.HTMLProps<HTMLElement>, PropTypes> & {
   minSize?: number;
   maxSize?: number;
   preventDropOnDocument?: boolean;
+  noClick?: boolean;
+  noKeyboard?: boolean;
+  noDrag?: boolean;
+  noDragEventsBubbling?: boolean;
   disabled?: boolean;
   onDrop?(acceptedFiles: File[], rejectedFiles: File[], event: DropEvent): void;
   onDropAccepted?(files: File[], event: DropEvent): void;

--- a/typings/tests/all.tsx
+++ b/typings/tests/all.tsx
@@ -17,6 +17,10 @@ export default class Test extends React.Component {
           minSize={2000}
           maxSize={Infinity}
           preventDropOnDocument
+          noClick={false}
+          noKeyboard={false}
+          noDrag={false}
+          noDragEventsBubbling={false}
           disabled
           multiple={false}
           accept="*.png"


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

- [x] bugfix
- [x] feature
- [ ] refactoring / style
- [ ] build / chore
- [x] documentation

**Did you add tests for your changes?**

- [x] Yes, my code is well tested
- [ ] Not relevant

**If relevant, did you update the documentation?**

- [x] Yes, I've updated the documentation
- [ ] Not relevant

**Summary**
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
Bring back the `{disableClick}` prop (with a different name) as using idiomatic js causes some other issues in the user land (e.g. `event.stopPropagation()` will stop events from being propagated to children, see #783).

Alongside that, also introduce:
- `{noKeyboard}` to disable keyboard events (SPACE/ENTER to open file dialog, focus/blur state)
- `{noDrag}` to disable drag events
- `{noDragEventsBubbling}` to stop drag events propagation to parents

**Does this PR introduce a breaking change?**
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->
No.

**Other information**
