### PR TITLE
docs:update readme FileReader -> createObjectURL

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ function MyDropzone() {
     acceptedFiles.forEach(file => {
       console.log(URL.createObjectURL(file))
       
-      /* you should */ // URL.revokeObjectURL(file)
+      /* should be after some processing */ // URL.revokeObjectURL(file)
     })
   }
   const {getRootProps, getInputProps, isDragActive} = useDropzone({onDrop})

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ import Dropzone from 'react-dropzone'
 
 **Warning**: On most recent browsers versions, the files given by `onDrop` won't have properties `path` or `fullPath`, see [this SO question](https://stackoverflow.com/a/23005925/2275818) and [this issue](https://github.com/react-dropzone/react-dropzone/issues/477).
 
-Furthermore, if you want to access file contents you have to use the [FileReader API](https://developer.mozilla.org/en-US/docs/Web/API/FileReader):
+Furthermore, if you want to access file contents you have to use the [URL.createObjectURL](https://developer.mozilla.org/en-US/docs/Web/API/URL/createObjectURL):
 
 ```jsx static
 import React, {useCallback} from 'react'
@@ -82,18 +82,12 @@ import {useDropzone} from 'react-dropzone'
 
 function MyDropzone() {
   const onDrop = useCallback(acceptedFiles => {
-    const reader = new FileReader()
-
-    reader.onabort = () => console.log('file reading was aborted')
-    reader.onerror = () => console.log('file reading has failed')
-    reader.onload = () => {
-      // Do whatever you want with the file contents
-      const binaryStr = reader.result
-      console.log(binaryStr)
-    }
-
-    acceptedFiles.forEach(file => reader.readAsBinaryString(file))
-  }, [])
+    acceptedFiles.forEach(file => {
+      console.log(URL.createObjectURL(file))
+      
+      /* you should */ // URL.revokeObjectURL(file)
+    })
+  }
   const {getRootProps, getInputProps, isDragActive} = useDropzone({onDrop})
 
   return (


### PR DESCRIPTION
if multiple file dropped, FileReader API throw error.

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

- [ ] bugfix
- [ ] feature
- [ ] refactoring / style
- [ ] build / chore
- [x] documentation

**Did you add tests for your changes?**

- [x] Yes, my code is well tested
- [ ] Not relevant

**If relevant, did you update the documentation?**

- [x] Yes, I've updated the documentation
- [ ] Not relevant

**Summary**

Use FileReader, multiple file dropped, FileReader read only one.[code and sample app](https://stackblitz.com/edit/react-filereader-vs-createobjecturl-fr)
on the other hand, URL.createObjectURL was successfully read multiple file.[code and sample app](https://stackblitz.com/edit/react-filereader-vs-createobjecturl-objurl) 
In readme.md, should be avoid misunderstanding.

**Does this PR introduce a breaking change?**
no.

**Other information**
