### PR TITLE
fix: cache effect for setting the ref and close #806

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -54,7 +54,7 @@ const Dropzone = forwardRef(({ children, ...params }, ref) => {
         ref.current = null
       }
     }
-  })
+  }, [ref])
 
   // TODO: Figure out why react-styleguidist cannot create docs if we don't return a jsx element
   return <Fragment>{children({ ...props, open })}</Fragment>

--- a/src/index.spec.js
+++ b/src/index.spec.js
@@ -359,6 +359,26 @@ describe('useDropzone() hook', () => {
       expect(dropzoneRef).toBeNull()
     })
 
+    test("<Dropzone> doesn't invoke the ref fn if it hasn't changed", () => {
+      const setRef = jest.fn()
+
+      const { rerender } = render(
+        <Dropzone ref={setRef}>
+          {({ getRootProps, getInputProps }) => (
+            <div {...getRootProps()}>
+              <input {...getInputProps()} />
+            </div>
+          )}
+        </Dropzone>
+      )
+
+      rerender(
+        <Dropzone ref={setRef}>{({ getRootProps }) => <div {...getRootProps()} />}</Dropzone>
+      )
+
+      expect(setRef).toHaveBeenCalledTimes(1)
+    })
+
     it('sets {isFocused} to false if {disabled} is true', () => {
       const { container, rerender } = render(
         <Dropzone>


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

- [x] bugfix
- [ ] feature
- [ ] refactoring / style
- [ ] build / chore
- [ ] documentation

**Did you add tests for your changes?**

- [x] Yes, my code is well tested
- [ ] Not relevant

**If relevant, did you update the documentation?**

- [ ] Yes, I've updated the documentation
- [x] Not relevant

**Summary**
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
We use an effect to set the dropzone ref when using the `<Dropzone>` component, but we did not cache, so if a cb function was provided, it would be called whenever react ran through all effects. This PR addresses that issue.

**Does this PR introduce a breaking change?**
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->
No.

**Other information**
