### PR TITLE
fix: prevent click on input when propagated form a <label>, close #182

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -454,20 +454,27 @@ export function useDropzone({
   }, [])
 
   // Cb to open the file dialog when click occurs on the dropzone
-  const onClickCb = useCallback(() => {
-    if (noClick) {
-      return
-    }
+  const onClickCb = useCallback(
+    event => {
+      // Prevent click events from propagating to the <input> when the click event
+      // originated from a <label> that wraps the dropzone
+      event.preventDefault()
 
-    // In IE11/Edge the file-browser dialog is blocking, therefore, use setTimeout()
-    // to ensure React can handle state changes
-    // See: https://github.com/react-dropzone/react-dropzone/issues/450
-    if (isIeOrEdge()) {
-      setTimeout(openFileDialog, 0)
-    } else {
-      openFileDialog()
-    }
-  }, [inputRef, noClick])
+      if (noClick) {
+        return
+      }
+
+      // In IE11/Edge the file-browser dialog is blocking, therefore, use setTimeout()
+      // to ensure React can handle state changes
+      // See: https://github.com/react-dropzone/react-dropzone/issues/450
+      if (isIeOrEdge()) {
+        setTimeout(openFileDialog, 0)
+      } else {
+        openFileDialog()
+      }
+    },
+    [inputRef, noClick]
+  )
 
   const [dragTargets, setDragTargets] = useState([])
   const onDocumentDrop = event => {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

- [x] bugfix
- [ ] feature
- [ ] refactoring / style
- [ ] build / chore
- [ ] documentation

**Did you add tests for your changes?**

- [x] Yes, my code is well tested
- [ ] Not relevant

**If relevant, did you update the documentation?**

- [ ] Yes, I've updated the documentation
- [x] Not relevant

**Summary**
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
Address https://github.com/react-dropzone/react-dropzone/issues/182, which prevents click events from being triggered when the dropzone is wrapped in a `<label>` without the `for` attribute.

**Does this PR introduce a breaking change?**
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->
No.

**Other information**
