### PR TITLE
fix: change typescript types to FileWithPath instead of File

### DIFF
--- a/typings/react-dropzone.d.ts
+++ b/typings/react-dropzone.d.ts
@@ -1,5 +1,6 @@
 import * as React from "react";
 
+export { FileWithPath } from "file-selector";
 export default function Dropzone(props: DropzoneProps & React.RefAttributes<DropzoneRef>): JSX.Element;
 export function useDropzone(options?: DropzoneOptions): DropzoneState;
 
@@ -17,9 +18,9 @@ export type DropzoneOptions = Pick<React.HTMLProps<HTMLElement>, PropTypes> & {
   noDrag?: boolean;
   noDragEventsBubbling?: boolean;
   disabled?: boolean;
-  onDrop?(acceptedFiles: File[], rejectedFiles: File[], event: DropEvent): void;
-  onDropAccepted?(files: File[], event: DropEvent): void;
-  onDropRejected?(files: File[], event: DropEvent): void;
+  onDrop?<T extends File>(acceptedFiles: T[], rejectedFiles: T[], event: DropEvent): void;
+  onDropAccepted?<T extends File>(files: T[], event: DropEvent): void;
+  onDropRejected?<T extends File>(files: T[], event: DropEvent): void;
   getFilesFromEvent?(event: DropEvent): Promise<Array<File | DataTransferItem>>;
   onFileDialogCancel?(): void;
 };

--- a/typings/tests/basic.tsx
+++ b/typings/tests/basic.tsx
@@ -1,10 +1,11 @@
 import React from "react";
 import Dropzone from "../../";
+import { FileWithPath } from "file-selector";
 
 export default class Basic extends React.Component {
   state = { files: [] };
 
-  onDrop = files => {
+  onDrop = (files: FileWithPath[]) => {
     this.setState({
       files
     });


### PR DESCRIPTION
**What kind of change does this PR introduce?**

- [x] bugfix
- [ ] feature
- [ ] refactoring / style
- [ ] build / chore
- [ ] documentation

**Did you add tests for your changes?**

- [ ] Yes, my code is well tested
- [x] Not relevant

**If relevant, did you update the documentation?**

- [ ] Yes, I've updated the documentation
- [x] Not relevant

**Summary**

Small change to type definitions of `files` from `File` to `FileWithPath`.

Motivation is that I receive type errors when trying to access the `path` property in the `acceptedFiles` array returned from `onDrop` as they are incorrectly typed as `File`.

**Does this PR introduce a breaking change?** 

No, as `FileWithType` extends `File` (only difference is optional `path` property)