### PR TITLE
Rename package to react-drag-and-drop

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![react-dropzone logo](https://raw.githubusercontent.com/react-dropzone/react-dropzone/master/logo/logo.png)
 
-# react-dropzone
+# react-drag-and-drop
 
 [![npm](https://img.shields.io/npm/v/react-dropzone.svg?style=flat-square)](https://www.npmjs.com/package/react-dropzone)
 [![Build Status](https://img.shields.io/travis/react-dropzone/react-dropzone/master.svg?style=flat-square)](https://travis-ci.org/react-dropzone/react-dropzone)
@@ -18,11 +18,11 @@ Documentation and examples at https://react-dropzone.js.org. Source code at http
 Install it from npm and include it in your React build process (using [Webpack](http://webpack.github.io/), [Browserify](http://browserify.org/), etc).
 
 ```bash
-npm install --save react-dropzone
+npm install --save react-drag-and-drop
 ```
 or:
 ```bash
-yarn add react-dropzone
+yarn add react-drag-and-drop
 ```
 
 
@@ -31,7 +31,7 @@ You can either use the hook:
 
 ```jsx static
 import React, {useCallback} from 'react'
-import {useDropzone} from 'react-dropzone'
+import {useDropzone} from 'react-drag-and-drop'
 
 function MyDropzone() {
   const onDrop = useCallback(acceptedFiles => {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "react-dropzone",
+  "name": "react-drag-and-drop",
   "description": "Simple HTML5 drag-drop zone with React.js",
   "main": "dist/index.js",
   "module": "dist/es/index.js",


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

- [ ] bugfix
- [ ] feature
- [ ] refactoring / style
- [ ] build / chore
- [x] documentation

**Did you add tests for your changes?**

- [ ] Yes, my code is well tested
- [x] Not relevant

**If relevant, did you update the documentation?**

- [x] Yes, I've updated the documentation
- [ ] Not relevant

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
Tihs package currently uses the name "Dropzone" which is easy to confuse with the Dropzone.js library. However, this package is not related to Dropzone.js (aside from achieving the same basic goal of drag-and-drop file upload, but without any of the advanced features that Dropzone.js has). By using a package name that better reflects the more limited goals of this package, it will allow developers to make a more informed choice from the npm registry.

**Does this PR introduce a breaking change?**
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->
Yes

**Other information**
Still a work in progress, but if you like the concept we can iron out some of the details.