### PR TITLE
Enable disabling disabled

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -716,7 +716,7 @@ export function useDropzone({
         onClick: composeHandler(composeEventHandlers(onClick, onInputElementClick)),
         autoComplete: 'off',
         tabIndex: -1,
-        disabled: disabled || noClick,
+        disabled: disabled !== undefined ? disabled : noClick,
         [refKey]: inputRef
       }
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

- [x] bugfix
- [ ] feature
- [ ] refactoring / style
- [ ] build / chore
- [ ] documentation

**Did you add tests for your changes?**

- [ ] Yes, my code is well tested
- [x] Not relevant

**If relevant, did you update the documentation?**

- [ ] Yes, I've updated the documentation
- [x] Not relevant

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

If someone sets `disabled: false`, they want the input to be _not disabled_. That is, they want it to be enabled.

But `false || noClick` always returns `noClick`, so the `noClick` setting wins.

Without this change, there's a bug:

* set `noClick: true`
* set `onClick={open}` on a button somewhere
* since the input is disabled, clicking it does nothing, and the file picker cannot be opened

Code to create this situation:

```js
const { getRootProps, getInputProps, open } = useDropzone({ noClick: true })

return (
  <div {...getRootProps()}>
    <Button onClick={open}>Upload</Button>
    <input {...getInputProps({ disabled: false })} />
  </div>
)
```

This raises another question, though: why do we need that `disabled: false` at all? Given I want to disable `onClick` on that wrapping `div`, why would we ever need or want to set `disabled` on the input? I want to remove an `onClick`, not disable my file input altogether.


**Does this PR introduce a breaking change?**
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

No.

**Other information**

Bug [introduced here](https://github.com/react-dropzone/react-dropzone/commit/a159354d6281ea2a2cd92f1b1d4a5510412a1fe2#diff-1fdf421c05c1140f6d71444ea2b27638R719)