### PR TITLE
Fix for #876: Dropping file into child element of drop zone opens it

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -6,8 +6,7 @@ import React, {
   useEffect,
   useMemo,
   useReducer,
-  useRef,
-  useState
+  useRef
 } from 'react'
 import PropTypes from 'prop-types'
 import { fromEvent } from 'file-selector'
@@ -469,14 +468,14 @@ export function useDropzone({
     }
   }, [inputRef, noClick])
 
-  const [dragTargets, setDragTargets] = useState([])
+  const dragTargetsRef = useRef([])
   const onDocumentDrop = event => {
     if (rootRef.current && rootRef.current.contains(event.target)) {
       // If we intercepted an event for our instance, let it propagate down to the instance's onDrop handler
       return
     }
     event.preventDefault()
-    setDragTargets([])
+    dragTargetsRef.current = []
   }
 
   useEffect(() => {
@@ -501,8 +500,8 @@ export function useDropzone({
       stopPropagation(event)
 
       // Count the dropzone and any children that are entered.
-      if (dragTargets.indexOf(event.target) === -1) {
-        setDragTargets([...dragTargets, event.target])
+      if (dragTargetsRef.current.indexOf(event.target) === -1) {
+        dragTargetsRef.current = [...dragTargetsRef.current, event.target]
       }
 
       if (isEvtWithFiles(event)) {
@@ -523,7 +522,7 @@ export function useDropzone({
         })
       }
     },
-    [dragTargets, getFilesFromEvent, onDragEnter, noDragEventsBubbling]
+    [getFilesFromEvent, onDragEnter, noDragEventsBubbling]
   )
 
   const onDragOverCb = useCallback(
@@ -554,12 +553,10 @@ export function useDropzone({
       stopPropagation(event)
 
       // Only deactivate once the dropzone and all children have been left
-      const targets = [
-        ...dragTargets.filter(
-          target => target !== event.target && rootRef.current && rootRef.current.contains(target)
-        )
-      ]
-      setDragTargets(targets)
+      const targets = dragTargetsRef.current.filter(
+        target => target !== event.target && rootRef.current && rootRef.current.contains(target)
+      )
+      dragTargetsRef.current = targets
       if (targets.length > 0) {
         return
       }
@@ -574,7 +571,7 @@ export function useDropzone({
         onDragLeave(event)
       }
     },
-    [rootRef, dragTargets, onDragLeave, noDragEventsBubbling]
+    [rootRef, onDragLeave, noDragEventsBubbling]
   )
 
   const onDropCb = useCallback(
@@ -584,7 +581,7 @@ export function useDropzone({
       event.persist()
       stopPropagation(event)
 
-      setDragTargets([])
+      dragTargetsRef.current = []
       dispatch({ type: 'reset' })
 
       if (isEvtWithFiles(event)) {


### PR DESCRIPTION
**What kind of change does this PR introduce?**

- [x] bugfix
- [ ] feature
- [ ] refactoring / style
- [ ] build / chore
- [ ] documentation

**Did you add tests for your changes?**

- [ ] Yes, my code is well tested
- [x] Not relevant

**If relevant, did you update the documentation?**

- [ ] Yes, I've updated the documentation
- [x] Not relevant

**Summary**

This is a potential fix for #876. Ideally, the dragged files stored in the component state would be replaced by a data structure that the browser isn't going to modify, but this would be a breaking change since `draggedFiles` gets returned by the `useDropzone` hook and thus can be used directly by consumers of this library. Instead, we can work around the problem by changing `dragTargets` to be stored in a ref rather than the state, which eliminates the re-render that occurs after `draggedFiles` has been cleared out by the browser and before a new `draggedFiles` gets returned. It's not a perfect solution, since the problem could still occur if a re-render is triggered due to other reasons during this time period.

**Does this PR introduce a breaking change?**
No

**Other information**
