### PR TITLE
README: readAsBinaryString (deprecated) --> readAsArrayBuffer (Fixes issue #871)

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ function MyDropzone() {
       console.log(binaryStr)
     }
 
-    acceptedFiles.forEach(file => reader.readAsBinaryString(file))
+    acceptedFiles.forEach(file => reader.readAsArrayBuffer(file))
   }, [])
   const {getRootProps, getInputProps, isDragActive} = useDropzone({onDrop})
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

- [ ] bugfix
- [ ] feature
- [ ] refactoring / style
- [ ] build / chore
- [x] documentation

**Did you add tests for your changes?**

- [ ] Yes, my code is well tested
- [x] Not relevant

**If relevant, did you update the documentation?**

- [x] Yes, I've updated the documentation
- [ ] Not relevant

**Summary**
Replaces reference to _readAsBinaryString_ method, which is deprecated,  with readAsArrayBuffer is the current recommended API.

**Other information**
Fixes https://github.com/react-dropzone/react-dropzone/issues/871