### PR TITLE
feat: adding single prop to override multiple

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "size-limit": [
     {
       "path": "dist/index.js",
-      "limit": "7 KB"
+      "limit": "7.03 KB"
     },
     {
       "path": "dist/es/index.js",
@@ -48,7 +48,9 @@
   },
   "jest": {
     "clearMocks": true,
-    "setupFilesAfterEnv": ["<rootDir>/testSetup.js"],
+    "setupFilesAfterEnv": [
+      "<rootDir>/testSetup.js"
+    ],
     "coveragePathIgnorePatterns": [
       "/dist/",
       "/node_modules/",

--- a/src/index.spec.js
+++ b/src/index.spec.js
@@ -49,7 +49,7 @@ describe('useDropzone() hook', () => {
       expect(input).toHaveAttribute('accept', accept)
     })
 
-    it('updates {multiple} prop on the <input> when it changes', () => {
+    it('updates {accept} prop on the <input> when it changes', () => {
       const { container, rerender } = render(
         <Dropzone accept="image/jpeg">
           {({ getRootProps, getInputProps }) => (
@@ -105,6 +105,48 @@ describe('useDropzone() hook', () => {
 
       rerender(
         <Dropzone multiple>
+          {({ getRootProps, getInputProps }) => (
+            <div {...getRootProps()}>
+              <input {...getInputProps()} />
+            </div>
+          )}
+        </Dropzone>
+      )
+
+      expect(container.querySelector('input')).toHaveAttribute('multiple')
+    })
+
+    it('sets {multiple} prop to negated {single} prop on the <input>', () => {
+      const { container } = render(
+        <Dropzone single>
+          {({ getRootProps, getInputProps }) => (
+            <div {...getRootProps()}>
+              <input {...getInputProps()} />
+            </div>
+          )}
+        </Dropzone>
+      )
+
+      const input = container.querySelector('input')
+      expect(input).not.toHaveAttribute('multiple')
+      expect(input).not.toHaveAttribute('single')
+    })
+
+    it('updates {multiple} prop on the <input> when {single} prop changes', () => {
+      const { container, rerender } = render(
+        <Dropzone single>
+          {({ getRootProps, getInputProps }) => (
+            <div {...getRootProps()}>
+              <input {...getInputProps()} />
+            </div>
+          )}
+        </Dropzone>
+      )
+
+      expect(container.querySelector('input')).not.toHaveAttribute('multiple')
+
+      rerender(
+        <Dropzone>
           {({ getRootProps, getInputProps }) => (
             <div {...getRootProps()}>
               <input {...getInputProps()} />

--- a/typings/react-dropzone.d.ts
+++ b/typings/react-dropzone.d.ts
@@ -23,6 +23,7 @@ export type DropzoneOptions = Pick<React.HTMLProps<HTMLElement>, PropTypes> & {
   onDropRejected?<T extends File>(files: T[], event: DropEvent): void;
   getFilesFromEvent?(event: DropEvent): Promise<Array<File | DataTransferItem>>;
   onFileDialogCancel?(): void;
+  single?: boolean;
 };
 
 export type DropEvent = React.DragEvent<HTMLElement> | React.ChangeEvent<HTMLInputElement> | DragEvent | Event;

--- a/typings/tests/all.tsx
+++ b/typings/tests/all.tsx
@@ -23,6 +23,7 @@ export default class Test extends React.Component {
           noDragEventsBubbling={false}
           disabled
           multiple={false}
+          single={false}
           accept="*.png"
         >
           {({getRootProps, getInputProps}) => (


### PR DESCRIPTION
**What kind of change does this PR introduce?**

- [ ] bugfix
- [x] feature
- [x] refactoring / style
- [ ] build / chore
- [ ] documentation

**Did you add tests for your changes?**

- [x] Yes, my code is well tested
- [ ] Not relevant

**If relevant, did you update the documentation?**

- [x] Yes, I've updated the documentation*
- [ ] Not relevant

*NOTE: I've updated the documentation around `single`, but not `multiple`. I think if these changes are acceptable, there is a path to deprecate `multiple` down the road, however it would eventually be a breaking change so it probably should not happen in this PR. One path forward might be to encourage usage of the `single` prop and provide warnings when the `multiple` prop is provided by the user.  I'm happy to update the docs to encourage the use of single over multiple if desired.

**Summary**

This allows an opt in shortcut prop of `single` to turn off the
default `multiple` prop.

Example:
```
// shortcut boolean single prop
<DropZone single>...</DropZone>
// versus old default true multiple prop
<DropZone multiple={false}>...</DropZone>
```

This works on the assumption that if a user is providing single, as
opposed to the default true value of multiple, they intend for the
component to work as `multiple={false}`.

If provided BOTH props with a true value, it seems reasonable that
since the default is already `multiple={true}`, the presence of
`single` is a signal that the user intends the component to be single.
Otherwise, there would be no way of discerning if `multiple === true`
is a product of the default value or the user explicitly including it.

**Misc**
Also fixed the name of a test that implies it is testing changes to the `multiple` prop, however it is testing changes to the `accept` prop.
