### PR TITLE
feat: add reject reasons to onDrop, onDropRejected callbacks

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -569,7 +569,6 @@ export function useDropzone({
       stopPropagation(event)
 
       dragTargetsRef.current = []
-      dispatch({ type: 'reset' })
 
       if (isEvtWithFiles(event)) {
         Promise.resolve(getFilesFromEvent(event)).then(files => {
@@ -611,6 +610,7 @@ export function useDropzone({
           }
         })
       }
+      dispatch({ type: 'reset' })
     },
     [
       multiple,
@@ -711,9 +711,8 @@ export function useDropzone({
   )
 
   const fileCount = draggedFiles.length
-  const isMultipleAllowed = multiple || fileCount <= 1
-  const isDragAccept = fileCount > 0 && allFilesAccepted(draggedFiles, accept, minSize, maxSize)
-  const isDragReject = fileCount > 0 && (!isDragAccept || !isMultipleAllowed)
+  const isDragAccept = fileCount > 0 && allFilesAccepted({ files: draggedFiles, accept, minSize, maxSize, multiple })
+  const isDragReject = fileCount > 0 && !isDragAccept
 
   return {
     ...state,
@@ -770,7 +769,9 @@ function reducer(state, action) {
         ...state,
         isFileDialogActive: false,
         isDragActive: false,
-        draggedFiles: []
+        draggedFiles: [],
+        acceptedFiles: [],
+        rejectedFiles: [],
       }
     default:
       return state

--- a/src/index.js
+++ b/src/index.js
@@ -779,7 +779,7 @@ function reducer(state, action) {
         isDragActive: false,
         draggedFiles: [],
         acceptedFiles: [],
-        rejectedFiles: [],
+        fileRejections: [],
       }
     default:
       return state

--- a/src/index.js
+++ b/src/index.js
@@ -20,7 +20,7 @@ import {
   isIeOrEdge,
   isPropagationStopped,
   onDocumentDragOver,
-  REJECTED_EXCESSIVE
+  TOO_MANY_FILES_REJECTION
 } from './utils/index'
 
 /**
@@ -594,7 +594,7 @@ export function useDropzone({
           if (!multiple && acceptedFiles.length > 1) {
             // Reject everything and empty accepted files
             acceptedFiles.forEach(file => {
-              fileRejections.push({ file, errors: [REJECTED_EXCESSIVE] })
+              fileRejections.push({ file, errors: [TOO_MANY_FILES_REJECTION] })
             })
             acceptedFiles.splice(0)
           }

--- a/src/index.spec.js
+++ b/src/index.spec.js
@@ -1749,7 +1749,7 @@ describe('useDropzone() hook', () => {
       expect(dropzone).toHaveTextContent('dragReject')
     })
 
-    it('sets {isDragActive, isDragAccept, isDragReject} if all files are accepted and {multiple} is false on dragenter', async () => {
+    it('sets {isDragActive, isDragAccept, isDragReject} if any files are rejected and {multiple} is false on dragenter', async () => {
       const ui = (
         <Dropzone accept="image/*" multiple={false}>
           {({ getRootProps, getInputProps, isDragActive, isDragAccept, isDragReject }) => (
@@ -1770,7 +1770,7 @@ describe('useDropzone() hook', () => {
       await flushPromises(ui, container)
 
       expect(dropzone).toHaveTextContent('dragActive')
-      expect(dropzone).toHaveTextContent('dragAccept')
+      expect(dropzone).not.toHaveTextContent('dragAccept')
       expect(dropzone).toHaveTextContent('dragReject')
     })
 

--- a/src/index.spec.js
+++ b/src/index.spec.js
@@ -741,7 +741,7 @@ describe('useDropzone() hook', () => {
 
       Object.keys(innerProps).forEach(prop =>
         innerProps[prop].mockImplementation((...args) => {
-          const event = prop === 'onDrop' ? args.pop() : args.shift()
+          const event = prop === 'onDrop' ? args[2] : args[0]
           event.stopPropagation()
         })
       )
@@ -1911,7 +1911,7 @@ describe('useDropzone() hook', () => {
       dispatchEvt(input, 'change')
       await flushPromises(ui, container)
 
-      expect(onDropSpy).toHaveBeenCalledWith(files, [], expect.anything())
+      expect(onDropSpy).toHaveBeenCalledWith(files, [], expect.anything(), [])
     })
 
     it('sets {acceptedFiles, rejectedFiles}', async () => {
@@ -2005,7 +2005,7 @@ describe('useDropzone() hook', () => {
 
       fireDrop(dropzone, createDtWithFiles(files))
       await flushPromises(ui, container)
-      expect(onDropSpy).toHaveBeenCalledWith([], files, expect.anything())
+      expect(onDropSpy).toHaveBeenCalledWith([], files, expect.anything(), [{code: 'file-invalid-type', file: files[0], message: 'File type must be image/*'}])
     })
 
     it('rejects all files if {multiple} is false and {accept} criteria is met', async () => {
@@ -2024,7 +2024,7 @@ describe('useDropzone() hook', () => {
 
       fireDrop(dropzone, createDtWithFiles(images))
       await flushPromises(ui, container)
-      expect(onDropSpy).toHaveBeenCalledWith([], images, expect.anything())
+      expect(onDropSpy).toHaveBeenCalledWith([], images, expect.anything(), [{code: 'file-excessive', file: images[0], message: 'Too many files'}, {code: 'file-excessive', file: images[1], message: 'Too many files'}])
     })
 
     it('accepts a single files if {multiple} is false and {accept} criteria is met', async () => {
@@ -2044,7 +2044,7 @@ describe('useDropzone() hook', () => {
       const [image] = images
       fireDrop(dropzone, createDtWithFiles([image]))
       await flushPromises(ui, container)
-      expect(onDropSpy).toHaveBeenCalledWith([image], [], expect.anything())
+      expect(onDropSpy).toHaveBeenCalledWith([image], [], expect.anything(), [])
     })
 
     it('accepts all files if {multiple} is true', async () => {
@@ -2063,7 +2063,7 @@ describe('useDropzone() hook', () => {
 
       fireDrop(dropzone, createDtWithFiles(files))
       await flushPromises(ui, container)
-      expect(onDropSpy).toHaveBeenCalledWith(files, [], expect.anything())
+      expect(onDropSpy).toHaveBeenCalledWith(files, [], expect.anything(), [])
     })
 
     it('resets {isFileDialogActive} state', async () => {
@@ -2115,17 +2115,17 @@ describe('useDropzone() hook', () => {
 
       fireDrop(dropzone, createDtWithFiles(files))
       await flushPromises(ui, container)
-      expect(onDropSpy).toHaveBeenCalledWith([], files, expect.anything())
+      expect(onDropSpy).toHaveBeenCalledWith([], files, expect.anything(), [{code: 'file-invalid-type', file: files[0], message: 'File type must be image/*'}])
       onDropSpy.mockClear()
 
       fireDrop(dropzone, createDtWithFiles(images))
       await flushPromises(ui, container)
-      expect(onDropSpy).toHaveBeenCalledWith(images, [], expect.anything())
+      expect(onDropSpy).toHaveBeenCalledWith(images, [], expect.anything(), [])
       onDropSpy.mockClear()
 
       fireDrop(dropzone, createDtWithFiles([...files, ...images]))
       await flushPromises(ui, container)
-      expect(onDropSpy).toHaveBeenCalledWith(images, files, expect.anything())
+      expect(onDropSpy).toHaveBeenCalledWith(images, files, expect.anything(), [{code: 'file-invalid-type', file: files[0], message: 'File type must be image/*'}])
     })
 
     test('onDropAccepted callback is invoked if some files are accepted', async () => {
@@ -2173,7 +2173,7 @@ describe('useDropzone() hook', () => {
 
       fireDrop(dropzone, createDtWithFiles(files))
       await flushPromises(ui, container)
-      expect(onDropRejectedSpy).toHaveBeenCalledWith(files, expect.anything())
+      expect(onDropRejectedSpy).toHaveBeenCalledWith(files, expect.anything(), [{code: 'file-invalid-type', file: files[0], message: 'File type must be image/*'}])
       onDropRejectedSpy.mockClear()
 
       fireDrop(dropzone, createDtWithFiles(images))
@@ -2183,7 +2183,7 @@ describe('useDropzone() hook', () => {
 
       fireDrop(dropzone, createDtWithFiles([...files, ...images]))
       await flushPromises(ui, container)
-      expect(onDropRejectedSpy).toHaveBeenCalledWith(files, expect.anything())
+      expect(onDropRejectedSpy).toHaveBeenCalledWith(files, expect.anything(), [{code: 'file-invalid-type', file: files[0], message: 'File type must be image/*'}])
     })
 
     it('accepts a dropped image when Firefox provides a bogus file type', async () => {
@@ -2204,7 +2204,7 @@ describe('useDropzone() hook', () => {
       fireDrop(dropzone, createDtWithFiles(images))
       await flushPromises(ui, container)
 
-      expect(onDropSpy).toHaveBeenCalledWith(images, [], expect.anything())
+      expect(onDropSpy).toHaveBeenCalledWith(images, [], expect.anything(), [])
     })
 
     it('filters files according to {maxSize}', async () => {
@@ -2224,7 +2224,7 @@ describe('useDropzone() hook', () => {
       fireDrop(dropzone, createDtWithFiles(images))
       await flushPromises(ui, container)
 
-      expect(onDropSpy).toHaveBeenCalledWith([], images, expect.anything())
+      expect(onDropSpy).toHaveBeenCalledWith([], images, expect.anything(), [{code: 'file-too-large', file: images[0], message: 'File is larger than 1111 bytes'}, {code: 'file-too-large', file: images[1], message: 'File is larger than 1111 bytes'}])
     })
 
     it('filters files according to {minSize}', async () => {
@@ -2244,7 +2244,7 @@ describe('useDropzone() hook', () => {
       fireDrop(dropzone, createDtWithFiles(files))
       await flushPromises(ui, container)
 
-      expect(onDropSpy).toHaveBeenCalledWith([], files, expect.anything())
+      expect(onDropSpy).toHaveBeenCalledWith([], files, expect.anything(), [{code: 'file-too-small', file: files[0], message: 'File is smaller than 1112 bytes'}])
     })
   })
 

--- a/src/index.spec.js
+++ b/src/index.spec.js
@@ -741,7 +741,7 @@ describe('useDropzone() hook', () => {
 
       Object.keys(innerProps).forEach(prop =>
         innerProps[prop].mockImplementation((...args) => {
-          const event = prop === 'onDrop' ? args[2] : args[0]
+          const event = prop === 'onDrop' ? args.pop() : args.shift()
           event.stopPropagation()
         })
       )
@@ -1911,7 +1911,7 @@ describe('useDropzone() hook', () => {
       dispatchEvt(input, 'change')
       await flushPromises(ui, container)
 
-      expect(onDropSpy).toHaveBeenCalledWith(files, [], expect.anything(), [])
+      expect(onDropSpy).toHaveBeenCalledWith(files, [], expect.anything())
     })
 
     it('sets {acceptedFiles, rejectedFiles}', async () => {
@@ -1932,11 +1932,11 @@ describe('useDropzone() hook', () => {
 
       const ui = (
         <Dropzone accept="image/*">
-          {({ getRootProps, getInputProps, acceptedFiles, rejectedFiles }) => (
+          {({ getRootProps, getInputProps, acceptedFiles, fileRejections }) => (
             <div {...getRootProps()}>
               <input {...getInputProps()} />
               <FileList files={acceptedFiles} type="accepted" />
-              <FileList files={rejectedFiles} type="rejected" />
+              <FileList files={fileRejections.map(rejection => rejection.file)} type="rejected" />
             </div>
           )}
         </Dropzone>
@@ -2005,7 +2005,17 @@ describe('useDropzone() hook', () => {
 
       fireDrop(dropzone, createDtWithFiles(files))
       await flushPromises(ui, container)
-      expect(onDropSpy).toHaveBeenCalledWith([], files, expect.anything(), [{code: 'file-invalid-type', file: files[0], message: 'File type must be image/*'}])
+      expect(onDropSpy).toHaveBeenCalledWith([], [
+        {
+          file: files[0],
+          errors: [
+            {
+              code: 'file-invalid-type',
+              message: 'File type must be image/*',
+            }
+          ]
+        }
+      ], expect.anything())
     })
 
     it('rejects all files if {multiple} is false and {accept} criteria is met', async () => {
@@ -2024,7 +2034,26 @@ describe('useDropzone() hook', () => {
 
       fireDrop(dropzone, createDtWithFiles(images))
       await flushPromises(ui, container)
-      expect(onDropSpy).toHaveBeenCalledWith([], images, expect.anything(), [{code: 'file-excessive', file: images[0], message: 'Too many files'}, {code: 'file-excessive', file: images[1], message: 'Too many files'}])
+      expect(onDropSpy).toHaveBeenCalledWith([], [
+        {
+          file: images[0],
+          errors: [
+            {
+              code: 'file-excessive',
+              message: 'Too many files',
+            }
+          ]
+        },
+        {
+          file: images[1],
+          errors: [
+            {
+              code: 'file-excessive',
+              message: 'Too many files',
+            }
+          ]
+        }
+      ], expect.anything())
     })
 
     it('accepts a single files if {multiple} is false and {accept} criteria is met', async () => {
@@ -2044,7 +2073,7 @@ describe('useDropzone() hook', () => {
       const [image] = images
       fireDrop(dropzone, createDtWithFiles([image]))
       await flushPromises(ui, container)
-      expect(onDropSpy).toHaveBeenCalledWith([image], [], expect.anything(), [])
+      expect(onDropSpy).toHaveBeenCalledWith([image], [], expect.anything())
     })
 
     it('accepts all files if {multiple} is true', async () => {
@@ -2063,7 +2092,7 @@ describe('useDropzone() hook', () => {
 
       fireDrop(dropzone, createDtWithFiles(files))
       await flushPromises(ui, container)
-      expect(onDropSpy).toHaveBeenCalledWith(files, [], expect.anything(), [])
+      expect(onDropSpy).toHaveBeenCalledWith(files, [], expect.anything())
     })
 
     it('resets {isFileDialogActive} state', async () => {
@@ -2115,17 +2144,37 @@ describe('useDropzone() hook', () => {
 
       fireDrop(dropzone, createDtWithFiles(files))
       await flushPromises(ui, container)
-      expect(onDropSpy).toHaveBeenCalledWith([], files, expect.anything(), [{code: 'file-invalid-type', file: files[0], message: 'File type must be image/*'}])
+      expect(onDropSpy).toHaveBeenCalledWith([], [
+        {
+          file: files[0],
+          errors: [
+            {
+              code: 'file-invalid-type',
+              message: 'File type must be image/*',
+            }
+          ]
+        }
+      ], expect.anything())
       onDropSpy.mockClear()
 
       fireDrop(dropzone, createDtWithFiles(images))
       await flushPromises(ui, container)
-      expect(onDropSpy).toHaveBeenCalledWith(images, [], expect.anything(), [])
+      expect(onDropSpy).toHaveBeenCalledWith(images, [], expect.anything())
       onDropSpy.mockClear()
 
       fireDrop(dropzone, createDtWithFiles([...files, ...images]))
       await flushPromises(ui, container)
-      expect(onDropSpy).toHaveBeenCalledWith(images, files, expect.anything(), [{code: 'file-invalid-type', file: files[0], message: 'File type must be image/*'}])
+      expect(onDropSpy).toHaveBeenCalledWith(images, [
+        {
+          file: files[0],
+          errors: [
+            {
+              code: 'file-invalid-type',
+              message: 'File type must be image/*'
+            }
+          ]
+        }
+      ], expect.anything())
     })
 
     test('onDropAccepted callback is invoked if some files are accepted', async () => {
@@ -2173,7 +2222,17 @@ describe('useDropzone() hook', () => {
 
       fireDrop(dropzone, createDtWithFiles(files))
       await flushPromises(ui, container)
-      expect(onDropRejectedSpy).toHaveBeenCalledWith(files, expect.anything(), [{code: 'file-invalid-type', file: files[0], message: 'File type must be image/*'}])
+      expect(onDropRejectedSpy).toHaveBeenCalledWith([
+        {
+          file: files[0],
+          errors: [
+            {
+              code: 'file-invalid-type',
+              message: 'File type must be image/*',
+            }
+          ]
+        }
+      ], expect.anything())
       onDropRejectedSpy.mockClear()
 
       fireDrop(dropzone, createDtWithFiles(images))
@@ -2183,7 +2242,17 @@ describe('useDropzone() hook', () => {
 
       fireDrop(dropzone, createDtWithFiles([...files, ...images]))
       await flushPromises(ui, container)
-      expect(onDropRejectedSpy).toHaveBeenCalledWith(files, expect.anything(), [{code: 'file-invalid-type', file: files[0], message: 'File type must be image/*'}])
+      expect(onDropRejectedSpy).toHaveBeenCalledWith([
+        {
+          file: files[0],
+          errors: [
+            {
+              code: 'file-invalid-type',
+              message: 'File type must be image/*',
+            }
+          ]
+        }
+      ], expect.anything())
     })
 
     it('accepts a dropped image when Firefox provides a bogus file type', async () => {
@@ -2204,7 +2273,7 @@ describe('useDropzone() hook', () => {
       fireDrop(dropzone, createDtWithFiles(images))
       await flushPromises(ui, container)
 
-      expect(onDropSpy).toHaveBeenCalledWith(images, [], expect.anything(), [])
+      expect(onDropSpy).toHaveBeenCalledWith(images, [], expect.anything())
     })
 
     it('filters files according to {maxSize}', async () => {
@@ -2224,7 +2293,26 @@ describe('useDropzone() hook', () => {
       fireDrop(dropzone, createDtWithFiles(images))
       await flushPromises(ui, container)
 
-      expect(onDropSpy).toHaveBeenCalledWith([], images, expect.anything(), [{code: 'file-too-large', file: images[0], message: 'File is larger than 1111 bytes'}, {code: 'file-too-large', file: images[1], message: 'File is larger than 1111 bytes'}])
+      expect(onDropSpy).toHaveBeenCalledWith([], [
+        {
+          file: images[0],
+          errors: [
+            {
+              code: 'file-too-large',
+              message: 'File is larger than 1111 bytes',
+            }
+          ]
+        },
+        {
+          file: images[1],
+          errors: [
+            {
+              code: 'file-too-large',
+              message: 'File is larger than 1111 bytes',
+            }
+          ]
+        },
+      ], expect.anything())
     })
 
     it('filters files according to {minSize}', async () => {
@@ -2244,7 +2332,17 @@ describe('useDropzone() hook', () => {
       fireDrop(dropzone, createDtWithFiles(files))
       await flushPromises(ui, container)
 
-      expect(onDropSpy).toHaveBeenCalledWith([], files, expect.anything(), [{code: 'file-too-small', file: files[0], message: 'File is smaller than 1112 bytes'}])
+      expect(onDropSpy).toHaveBeenCalledWith([], [
+        {
+          file: files[0],
+          errors: [
+            {
+              code: 'file-too-small',
+              message: 'File is smaller than 1112 bytes',
+            }
+          ]
+        }
+      ], expect.anything())
     })
   })
 

--- a/src/index.spec.js
+++ b/src/index.spec.js
@@ -2039,7 +2039,7 @@ describe('useDropzone() hook', () => {
           file: images[0],
           errors: [
             {
-              code: 'file-excessive',
+              code: 'too-many-files',
               message: 'Too many files',
             }
           ]
@@ -2048,7 +2048,7 @@ describe('useDropzone() hook', () => {
           file: images[1],
           errors: [
             {
-              code: 'file-excessive',
+              code: 'too-many-files',
               message: 'Too many files',
             }
           ]

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -22,7 +22,11 @@ function isDefined(value) {
   return value !== undefined && value !== null
 }
 
-export function allFilesAccepted(files, accept, minSize, maxSize) {
+export function allFilesAccepted({ files, accept, minSize, maxSize, multiple }) {
+  if (!multiple && files.length > 1) {
+    return false;
+  }
+
   return files.every(file => {
     return fileAccepted(file, accept) && fileMatchSize(file, minSize, maxSize)
   })

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -7,7 +7,7 @@ export const FILE_TOO_SMALL = 'file-too-small'
 export const TOO_MANY_FILES = 'too-many-files'
 
 // File Errors
-export const getInvalidTypeRejectionMsg = accept => {
+export const getInvalidTypeRejectionErr = accept => {
   accept = Array.isArray(accept) && accept.length === 1 ? accept[0] : accept
   const messageSuffix = Array.isArray(accept) ? `one of ${accept.join(', ')}` : accept
   return {
@@ -16,14 +16,14 @@ export const getInvalidTypeRejectionMsg = accept => {
   }
 }
 
-export const getTooLargeRejectionMsg = maxSize => {
+export const getTooLargeRejectionErr = maxSize => {
   return {
     code: FILE_TOO_LARGE,
     message: `File is larger than ${maxSize} bytes`
   }
 }
 
-export const getTooSmallRejectionMsg = minSize => {
+export const getTooSmallRejectionErr = minSize => {
   return {
     code: FILE_TOO_SMALL,
     message: `File is smaller than ${minSize} bytes`
@@ -39,18 +39,18 @@ export const TOO_MANY_FILES_REJECTION = {
 // that MIME type will always be accepted
 export function fileAccepted(file, accept) {
   const isAcceptable = file.type === 'application/x-moz-file' || accepts(file, accept)
-  return [isAcceptable, isAcceptable ? null : getInvalidTypeRejectionMsg(accept)]
+  return [isAcceptable, isAcceptable ? null : getInvalidTypeRejectionErr(accept)]
 }
 
 export function fileMatchSize(file, minSize, maxSize) {
   if (isDefined(file.size)) {
     if (isDefined(minSize) && isDefined(maxSize)) {
-      if (file.size > maxSize) return [false, getTooLargeRejectionMsg(maxSize)]
-      if (file.size < minSize) return [false, getTooSmallRejectionMsg(minSize)]
+      if (file.size > maxSize) return [false, getTooLargeRejectionErr(maxSize)]
+      if (file.size < minSize) return [false, getTooSmallRejectionErr(minSize)]
     } else if (isDefined(minSize) && file.size < minSize)
-      return [false, getTooSmallRejectionMsg(minSize)]
+      return [false, getTooSmallRejectionErr(minSize)]
     else if (isDefined(maxSize) && file.size > maxSize)
-      return [false, getTooLargeRejectionMsg(maxSize)]
+      return [false, getTooLargeRejectionErr(maxSize)]
   }
   return [true, null]
 }

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -2,6 +2,7 @@ import accepts from 'attr-accept'
 
 export const REJECT_REASONS = {
   INVALID_TYPE: accept => {
+    accept = Array.isArray(accept) && accept.length === 1 ? accept[0] : accept;
     const messageSuffix = Array.isArray(accept) ? `one of ${accept.join(', ')}` : accept
     return {
       code: 'file-invalid-type',
@@ -32,7 +33,7 @@ export const REJECT_REASONS = {
 // that MIME type will always be accepted
 export function fileAccepted(file, accept) {
   const isAcceptable = file.type === 'application/x-moz-file' || accepts(file, accept)
-  return isAcceptable ? [isAcceptable, null] : [false, REJECT_REASONS.INVALID_TYPE(accept)]
+  return isAcceptable ? [isAcceptable, null] : [isAcceptable, REJECT_REASONS.INVALID_TYPE(accept)]
 }
 
 export function fileMatchSize(file, minSize, maxSize) {

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -1,21 +1,49 @@
 import accepts from 'attr-accept'
 
+export const REJECT_REASONS = {
+  INVALID_TYPE: accept => {
+    const messageSuffix = Array.isArray(accept) ? `one of ${accept.join(', ')}` : accept
+    return {
+      code: 'file-invalid-type',
+      message: `File type must be ${messageSuffix}`
+    }
+  },
+  TOO_LARGE: maxSize => {
+    return {
+      code: 'file-too-large',
+      message: `File is larger than ${maxSize} bytes`
+    }
+  },
+  TOO_SMALL: minSize => {
+    return {
+      code: 'file-too-small',
+      message: `File is smaller than ${minSize} bytes`
+    }
+  },
+  TOO_MANY: () => {
+    return {
+      code: 'file-excessive',
+      message: 'Too many files'
+    }
+  }
+}
+
 // Firefox versions prior to 53 return a bogus MIME type for every file drag, so dragovers with
 // that MIME type will always be accepted
 export function fileAccepted(file, accept) {
-  return file.type === 'application/x-moz-file' || accepts(file, accept)
+  const isAcceptable = file.type === 'application/x-moz-file' || accepts(file, accept)
+  return isAcceptable ? [isAcceptable, null] : [false, REJECT_REASONS.INVALID_TYPE(accept)]
 }
 
 export function fileMatchSize(file, minSize, maxSize) {
   if (isDefined(file.size)) {
-    if (isDefined(minSize) && isDefined(maxSize))
-      return file.size >= minSize && file.size <= maxSize
-    else if (isDefined(minSize))
-      return file.size >= minSize
-    else if (isDefined(maxSize))
-      return file.size <= maxSize
+    if (isDefined(minSize) && isDefined(maxSize)) {
+      if (file.size > maxSize) return [false, REJECT_REASONS.TOO_LARGE(maxSize)]
+      if (file.size < minSize) return [false, REJECT_REASONS.TOO_SMALL(minSize)]
+    } else if (isDefined(minSize) && file.size < minSize) return [false, REJECT_REASONS.TOO_SMALL(minSize)]
+    else if (isDefined(maxSize) && file.size > maxSize) return [false, REJECT_REASONS.TOO_LARGE(maxSize)]
   }
-  return true
+  return [true, null]
 }
 
 function isDefined(value) {
@@ -28,7 +56,9 @@ export function allFilesAccepted({ files, accept, minSize, maxSize, multiple }) 
   }
 
   return files.every(file => {
-    return fileAccepted(file, accept) && fileMatchSize(file, minSize, maxSize)
+    const [accepted] = fileAccepted(file, accept)
+    const [sizeMatch] = fileMatchSize(file, minSize, maxSize)
+    return accepted && sizeMatch
   })
 }
 

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -4,10 +4,10 @@ import accepts from 'attr-accept'
 export const FILE_INVALID_TYPE = 'file-invalid-type'
 export const FILE_TOO_LARGE = 'file-too-large'
 export const FILE_TOO_SMALL = 'file-too-small'
-export const FILE_EXCESSIVE = 'file-excessive'
+export const TOO_MANY_FILES = 'too-many-files'
 
 // File Errors
-export const REJECTED_INVALID_TYPE = accept => {
+export const getInvalidTypeRejectionMsg = accept => {
   accept = Array.isArray(accept) && accept.length === 1 ? accept[0] : accept
   const messageSuffix = Array.isArray(accept) ? `one of ${accept.join(', ')}` : accept
   return {
@@ -16,22 +16,22 @@ export const REJECTED_INVALID_TYPE = accept => {
   }
 }
 
-export const REJECTED_TOO_LARGE = maxSize => {
+export const getTooLargeRejectionMsg = maxSize => {
   return {
     code: FILE_TOO_LARGE,
     message: `File is larger than ${maxSize} bytes`
   }
 }
 
-export const REJECTED_TOO_SMALL = minSize => {
+export const getTooSmallRejectionMsg = minSize => {
   return {
     code: FILE_TOO_SMALL,
     message: `File is smaller than ${minSize} bytes`
   }
 }
 
-export const REJECTED_EXCESSIVE = {
-  code: 'file-excessive',
+export const TOO_MANY_FILES_REJECTION = {
+  code: TOO_MANY_FILES,
   message: 'Too many files'
 }
 
@@ -39,18 +39,18 @@ export const REJECTED_EXCESSIVE = {
 // that MIME type will always be accepted
 export function fileAccepted(file, accept) {
   const isAcceptable = file.type === 'application/x-moz-file' || accepts(file, accept)
-  return [isAcceptable, isAcceptable ? null : REJECTED_INVALID_TYPE(accept)]
+  return [isAcceptable, isAcceptable ? null : getInvalidTypeRejectionMsg(accept)]
 }
 
 export function fileMatchSize(file, minSize, maxSize) {
   if (isDefined(file.size)) {
     if (isDefined(minSize) && isDefined(maxSize)) {
-      if (file.size > maxSize) return [false, REJECTED_TOO_LARGE(maxSize)]
-      if (file.size < minSize) return [false, REJECTED_TOO_SMALL(minSize)]
+      if (file.size > maxSize) return [false, getTooLargeRejectionMsg(maxSize)]
+      if (file.size < minSize) return [false, getTooSmallRejectionMsg(minSize)]
     } else if (isDefined(minSize) && file.size < minSize)
-      return [false, REJECTED_TOO_SMALL(minSize)]
+      return [false, getTooSmallRejectionMsg(minSize)]
     else if (isDefined(maxSize) && file.size > maxSize)
-      return [false, REJECTED_TOO_LARGE(maxSize)]
+      return [false, getTooLargeRejectionMsg(maxSize)]
   }
   return [true, null]
 }

--- a/src/utils/index.spec.js
+++ b/src/utils/index.spec.js
@@ -223,6 +223,11 @@ describe('fileAccepted', () => {
     expect(utils.fileAccepted(file, ['.gif', '.png'])).toEqual([false, { code: 'file-invalid-type', message: 'File type must be one of .gif, .png' }])
   })
 
+it('rejects file when single accept criteria as array', () => {
+  const file = createFile('hamster.pdf', 100, 'application/pdf');
+  expect(utils.fileAccepted(file, ['.gif'])).toEqual([false, { code: 'file-invalid-type', message: 'File type must be .gif' }])
+})
+
 })
 
 function createFile(name, size, type) {

--- a/src/utils/index.spec.js
+++ b/src/utils/index.spec.js
@@ -11,32 +11,32 @@ describe('fileMatchSize()', () => {
   })
 
   it('should return true if the file object doesn\'t have a {size} property', () => {
-    expect(utils.fileMatchSize({})).toBe(true)
-    expect(utils.fileMatchSize({size: null})).toBe(true)
+    expect(utils.fileMatchSize({})).toEqual([true, null])
+    expect(utils.fileMatchSize({size: null})).toEqual([true, null])
   })
 
   it('should return true if the minSize and maxSize were not provided', () => {
-    expect(utils.fileMatchSize({size: 100})).toBe(true)
-    expect(utils.fileMatchSize({size: 100}, undefined, undefined)).toBe(true)
-    expect(utils.fileMatchSize({size: 100}, null, null)).toBe(true)
+    expect(utils.fileMatchSize({size: 100})).toEqual([true, null])
+    expect(utils.fileMatchSize({size: 100}, undefined, undefined)).toEqual([true, null])
+    expect(utils.fileMatchSize({size: 100}, null, null)).toEqual([true, null])
   })
 
   it('should return true if the file {size} is within the [minSize, maxSize] range', () => {
-    expect(utils.fileMatchSize({size: 100}, 10, 200)).toBe(true)
-    expect(utils.fileMatchSize({size: 100}, 10, 99)).toBe(false)
-    expect(utils.fileMatchSize({size: 100}, 101, 200)).toBe(false)
+    expect(utils.fileMatchSize({size: 100}, 10, 200)).toEqual([true, null])
+    expect(utils.fileMatchSize({size: 100}, 10, 99)).toEqual([false, { code: 'file-too-large', message: 'File is larger than 99 bytes' }])
+    expect(utils.fileMatchSize({size: 100}, 101, 200)).toEqual([false, { code: 'file-too-small', message: 'File is smaller than 101 bytes' }])
   })
 
   it('should return true if the file {size} is more than minSize', () => {
-    expect(utils.fileMatchSize({size: 100}, 100)).toBe(true)
-    expect(utils.fileMatchSize({size: 100}, 101)).toBe(false)
+    expect(utils.fileMatchSize({size: 100}, 100)).toEqual([true, null])
+    expect(utils.fileMatchSize({size: 100}, 101)).toEqual([false, { code: 'file-too-small', message: 'File is smaller than 101 bytes' }])
   })
 
   it('should return true if the file {size} is less than maxSize', () => {
-    expect(utils.fileMatchSize({size: 100}, undefined, 100)).toBe(true)
-    expect(utils.fileMatchSize({size: 100}, null, 100)).toBe(true)
-    expect(utils.fileMatchSize({size: 100}, undefined, 99)).toBe(false)
-    expect(utils.fileMatchSize({size: 100}, null, 99)).toBe(false)
+    expect(utils.fileMatchSize({size: 100}, undefined, 100)).toEqual([true, null])
+    expect(utils.fileMatchSize({size: 100}, null, 100)).toEqual([true, null])
+    expect(utils.fileMatchSize({size: 100}, undefined, 99)).toEqual([false, { code: 'file-too-large', message: 'File is larger than 99 bytes' }])
+    expect(utils.fileMatchSize({size: 100}, null, 99)).toEqual([false, { code: 'file-too-large', message: 'File is larger than 99 bytes' }])
   })
 })
 
@@ -190,3 +190,48 @@ describe('composeEventHandlers', () => {
     expect(fn2).not.toHaveBeenCalled()
   })
 })
+
+describe('fileAccepted', () => {
+  let utils
+  beforeEach(async done => {
+    utils = await import('./index')
+    done()
+  })
+
+  it('accepts bogus firefox file', () => {
+    const file = createFile('bogus.png', 100, 'application/x-moz-file');
+    expect(utils.fileAccepted(file, '.pdf')).toEqual([true, null])
+  })
+
+  it('accepts file when single accept criteria', () => {
+    const file = createFile('hamster.pdf', 100, 'application/pdf');
+    expect(utils.fileAccepted(file, '.pdf')).toEqual([true, null])
+  })
+
+  it('accepts file when multiple accept criteria', () => {
+    const file = createFile('hamster.pdf', 100, 'application/pdf');
+    expect(utils.fileAccepted(file, ['.pdf', '.png'])).toEqual([true, null])
+  })
+
+  it('rejects file when single accept criteria', () => {
+    const file = createFile('hamster.pdf', 100, 'application/pdf');
+    expect(utils.fileAccepted(file, '.png')).toEqual([false, { code: 'file-invalid-type', message: 'File type must be .png' }])
+  })
+
+  it('rejects file when multiple accept criteria', () => {
+    const file = createFile('hamster.pdf', 100, 'application/pdf');
+    expect(utils.fileAccepted(file, ['.gif', '.png'])).toEqual([false, { code: 'file-invalid-type', message: 'File type must be one of .gif, .png' }])
+  })
+
+})
+
+function createFile(name, size, type) {
+  const file = new File([], name, { type })
+  Object.defineProperty(file, 'size', {
+    get() {
+      return size
+    }
+  })
+  return file
+}
+

--- a/typings/react-dropzone.d.ts
+++ b/typings/react-dropzone.d.ts
@@ -8,6 +8,11 @@ export interface DropzoneProps extends DropzoneOptions {
   children?(state: DropzoneState): JSX.Element;
 }
 
+export interface FileError extends Error {
+  message: string;
+  code: string;
+  file: File;
+}
 export type DropzoneOptions = Pick<React.HTMLProps<HTMLElement>, PropTypes> & {
   accept?: string | string[];
   minSize?: number;
@@ -18,9 +23,9 @@ export type DropzoneOptions = Pick<React.HTMLProps<HTMLElement>, PropTypes> & {
   noDrag?: boolean;
   noDragEventsBubbling?: boolean;
   disabled?: boolean;
-  onDrop?<T extends File>(acceptedFiles: T[], rejectedFiles: T[], event: DropEvent): void;
+  onDrop?<T extends File>(acceptedFiles: T[], rejectedFiles: T[], event: DropEvent, rejectReasons: FileError[]): void;
   onDropAccepted?<T extends File>(files: T[], event: DropEvent): void;
-  onDropRejected?<T extends File>(files: T[], event: DropEvent): void;
+  onDropRejected?<T extends File>(files: T[], event: DropEvent, rejectReasons: FileError[]): void;
   getFilesFromEvent?(event: DropEvent): Promise<Array<File | DataTransferItem>>;
   onFileDialogCancel?(): void;
 };
@@ -36,6 +41,7 @@ export type DropzoneState = DropzoneRef & {
   draggedFiles: File[];
   acceptedFiles: File[];
   rejectedFiles: File[];
+  rejectReasons: FileError[];
   rootRef: React.RefObject<HTMLElement>;
   inputRef: React.RefObject<HTMLInputElement>;
   getRootProps(props?: DropzoneRootProps): DropzoneRootProps;

--- a/typings/react-dropzone.d.ts
+++ b/typings/react-dropzone.d.ts
@@ -8,11 +8,16 @@ export interface DropzoneProps extends DropzoneOptions {
   children?(state: DropzoneState): JSX.Element;
 }
 
-export interface FileError extends Error {
+export interface FileError {
   message: string;
   code: string;
-  file: File;
 }
+
+export interface FileRejection {
+  file: File;
+  errors: FileError[];
+}
+
 export type DropzoneOptions = Pick<React.HTMLProps<HTMLElement>, PropTypes> & {
   accept?: string | string[];
   minSize?: number;
@@ -23,9 +28,9 @@ export type DropzoneOptions = Pick<React.HTMLProps<HTMLElement>, PropTypes> & {
   noDrag?: boolean;
   noDragEventsBubbling?: boolean;
   disabled?: boolean;
-  onDrop?<T extends File>(acceptedFiles: T[], rejectedFiles: T[], event: DropEvent, rejectReasons: FileError[]): void;
+  onDrop?<T extends File>(acceptedFiles: T[], fileRejections: FileRejection[], event: DropEvent): void;
   onDropAccepted?<T extends File>(files: T[], event: DropEvent): void;
-  onDropRejected?<T extends File>(files: T[], event: DropEvent, rejectReasons: FileError[]): void;
+  onDropRejected?(fileRejections: FileRejection[], event: DropEvent): void;
   getFilesFromEvent?(event: DropEvent): Promise<Array<File | DataTransferItem>>;
   onFileDialogCancel?(): void;
 };
@@ -40,8 +45,7 @@ export type DropzoneState = DropzoneRef & {
   isFileDialogActive: boolean;
   draggedFiles: File[];
   acceptedFiles: File[];
-  rejectedFiles: File[];
-  rejectReasons: FileError[];
+  fileRejections: FileRejection[];
   rootRef: React.RefObject<HTMLElement>;
   inputRef: React.RefObject<HTMLInputElement>;
   getRootProps(props?: DropzoneRootProps): DropzoneRootProps;


### PR DESCRIPTION
**What kind of change does this PR introduce?**

- [ ] bugfix
- [X ] feature
- [ ] refactoring / style
- [ ] build / chore
- [ ] documentation

**Did you add tests for your changes?**

- [X ] Yes, my code is well tested
- [ ] Not relevant

**If relevant, did you update the documentation?**
- I will update the documentation in a separate PR once this PR is merged. *Question for maintainers:* That PR should go to the `gh-pages` branch, correct?

**Summary**

See conversation in #752 

**Does this PR introduce a breaking change?**
Yes. The method signatures of `onDrop` and `onDropRejected` as well as the return value of `useDropzone` were changed in order to add the reasons why rejected files were rejected.

## onDrop Changes
`onDrop` BEFORE this change:

```
onDrop?<T extends File>(acceptedFiles: T[], rejectedFiles: T[], event: DropEvent): void;
```

`onDrop` AFTER this change:

```
onDrop?<T extends File>(acceptedFiles: T[], fileRejections: FileRejection[], event: DropEvent): void;
```
## onDropRejected changes

`onDropRejected` BEFORE this change:

```
onDropRejected?<T extends File>(files: T[], event: DropEvent): void;
```

`onDropRejected` AFTER this change:

```
onDropRejected?(fileRejections: FileRejection[], event: DropEvent): void;
```
## useDropzone changes
`rejectedFiles` from the return value of `useDropzone` was replaced with `fileRejections`.

## Additional Information
The definition of a `FileRejection` is:
```
export interface FileError {
  message: string;
  code: string;
}

export interface FileRejection {
  file: File;
  errors: FileError[];
}
```
closes #752 
