### PR TITLE
fix: isDragReject consistent with onDrop, close #921

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -569,7 +569,6 @@ export function useDropzone({
       stopPropagation(event)
 
       dragTargetsRef.current = []
-      dispatch({ type: 'reset' })
 
       if (isEvtWithFiles(event)) {
         Promise.resolve(getFilesFromEvent(event)).then(files => {
@@ -611,6 +610,7 @@ export function useDropzone({
           }
         })
       }
+      dispatch({ type: 'reset' })
     },
     [
       multiple,
@@ -711,9 +711,8 @@ export function useDropzone({
   )
 
   const fileCount = draggedFiles.length
-  const isMultipleAllowed = multiple || fileCount <= 1
-  const isDragAccept = fileCount > 0 && allFilesAccepted(draggedFiles, accept, minSize, maxSize)
-  const isDragReject = fileCount > 0 && (!isDragAccept || !isMultipleAllowed)
+  const isDragAccept = fileCount > 0 && allFilesAccepted({ files: draggedFiles, accept, minSize, maxSize, multiple })
+  const isDragReject = fileCount > 0 && !isDragAccept
 
   return {
     ...state,
@@ -770,7 +769,9 @@ function reducer(state, action) {
         ...state,
         isFileDialogActive: false,
         isDragActive: false,
-        draggedFiles: []
+        draggedFiles: [],
+        acceptedFiles: [],
+        rejectedFiles: [],
       }
     default:
       return state

--- a/src/index.spec.js
+++ b/src/index.spec.js
@@ -1749,7 +1749,7 @@ describe('useDropzone() hook', () => {
       expect(dropzone).toHaveTextContent('dragReject')
     })
 
-    it('sets {isDragActive, isDragAccept, isDragReject} if all files are accepted and {multiple} is false on dragenter', async () => {
+    it('sets {isDragActive, isDragAccept, isDragReject} if any files are rejected and {multiple} is false on dragenter', async () => {
       const ui = (
         <Dropzone accept="image/*" multiple={false}>
           {({ getRootProps, getInputProps, isDragActive, isDragAccept, isDragReject }) => (
@@ -1770,7 +1770,7 @@ describe('useDropzone() hook', () => {
       await flushPromises(ui, container)
 
       expect(dropzone).toHaveTextContent('dragActive')
-      expect(dropzone).toHaveTextContent('dragAccept')
+      expect(dropzone).not.toHaveTextContent('dragAccept')
       expect(dropzone).toHaveTextContent('dragReject')
     })
 

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -22,7 +22,11 @@ function isDefined(value) {
   return value !== undefined && value !== null
 }
 
-export function allFilesAccepted(files, accept, minSize, maxSize) {
+export function allFilesAccepted({ files, accept, minSize, maxSize, multiple }) {
+  if (!multiple && files.length > 1) {
+    return false;
+  }
+
   return files.every(file => {
     return fileAccepted(file, accept) && fileMatchSize(file, minSize, maxSize)
   })


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

- [x] bugfix
- [ ] feature
- [ ] refactoring / style
- [ ] build / chore
- [ ] documentation

**Did you add tests for your changes?**

- [ ] Yes, my code is well tested
- [x] Not relevant

**If relevant, did you update the documentation?**

- [ ] Yes, I've updated the documentation
- [x] Not relevant

**Summary**

[ISSUE](https://github.com/react-dropzone/react-dropzone/issues/921)

Fixed issue with `isDragReject` and `isDragAccept` when `multiple` is false and `acceptedFiles` are empty. Updated resolution of those two properties which are inlined with `acceptedFiles`.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->
No.

**Other information**
I have updated the tests for these changes.