### PR TITLE
feat: adds removeFiles, onRemoveFiles

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8566,7 +8566,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -8587,12 +8588,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -8607,17 +8610,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -8734,7 +8740,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -8746,6 +8753,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -8760,6 +8768,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -8767,12 +8776,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -8791,6 +8802,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -8871,7 +8883,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -8883,6 +8896,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -8968,7 +8982,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -9004,6 +9019,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -9023,6 +9039,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -9066,12 +9083,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/src/index.js
+++ b/src/index.js
@@ -202,7 +202,14 @@ Dropzone.propTypes = {
    * @param {object[]} files
    * @param {(DragEvent|Event)} event
    */
-  onDropRejected: PropTypes.func
+  onDropRejected: PropTypes.func,
+
+  /**
+   * Cb for when a user removes one or more files.
+   *
+   * @param {object[]} files
+   */
+  onRemoveFiles: PropTypes.func
 }
 
 export default Dropzone
@@ -269,6 +276,7 @@ export default Dropzone
  * @property {File[]} draggedFiles Files in active drag
  * @property {File[]} acceptedFiles Accepted files
  * @property {File[]} rejectedFiles Rejected files
+ * @property {Function} removeFiles Accepts an array of File objects to be removed
  */
 
 const initialState = {
@@ -368,6 +376,7 @@ export function useDropzone({
   onDropAccepted,
   onDropRejected,
   onFileDialogCancel,
+  onRemoveFiles,
   preventDropOnDocument = true,
   noClick = false,
   noKeyboard = false,
@@ -710,6 +719,26 @@ export function useDropzone({
     [inputRef, accept, multiple, onDropCb, disabled]
   )
 
+  const removeFiles = React.useCallback(
+    files => {
+      const acceptedFiles = state.acceptedFiles.filter(acceptedFile => {
+        return !files.find(f => f === acceptedFile);
+      });
+      const rejectedFiles = state.rejectedFiles.filter(rejectedFile => {
+        return !files.find(f => f === rejectedFile);
+      });
+
+      dispatch({
+        acceptedFiles,
+        rejectedFiles,
+        type: 'setFiles'
+      })
+
+      onRemoveFiles && onRemoveFiles(files)
+    },
+    [state, onRemoveFiles]
+  )
+
   const fileCount = draggedFiles.length
   const isMultipleAllowed = multiple || fileCount <= 1
   const isDragAccept = fileCount > 0 && allFilesAccepted(draggedFiles, accept, minSize, maxSize)
@@ -724,7 +753,8 @@ export function useDropzone({
     getInputProps,
     rootRef,
     inputRef,
-    open: composeHandler(openFileDialog)
+    open: composeHandler(openFileDialog),
+    removeFiles
   }
 }
 

--- a/typings/react-dropzone.d.ts
+++ b/typings/react-dropzone.d.ts
@@ -23,6 +23,7 @@ export type DropzoneOptions = Pick<React.HTMLProps<HTMLElement>, PropTypes> & {
   onDropRejected?<T extends File>(files: T[], event: DropEvent): void;
   getFilesFromEvent?(event: DropEvent): Promise<Array<File | DataTransferItem>>;
   onFileDialogCancel?(): void;
+  onRemoveFiles?(files: File[]): void;
 };
 
 export type DropEvent = React.DragEvent<HTMLElement> | React.ChangeEvent<HTMLInputElement> | DragEvent | Event;
@@ -40,6 +41,7 @@ export type DropzoneState = DropzoneRef & {
   inputRef: React.RefObject<HTMLInputElement>;
   getRootProps(props?: DropzoneRootProps): DropzoneRootProps;
   getInputProps(props?: DropzoneInputProps): DropzoneInputProps;
+  removeFiles(files: File[]): void;
 };
 
 export interface DropzoneRef {

--- a/typings/tests/all.tsx
+++ b/typings/tests/all.tsx
@@ -14,6 +14,7 @@ export default class Test extends React.Component {
           onDropAccepted={(files, event) => console.log(files, event)}
           onDropRejected={(files, event) => console.log(files, event)}
           onFileDialogCancel={() => console.log("abc")}
+          onRemoveFiles={file => {}}
           minSize={2000}
           maxSize={Infinity}
           preventDropOnDocument


### PR DESCRIPTION
**What kind of change does this PR introduce?**

- [ ] bugfix
- [x] feature
- [ ] refactoring / style
- [ ] build / chore
- [ ] documentation

**Did you add tests for your changes?**

- [x] Yes, my code is well tested
- [ ] Not relevant

**If relevant, did you update the documentation?**

- [x] Yes, I've updated the documentation
- [ ] Not relevant

**Summary**
I came across a situation where I'd like to be able to remove files from the internal state of `react-dropzone`. I saw that others have asked for this, and that [help was needed](https://github.com/react-dropzone/react-dropzone/issues/805#issuecomment-580034406).

This PR introduces two new API methods `onRemoveFiles` and `removeFiles`:
```jsx
<Dropzone onRemoveFiles={files => console.log('removed', files)}>
  {({ removeFiles, acceptedFiles }) => (
    <button onClick={() => removeFiles(acceptedFiles[0])}>Remove one file</button>
  )}
</Dropzone>
```

`onRemoveFiles` will always receive an array of `File`s, and `removeFiles` always accepts an array of `File`s. This makes it easy to remove multiple files at a time, say to "clear" the dropzone if needed.

**Does this PR introduce a breaking change?**
Shouldn't.

**Other information**
I could use some feedback on the tests, types, and JSDoc. Generally tried to stick to the patterns in place, but lmk if those need work.

Also, thanks for the library :)
