### PR TITLE
fix: #911 isDragActive value when dragging over text on Firefox

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -487,10 +487,7 @@ export function useDropzone({
       event.persist()
       stopPropagation(event)
 
-      // Count the dropzone and any children that are entered.
-      if (dragTargetsRef.current.indexOf(event.target) === -1) {
-        dragTargetsRef.current = [...dragTargetsRef.current, event.target]
-      }
+      dragTargetsRef.current = [...dragTargetsRef.current, event.target]
 
       if (isEvtWithFiles(event)) {
         Promise.resolve(getFilesFromEvent(event)).then(draggedFiles => {
@@ -542,8 +539,14 @@ export function useDropzone({
 
       // Only deactivate once the dropzone and all children have been left
       const targets = dragTargetsRef.current.filter(
-        target => target !== event.target && rootRef.current && rootRef.current.contains(target)
+        target => rootRef.current && rootRef.current.contains(target)
       )
+      // Make sure to remove a target present multiple times only once
+      // (Firefox may fire dragenter/dragleave multiple times on the same element)
+      const targetIdx = targets.indexOf(event.target)
+      if (targetIdx !== -1) {
+        targets.splice(targetIdx, 1)
+      }
       dragTargetsRef.current = targets
       if (targets.length > 0) {
         return

--- a/src/index.spec.js
+++ b/src/index.spec.js
@@ -1880,6 +1880,12 @@ describe('useDropzone() hook', () => {
 
       fireDragLeave(dropzone, data)
       await flushPromises(ui, container)
+      expect(dropzone).toHaveTextContent('dragActive')
+      expect(dropzone).toHaveTextContent('dragAccept')
+      expect(dropzone).not.toHaveTextContent('dragReject')
+
+      fireDragLeave(dropzone, data)
+      await flushPromises(ui, container)
       expect(dropzone).not.toHaveTextContent('dragActive')
       expect(dropzone).not.toHaveTextContent('dragAccept')
       expect(dropzone).not.toHaveTextContent('dragReject')


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

- [X] bugfix
- [ ] feature
- [ ] refactoring / style
- [ ] build / chore
- [ ] documentation

**Did you add tests for your changes?**

- [X] Yes, my code is well tested
- [ ] Not relevant

**If relevant, did you update the documentation?**

- [ ] Yes, I've updated the documentation
- [X] Not relevant

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
This PR fixes issues #911 and #526 
The issue is that when dragging over an element containing a text node, Firefox fires an event when entering the element and then another one when entering the text node.
This can be seen with this fiddle: https://jsfiddle.net/493wmzvL/2/
![firefox-drag](https://user-images.githubusercontent.com/465389/77827515-548d7f80-7116-11ea-8c9c-a657d8565443.gif)

With React the behavior is similar however both the text node and its container fire an event with the same contents in `event.target`. This can be seen in this fiddle: https://jsfiddle.net/wqcsg2un/2/
![firefox-react-drag](https://user-images.githubusercontent.com/465389/77827600-da112f80-7116-11ea-8da3-c9f2589a7311.gif)
I don't know if it is expected behavior from React or not, I will ask over there.

My suggested fix is to always add elements when `dragEnter` is fired and remove elements one by one when `dragLeave` is fired.

**Does this PR introduce a breaking change?**
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**
