### PR TITLE
Missing "isDragAccept" in styling example memo hook

### DIFF
--- a/examples/styling/README.md
+++ b/examples/styling/README.md
@@ -50,7 +50,8 @@ function StyledDropzone(props) {
     ...(isDragReject ? rejectStyle : {})
   }), [
     isDragActive,
-    isDragReject
+    isDragReject,
+    isDragAccept
   ]);
 
   return (


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

- [ ] bugfix
- [ ] feature
- [ ] refactoring / style
- [ ] build / chore
- [x] documentation

**Did you add tests for your changes?**

- [ ] Yes, my code is well tested
- [x] Not relevant

**If relevant, did you update the documentation?**

- [ ] Yes, I've updated the documentation
- [x] Not relevant

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
Just noticed a small mistake in the styling example. The `isDragAccept` prop was missing in the memo hook.