### PR TITLE
[types] Define functions as properties

### DIFF
--- a/typings/react-dropzone.d.ts
+++ b/typings/react-dropzone.d.ts
@@ -28,11 +28,11 @@ export type DropzoneOptions = Pick<React.HTMLProps<HTMLElement>, PropTypes> & {
   noDrag?: boolean;
   noDragEventsBubbling?: boolean;
   disabled?: boolean;
-  onDrop?<T extends File>(acceptedFiles: T[], fileRejections: FileRejection[], event: DropEvent): void;
-  onDropAccepted?<T extends File>(files: T[], event: DropEvent): void;
-  onDropRejected?(fileRejections: FileRejection[], event: DropEvent): void;
-  getFilesFromEvent?(event: DropEvent): Promise<Array<File | DataTransferItem>>;
-  onFileDialogCancel?(): void;
+  onDrop?: <T extends File>(acceptedFiles: T[], fileRejections: FileRejection[], event: DropEvent) => void;
+  onDropAccepted?: <T extends File>(files: T[], event: DropEvent) => void;
+  onDropRejected?: (fileRejections: FileRejection[], event: DropEvent) => void;
+  getFilesFromEvent?: (event: DropEvent) => Promise<Array<File | DataTransferItem>>;
+  onFileDialogCancel?: () => void;
 };
 
 export type DropEvent = React.DragEvent<HTMLElement> | React.ChangeEvent<HTMLInputElement> | DragEvent | Event;
@@ -48,12 +48,12 @@ export type DropzoneState = DropzoneRef & {
   fileRejections: FileRejection[];
   rootRef: React.RefObject<HTMLElement>;
   inputRef: React.RefObject<HTMLInputElement>;
-  getRootProps(props?: DropzoneRootProps): DropzoneRootProps;
-  getInputProps(props?: DropzoneInputProps): DropzoneInputProps;
+  getRootProps: (props?: DropzoneRootProps) => DropzoneRootProps;
+  getInputProps: (props?: DropzoneInputProps) => DropzoneInputProps;
 };
 
 export interface DropzoneRef {
-  open(): void;
+  open: () => void;
 }
 
 export interface DropzoneRootProps extends React.HTMLAttributes<HTMLElement> {


### PR DESCRIPTION
**What kind of change does this PR introduce?**

- [x] bugfix
- [ ] feature
- [ ] refactoring / style
- [ ] build / chore
- [ ] documentation

**Did you add tests for your changes?**

- [ ] Yes, my code is well tested
- [x] Not relevant

**If relevant, did you update the documentation?**

- [ ] Yes, I've updated the documentation
- [x] Not relevant

**Summary**

This is more correct for TS strict mode.
See info in [@typescript-eslint/method-signature-style](https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/method-signature-style.md)

It also is compatible with the [@typescript-eslint/unbound-method](https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/unbound-method.md) rule.

Currently this
```tsx
const { getRootProps } = useDropzone();
```
is viewed as a method that's been pulled out of a "class" that potentially uses `this`. Calling it directly like this would change the scope and break it. We know however, that this is not the case. It's just a function defined in a standard object, so this type change reflects that.
