### PR TITLE
feat(i): specefic error type for file error rejection

### DIFF
--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -34,6 +34,18 @@ export const TOO_MANY_FILES_REJECTION = {
   code: TOO_MANY_FILES,
   message: 'Too many files'
 }
+export const FILE_TOO_SMALL_REJECTION = {
+  code: FILE_TOO_SMALL,
+  message: 'file-too-small'
+}
+export const FILE_TOO_LARGE_REJECTION = {
+  code: FILE_TOO_LARGE,
+  message: 'file-too-large'
+}
+export const FILE_INVALID_TYPE_REJECTION = {
+  code: FILE_INVALID_TYPE,
+  message: 'file-invalid-type'
+}
 
 // Firefox versions prior to 53 return a bogus MIME type for every file drag, so dragovers with
 // that MIME type will always be accepted

--- a/typings/react-dropzone.d.ts
+++ b/typings/react-dropzone.d.ts
@@ -1,6 +1,7 @@
 import * as React from "react";
 
 export { FileWithPath } from "file-selector";
+
 export default function Dropzone(props: DropzoneProps & React.RefAttributes<DropzoneRef>): JSX.Element;
 export function useDropzone(options?: DropzoneOptions): DropzoneState;
 
@@ -8,9 +9,10 @@ export interface DropzoneProps extends DropzoneOptions {
   children?(state: DropzoneState): JSX.Element;
 }
 
+
 export interface FileError {
   message: string;
-  code: string;
+  code:  "file-invalid-type"|"file-too-large"|"file-too-small"|"too-many-files" ;
 }
 
 export interface FileRejection {


### PR DESCRIPTION
**What kind of change does this PR introduce?**
this merge request doesn't effect the code its just provide more typescript support for file error rejections:
`
export interface FileError {
  message: string;
  code:  "file-invalid-type"|"file-too-large"|"file-too-small"|"too-many-files" ;
}
`
it's hard to say that its a feature :) but the best option feats this merge request
- [ ] bugfix
- [x] feature
- [ ] refactoring / style
- [ ] build / chore
- [ ] documentation

**Did you add tests for your changes?**
due to this merge request doesn't effect code 
- [x] Yes, my code is well tested
- [ ] Not relevant

**If relevant, did you update the documentation?**

- [ ] Yes, I've updated the documentation
- [x] Not relevant

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
this is my first contributing on your project I saw on open issue and excited to fix that issue.
<!-- Try to link to an open issue for more information. -->
this merge request is opened base on this issue
[https://github.com/react-dropzone/react-dropzone/issues/988](url)
**Does this PR introduce a breaking change?**
No 
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**
