### PR TITLE
feat: add maximum number of accepted files

### DIFF
--- a/examples/maxFiles/README.md
+++ b/examples/maxFiles/README.md
@@ -1,20 +1,21 @@
-By providing `maxNumber` prop you can make the dropzone accept specific number of files.
+By providing `maxFiles` prop you can limit how many files the drop zone accepts.
 
-Attention this prop is enabled when the `multiple` props in true.
-by default, this props has 0 value which means no limitation in the accepted number of files.
+**Note** that this prop is enabled when the `multiple` prop is enabled.
+The default value for this prop is 0, which means there's no limitation to how many files are accepted.
+
 
 ```jsx harmony
 import React from 'react';
 import {useDropzone} from 'react-dropzone';
 
-function AcceptNumberOfFiles(props) {
+function AcceptMaxFiles(props) {
   const {
     acceptedFiles,
     fileRejections,
     getRootProps,
     getInputProps
   } = useDropzone({    
-    maxNumber:2
+    maxFiles:2
   });
 
   const acceptedFileItems = acceptedFiles.map(file => (
@@ -23,13 +24,13 @@ function AcceptNumberOfFiles(props) {
     </li>
   ));
 
-  const fileRejectionItems = fileRejections.map( ( { file, errors  } ) => { 
+  const fileRejectionItems = fileRejections.map(({ file, errors  }) => { 
    return(
      <li key={file.path}>
           {file.path} - {file.size} bytes
           <ul>
-         {errors.map(e => <li key={e.code}>{e.message}</li>)
-         }
+            {errors.map(e => <li key={e.code}>{e.message}</li>)
+            }
          </ul>
 
      </li>
@@ -54,5 +55,5 @@ function AcceptNumberOfFiles(props) {
   );
 }
 
-<AcceptNumberOfFiles />
+<AcceptMaxFiles />
 ```

--- a/examples/maxFiles/README.md
+++ b/examples/maxFiles/README.md
@@ -1,4 +1,4 @@
-By providing `maxFiles` prop you can limit how many files the drop zone accepts.
+By providing `maxFiles` prop you can limit how many files the dropzone accepts.
 
 **Note** that this prop is enabled when the `multiple` prop is enabled.
 The default value for this prop is 0, which means there's no limitation to how many files are accepted.
@@ -25,17 +25,16 @@ function AcceptMaxFiles(props) {
   ));
 
   const fileRejectionItems = fileRejections.map(({ file, errors  }) => { 
-   return(
+   return (
      <li key={file.path}>
           {file.path} - {file.size} bytes
           <ul>
-            {errors.map(e => <li key={e.code}>{e.message}</li>)
-            }
+            {errors.map(e => <li key={e.code}>{e.message}</li>)}
          </ul>
 
      </li>
    ) 
-  }  );
+  });
   
 
   return (
@@ -43,7 +42,7 @@ function AcceptMaxFiles(props) {
       <div {...getRootProps({ className: 'dropzone' })}>
         <input {...getInputProps()} />
         <p>Drag 'n' drop some files here, or click to select files</p>
-        <em>(2 files are the maximum number of file you can drop here)</em>
+        <em>(2 files are the maximum number of files you can drop here)</em>
       </div>
       <aside>
         <h4>Accepted files</h4>

--- a/examples/number-of-accepted-files/README.md
+++ b/examples/number-of-accepted-files/README.md
@@ -1,0 +1,58 @@
+By providing `maxNumber` prop you can make the dropzone accept specific number of files.
+
+Attention this prop is enabled when the `multiple` props in true.
+by default, this props has 0 value which means no limitation in the accepted number of files.
+
+```jsx harmony
+import React from 'react';
+import {useDropzone} from 'react-dropzone';
+
+function AcceptNumberOfFiles(props) {
+  const {
+    acceptedFiles,
+    fileRejections,
+    getRootProps,
+    getInputProps
+  } = useDropzone({    
+    maxNumber:2
+  });
+
+  const acceptedFileItems = acceptedFiles.map(file => (
+    <li key={file.path}>
+      {file.path} - {file.size} bytes
+    </li>
+  ));
+
+  const fileRejectionItems = fileRejections.map( ( { file, errors  } ) => { 
+   return(
+     <li key={file.path}>
+          {file.path} - {file.size} bytes
+          <ul>
+         {errors.map(e => <li key={e.code}>{e.message}</li>)
+         }
+         </ul>
+
+     </li>
+   ) 
+  }  );
+  
+
+  return (
+    <section className="container">
+      <div {...getRootProps({ className: 'dropzone' })}>
+        <input {...getInputProps()} />
+        <p>Drag 'n' drop some files here, or click to select files</p>
+        <em>(2 files are the maximum number of file you can drop here)</em>
+      </div>
+      <aside>
+        <h4>Accepted files</h4>
+        <ul>{acceptedFileItems}</ul>
+        <h4>Rejected files</h4>
+        <ul>{fileRejectionItems}</ul>
+      </aside>
+    </section>
+  );
+}
+
+<AcceptNumberOfFiles />
+```

--- a/src/index.js
+++ b/src/index.js
@@ -116,6 +116,12 @@ Dropzone.propTypes = {
    * Maximum file size (in bytes)
    */
   maxSize: PropTypes.number,
+  /**
+   * Maximum accepted number of files
+   * The default value is 0 which means there is no limitation in the accepted number of files
+   * The minimum accepted value is 2
+   */
+  maxNumber: PropTypes.number,
 
   /**
    * Enable/disable the dropzone
@@ -362,6 +368,7 @@ export function useDropzone({
   maxSize = Infinity,
   minSize = 0,
   multiple = true,
+  maxNumber=0,
   onDragEnter,
   onDragLeave,
   onDragOver,
@@ -595,6 +602,13 @@ export function useDropzone({
           })
 
           if (!multiple && acceptedFiles.length > 1) {
+            // Reject everything and empty accepted files
+            acceptedFiles.forEach(file => {
+              fileRejections.push({ file, errors: [TOO_MANY_FILES_REJECTION] })
+            })
+            acceptedFiles.splice(0)
+          }
+          if (multiple && maxNumber>1 &&  acceptedFiles.length > maxNumber) {
             // Reject everything and empty accepted files
             acceptedFiles.forEach(file => {
               fileRejections.push({ file, errors: [TOO_MANY_FILES_REJECTION] })

--- a/src/index.js
+++ b/src/index.js
@@ -121,7 +121,7 @@ Dropzone.propTypes = {
    * The default value is 0 which means there is no limitation in the accepted number of files
    * The minimum accepted value is 2
    */
-  maxNumber: PropTypes.number,
+  maxFiles: PropTypes.number,
 
   /**
    * Enable/disable the dropzone
@@ -368,7 +368,7 @@ export function useDropzone({
   maxSize = Infinity,
   minSize = 0,
   multiple = true,
-  maxNumber=0,
+  maxFiles=0,
   onDragEnter,
   onDragLeave,
   onDragOver,
@@ -608,7 +608,7 @@ export function useDropzone({
             })
             acceptedFiles.splice(0)
           }
-          if (multiple && maxNumber>1 &&  acceptedFiles.length > maxNumber) {
+          else if (multiple && maxFiles>1 &&  acceptedFiles.length > maxFiles) {
             // Reject everything and empty accepted files
             acceptedFiles.forEach(file => {
               fileRejections.push({ file, errors: [TOO_MANY_FILES_REJECTION] })

--- a/src/index.js
+++ b/src/index.js
@@ -119,7 +119,6 @@ Dropzone.propTypes = {
   /**
    * Maximum accepted number of files
    * The default value is 0 which means there is no limitation to how many files are accepted.
-   * The minimum accepted value is 2
    */
   maxFiles: PropTypes.number,
 
@@ -167,7 +166,7 @@ Dropzone.propTypes = {
    *
    * Files are accepted or rejected based on the `accept`, `multiple`, `minSize` and `maxSize` props.
    * `accept` must be a valid [MIME type](http://www.iana.org/assignments/media-types/media-types.xhtml) according to [input element specification](https://www.w3.org/wiki/HTML/Elements/input/file) or a valid file extension.
-   * If `multiple` is set to false and additional files are droppped,
+   * If `multiple` is set to false and additional files are dropped,
    * all files besides the first will be rejected.
    * Any file which does not have a size in the [`minSize`, `maxSize`] range, will be rejected as well.
    *
@@ -337,7 +336,7 @@ const initialState = {
  *
  * Files are accepted or rejected based on the `accept`, `multiple`, `minSize` and `maxSize` props.
  * `accept` must be a valid [MIME type](http://www.iana.org/assignments/media-types/media-types.xhtml) according to [input element specification](https://www.w3.org/wiki/HTML/Elements/input/file) or a valid file extension.
- * If `multiple` is set to false and additional files are droppped,
+ * If `multiple` is set to false and additional files are dropped,
  * all files besides the first will be rejected.
  * Any file which does not have a size in the [`minSize`, `maxSize`] range, will be rejected as well.
  *
@@ -368,7 +367,7 @@ export function useDropzone({
   maxSize = Infinity,
   minSize = 0,
   multiple = true,
-  maxFiles=0,
+  maxFiles = 0,
   onDragEnter,
   onDragLeave,
   onDragOver,
@@ -601,21 +600,14 @@ export function useDropzone({
             }
           })
 
-          if (!multiple && acceptedFiles.length > 1) {
+          if ((!multiple && acceptedFiles.length > 1) || (multiple && maxFiles >= 1 &&  acceptedFiles.length > maxFiles)) {
             // Reject everything and empty accepted files
             acceptedFiles.forEach(file => {
               fileRejections.push({ file, errors: [TOO_MANY_FILES_REJECTION] })
             })
             acceptedFiles.splice(0)
           }
-          else if (multiple && maxFiles>1 &&  acceptedFiles.length > maxFiles) {
-            // Reject everything and empty accepted files
-            acceptedFiles.forEach(file => {
-              fileRejections.push({ file, errors: [TOO_MANY_FILES_REJECTION] })
-            })
-            acceptedFiles.splice(0)
-          }
-
+        
           dispatch({
             acceptedFiles,
             fileRejections,

--- a/src/index.js
+++ b/src/index.js
@@ -118,7 +118,7 @@ Dropzone.propTypes = {
   maxSize: PropTypes.number,
   /**
    * Maximum accepted number of files
-   * The default value is 0 which means there is no limitation in the accepted number of files
+   * The default value is 0 which means there is no limitation to how many files are accepted.
    * The minimum accepted value is 2
    */
   maxFiles: PropTypes.number,

--- a/src/index.spec.js
+++ b/src/index.spec.js
@@ -9,12 +9,10 @@ import Dropzone, { useDropzone } from './index'
 describe('useDropzone() hook', () => {
   let files
   let images
-  let threeImages
 
   beforeEach(() => {
     files = [createFile('file1.pdf', 1111, 'application/pdf')]
     images = [createFile('cats.gif', 1234, 'image/gif'), createFile('dogs.gif', 2345, 'image/jpeg')]
-    threeImages = [createFile('cats.gif', 1234, 'image/gif'), createFile('dogs.gif', 2345, 'image/jpeg'),createFile('fish.gif', 2345, 'image/jpeg')]
   })
 
   afterEach(cleanup)
@@ -2092,7 +2090,7 @@ describe('useDropzone() hook', () => {
       const onDropSpy = jest.fn()
       const onDropRejectedSpy = jest.fn()
       const ui = (
-        <Dropzone accept="image/*" onDrop={onDropSpy} onDropRejected={onDropRejectedSpy} multiple={true} maxFiles={2}>
+        <Dropzone accept="image/*" onDrop={onDropSpy} onDropRejected={onDropRejectedSpy} multiple={true} maxFiles={1}>
           {({ getRootProps, getInputProps }) => (
             <div {...getRootProps()}>
               <input {...getInputProps()} />
@@ -2102,12 +2100,12 @@ describe('useDropzone() hook', () => {
       )
       const { container } = render(ui)
       const dropzone = container.querySelector('div')
-      fireDrop(dropzone, createDtWithFiles(threeImages))
+      fireDrop(dropzone, createDtWithFiles(images))
       await flushPromises(ui, container)
       expect(onDropRejectedSpy).toHaveBeenCalled()
       expect(onDropSpy).toHaveBeenCalledWith([], [
         {
-          file: threeImages[0],
+          file: images[0],
           errors: [
             {
               code: 'too-many-files',
@@ -2116,23 +2114,14 @@ describe('useDropzone() hook', () => {
           ]
         },
         {
-          file: threeImages[1],
+          file: images[1],
           errors: [
             {
               code: 'too-many-files',
               message: 'Too many files',
             }
           ]
-        },
-        {
-          file: threeImages[2],
-          errors: [
-            {
-              code: 'too-many-files',
-              message: 'Too many files',
-            }
-          ]
-        },
+        }
       ], expect.anything())
     })
 
@@ -2151,10 +2140,10 @@ describe('useDropzone() hook', () => {
       const { container } = render(ui)
       const dropzone = container.querySelector('div')
 
-      fireDrop(dropzone, createDtWithFiles(threeImages))
+      fireDrop(dropzone, createDtWithFiles(images))
       await flushPromises(ui, container)
       expect(onDropRejectedSpy).not.toHaveBeenCalled()
-      expect(onDropSpy).toHaveBeenCalledWith(threeImages, [], expect.anything())
+      expect(onDropSpy).toHaveBeenCalledWith(images, [], expect.anything())
     })
     
     it('accepts a single files if {multiple} is false and {accept} criteria is met', async () => {

--- a/src/index.spec.js
+++ b/src/index.spec.js
@@ -2102,7 +2102,6 @@ describe('useDropzone() hook', () => {
       )
       const { container } = render(ui)
       const dropzone = container.querySelector('div')
-
       fireDrop(dropzone, createDtWithFiles(threeImages))
       await flushPromises(ui, container)
       expect(onDropRejectedSpy).toHaveBeenCalled()
@@ -2152,7 +2151,6 @@ describe('useDropzone() hook', () => {
       const { container } = render(ui)
       const dropzone = container.querySelector('div')
 
-      
       fireDrop(dropzone, createDtWithFiles(threeImages))
       await flushPromises(ui, container)
       expect(onDropRejectedSpy).not.toHaveBeenCalled()

--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -46,6 +46,10 @@ module.exports = {
           content: 'examples/accept/README.md'
         },
         {
+          name: 'Accepting specific number of files',
+          content: 'examples/maxFiles/README.md'
+        },
+        {
           name: 'Opening File Dialog Programmatically',
           content: 'examples/file-dialog/README.md'
         },

--- a/typings/react-dropzone.d.ts
+++ b/typings/react-dropzone.d.ts
@@ -28,11 +28,11 @@ export type DropzoneOptions = Pick<React.HTMLProps<HTMLElement>, PropTypes> & {
   noDrag?: boolean;
   noDragEventsBubbling?: boolean;
   disabled?: boolean;
-  onDrop?<T extends File>(acceptedFiles: T[], fileRejections: FileRejection[], event: DropEvent): void;
-  onDropAccepted?<T extends File>(files: T[], event: DropEvent): void;
-  onDropRejected?(fileRejections: FileRejection[], event: DropEvent): void;
-  getFilesFromEvent?(event: DropEvent): Promise<Array<File | DataTransferItem>>;
-  onFileDialogCancel?(): void;
+  onDrop?: <T extends File>(acceptedFiles: T[], fileRejections: FileRejection[], event: DropEvent) => void;
+  onDropAccepted?: <T extends File>(files: T[], event: DropEvent) => void;
+  onDropRejected?: (fileRejections: FileRejection[], event: DropEvent) => void;
+  getFilesFromEvent?: (event: DropEvent) => Promise<Array<File | DataTransferItem>>;
+  onFileDialogCancel?: () => void;
 };
 
 export type DropEvent = React.DragEvent<HTMLElement> | React.ChangeEvent<HTMLInputElement> | DragEvent | Event;
@@ -48,12 +48,12 @@ export type DropzoneState = DropzoneRef & {
   fileRejections: FileRejection[];
   rootRef: React.RefObject<HTMLElement>;
   inputRef: React.RefObject<HTMLInputElement>;
-  getRootProps(props?: DropzoneRootProps): DropzoneRootProps;
-  getInputProps(props?: DropzoneInputProps): DropzoneInputProps;
+  getRootProps: (props?: DropzoneRootProps) => DropzoneRootProps;
+  getInputProps: (props?: DropzoneInputProps) => DropzoneInputProps;
 };
 
 export interface DropzoneRef {
-  open(): void;
+  open: () => void;
 }
 
 export interface DropzoneRootProps extends React.HTMLAttributes<HTMLElement> {

--- a/typings/react-dropzone.d.ts
+++ b/typings/react-dropzone.d.ts
@@ -22,7 +22,7 @@ export type DropzoneOptions = Pick<React.HTMLProps<HTMLElement>, PropTypes> & {
   accept?: string | string[];
   minSize?: number;
   maxSize?: number;
-  maxNumber?: number;
+  maxFiles?: number;
   preventDropOnDocument?: boolean;
   noClick?: boolean;
   noKeyboard?: boolean;

--- a/typings/react-dropzone.d.ts
+++ b/typings/react-dropzone.d.ts
@@ -22,6 +22,7 @@ export type DropzoneOptions = Pick<React.HTMLProps<HTMLElement>, PropTypes> & {
   accept?: string | string[];
   minSize?: number;
   maxSize?: number;
+  maxNumber?: number;
   preventDropOnDocument?: boolean;
   noClick?: boolean;
   noKeyboard?: boolean;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

- [ ] bugfix
- [x] feature
- [ ] refactoring / style
- [ ] build / chore
- [ ] documentation

**Did you add tests for your changes?**

- [ ] Yes, my code is well tested
- [x] Not relevant

**If relevant, did you update the documentation?**

- [x] Yes, I've updated the documentation
- [ ] Not relevant

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
This PR is created base on a user [suggestion  ](https://github.com/react-dropzone/react-dropzone/issues/999)that too many files cause freezing or even crash the browser.
one solution would be a limited number of files.
So I added `maxNumber` prop.

_How is it works?_
When `multiple` prop is true we can pass `maxNumber` witch limit the number of files that DropZone accepts.
The minimum accepted value is `2`.
I doubt naming to choose `maxFiles` or `maxNumber`, please tell me if `maxFiles` is a better choice.   
This is the main part of this PR:
```javascript
if (multiple && maxNumber>1 &&  acceptedFiles.length > maxNumber) {  
            // Reject everything and empty accepted files  
            acceptedFiles.forEach(file => {  
              fileRejections.push({ file, errors: [TOO_MANY_FILES_REJECTION] })  
            })  
            acceptedFiles.splice(0)  
          }  
```

I have also added a markdown that includes a sample this new feature.

**Does this PR introduce a breaking change?**
I don't think so, because it does not change the core of the code.
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

