### PR TITLE
docs: move default props to Dropzone component for react-docgen

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -63,7 +63,7 @@ const defaultProps = {
   noDragEventsBubbling: false
 }
 
-Dropzone.defaultProps = DefaultProps
+Dropzone.defaultProps = defaultProps
 
 Dropzone.propTypes = {
   /**
@@ -400,7 +400,7 @@ export function useDropzone(options = {}) {
     noDrag,
     noDragEventsBubbling
   } = {
-    ...DefaultProps,
+    ...defaultProps,
     ...options
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -49,7 +49,7 @@ const Dropzone = forwardRef(({ children, ...params }, ref) => {
 Dropzone.displayName = 'Dropzone'
 
 // Add default props for react-docgen
-const DefaultProps = {
+const defaultProps = {
   disabled: false,
   getFilesFromEvent: fromEvent,
   maxSize: Infinity,

--- a/src/index.js
+++ b/src/index.js
@@ -47,6 +47,24 @@ const Dropzone = forwardRef(({ children, ...params }, ref) => {
 })
 
 Dropzone.displayName = 'Dropzone'
+
+// Add default props for react-docgen
+const DefaultProps = {
+  disabled: false,
+  getFilesFromEvent: fromEvent,
+  maxSize: Infinity,
+  minSize: 0,
+  multiple: true,
+  maxFiles: 0,
+  preventDropOnDocument: true,
+  noClick: false,
+  noKeyboard: false,
+  noDrag: false,
+  noDragEventsBubbling: false
+}
+
+Dropzone.defaultProps = DefaultProps
+
 Dropzone.propTypes = {
   /**
    * Render function that exposes the dropzone state and prop getter fns
@@ -360,27 +378,32 @@ const initialState = {
  *
  * @returns {DropzoneState}
  */
-export function useDropzone({
-  accept,
-  disabled = false,
-  getFilesFromEvent = fromEvent,
-  maxSize = Infinity,
-  minSize = 0,
-  multiple = true,
-  maxFiles = 0,
-  onDragEnter,
-  onDragLeave,
-  onDragOver,
-  onDrop,
-  onDropAccepted,
-  onDropRejected,
-  onFileDialogCancel,
-  preventDropOnDocument = true,
-  noClick = false,
-  noKeyboard = false,
-  noDrag = false,
-  noDragEventsBubbling = false
-} = {}) {
+export function useDropzone(options = {}) {
+  const {
+    accept,
+    disabled,
+    getFilesFromEvent,
+    maxSize,
+    minSize,
+    multiple,
+    maxFiles,
+    onDragEnter,
+    onDragLeave,
+    onDragOver,
+    onDrop,
+    onDropAccepted,
+    onDropRejected,
+    onFileDialogCancel,
+    preventDropOnDocument,
+    noClick,
+    noKeyboard,
+    noDrag,
+    noDragEventsBubbling
+  } = {
+    ...DefaultProps,
+    ...options
+  }
+
   const rootRef = useRef(null)
   const inputRef = useRef(null)
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

- [ ] bugfix
- [ ] feature
- [ ] refactoring / style
- [ ] build / chore
- [x] documentation

**Did you add tests for your changes?**

- [x] Not relevant

**If relevant, did you update the documentation?**

- [x] Yes, I've updated the documentation

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

Hello! This PR simply moves the default props from the hook to the defaultProps property on the Dropzone component, so that the defaults can be documented on the documentation site.

### Current
![current](https://user-images.githubusercontent.com/10165959/95104100-5a02fc80-072d-11eb-9225-c7930d5cecaa.png)

### With default props
![with-pr](https://user-images.githubusercontent.com/10165959/95104088-57a0a280-072d-11eb-842c-9716cdea35f5.png)

**Does this PR introduce a breaking change?**
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->
No!
**Other information**
