### PR TITLE
bug:change isDragReject true when maxFiles rejectDrag

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -47,6 +47,24 @@ const Dropzone = forwardRef(({ children, ...params }, ref) => {
 })
 
 Dropzone.displayName = 'Dropzone'
+
+// Add default props for react-docgen
+const defaultProps = {
+  disabled: false,
+  getFilesFromEvent: fromEvent,
+  maxSize: Infinity,
+  minSize: 0,
+  multiple: true,
+  maxFiles: 0,
+  preventDropOnDocument: true,
+  noClick: false,
+  noKeyboard: false,
+  noDrag: false,
+  noDragEventsBubbling: false
+}
+
+Dropzone.defaultProps = defaultProps
+
 Dropzone.propTypes = {
   /**
    * Render function that exposes the dropzone state and prop getter fns
@@ -360,27 +378,32 @@ const initialState = {
  *
  * @returns {DropzoneState}
  */
-export function useDropzone({
-  accept,
-  disabled = false,
-  getFilesFromEvent = fromEvent,
-  maxSize = Infinity,
-  minSize = 0,
-  multiple = true,
-  maxFiles = 0,
-  onDragEnter,
-  onDragLeave,
-  onDragOver,
-  onDrop,
-  onDropAccepted,
-  onDropRejected,
-  onFileDialogCancel,
-  preventDropOnDocument = true,
-  noClick = false,
-  noKeyboard = false,
-  noDrag = false,
-  noDragEventsBubbling = false
-} = {}) {
+export function useDropzone(options = {}) {
+  const {
+    accept,
+    disabled,
+    getFilesFromEvent,
+    maxSize,
+    minSize,
+    multiple,
+    maxFiles,
+    onDragEnter,
+    onDragLeave,
+    onDragOver,
+    onDrop,
+    onDropAccepted,
+    onDropRejected,
+    onFileDialogCancel,
+    preventDropOnDocument,
+    noClick,
+    noKeyboard,
+    noDrag,
+    noDragEventsBubbling
+  } = {
+    ...defaultProps,
+    ...options
+  }
+
   const rootRef = useRef(null)
   const inputRef = useRef(null)
 

--- a/src/index.js
+++ b/src/index.js
@@ -751,7 +751,7 @@ export function useDropzone(options = {}) {
   )
 
   const fileCount = draggedFiles.length
-  const isDragAccept = fileCount > 0 && allFilesAccepted({ files: draggedFiles, accept, minSize, maxSize, multiple })
+  const isDragAccept = fileCount > 0 && allFilesAccepted({ files: draggedFiles, accept, minSize, maxSize, multiple,maxFiles })
   const isDragReject = fileCount > 0 && !isDragAccept
 
   return {

--- a/src/index.js
+++ b/src/index.js
@@ -751,7 +751,7 @@ export function useDropzone(options = {}) {
   )
 
   const fileCount = draggedFiles.length
-  const isDragAccept = fileCount > 0 && allFilesAccepted({ files: draggedFiles, accept, minSize, maxSize, multiple,maxFiles })
+  const isDragAccept = fileCount > 0 && allFilesAccepted({ files: draggedFiles, accept, minSize, maxSize, multiple, maxFiles })
   const isDragReject = fileCount > 0 && !isDragAccept
 
   return {

--- a/src/index.spec.js
+++ b/src/index.spec.js
@@ -2095,8 +2095,8 @@ describe('useDropzone() hook', () => {
     it('rejects all files if {multiple} is true and maxFiles is less than files and {accept} criteria is met', async () => {
       const onDropSpy = jest.fn()
       const onDropRejectedSpy = jest.fn()
-      const ui = ( 
-         <Dropzone accept="image/*" onDrop={onDropSpy} onDropRejected={onDropRejectedSpy} multiple={true} maxFiles={1}>
+      const ui = (
+        <Dropzone accept="image/*" onDrop={onDropSpy} onDropRejected={onDropRejectedSpy} multiple={true} maxFiles={1}>
           {({ getRootProps, getInputProps, isDragReject, isDragAccept }) => (
             <div {...getRootProps()}>
               <input {...getInputProps()} />

--- a/src/index.spec.js
+++ b/src/index.spec.js
@@ -2095,11 +2095,13 @@ describe('useDropzone() hook', () => {
     it('rejects all files if {multiple} is true and maxFiles is less than files and {accept} criteria is met', async () => {
       const onDropSpy = jest.fn()
       const onDropRejectedSpy = jest.fn()
-      const ui = (
-        <Dropzone accept="image/*" onDrop={onDropSpy} onDropRejected={onDropRejectedSpy} multiple={true} maxFiles={1}>
-          {({ getRootProps, getInputProps }) => (
+      const ui = ( 
+         <Dropzone accept="image/*" onDrop={onDropSpy} onDropRejected={onDropRejectedSpy} multiple={true} maxFiles={1}>
+          {({ getRootProps, getInputProps, isDragReject, isDragAccept }) => (
             <div {...getRootProps()}>
               <input {...getInputProps()} />
+               {isDragReject && 'dragReject'}
+               {isDragAccept && 'dragAccept'}
             </div>
           )}
         </Dropzone>
@@ -2109,6 +2111,10 @@ describe('useDropzone() hook', () => {
       fireDrop(dropzone, createDtWithFiles(images))
       await flushPromises(rerender, ui)
       expect(onDropRejectedSpy).toHaveBeenCalled()
+      fireDragEnter(dropzone, createDtWithFiles(images))
+      await flushPromises(rerender, ui)
+      expect(dropzone).toHaveTextContent('dragReject')
+      expect(dropzone).not.toHaveTextContent('dragAccept')
       expect(onDropSpy).toHaveBeenCalledWith([], [
         {
           file: images[0],

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -59,8 +59,8 @@ function isDefined(value) {
   return value !== undefined && value !== null
 }
 
-export function allFilesAccepted({ files, accept, minSize, maxSize, multiple }) {
-  if (!multiple && files.length > 1) {
+export function allFilesAccepted({ files, accept, minSize, maxSize, multiple,maxFiles }) {
+  if ((!multiple && files.length > 1) ||(multiple &&  files.length > maxFiles) ) {
     return false;
   }
 

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -59,8 +59,8 @@ function isDefined(value) {
   return value !== undefined && value !== null
 }
 
-export function allFilesAccepted({ files, accept, minSize, maxSize, multiple,maxFiles }) {
-  if ((!multiple && files.length > 1) ||(multiple && maxFiles >= 1 &&  files.length > maxFiles) ) {
+export function allFilesAccepted({ files, accept, minSize, maxSize, multiple, maxFiles }) {
+  if ((!multiple && files.length > 1) || (multiple && maxFiles >= 1 &&  files.length > maxFiles) ) {
     return false;
   }
 

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -60,7 +60,7 @@ function isDefined(value) {
 }
 
 export function allFilesAccepted({ files, accept, minSize, maxSize, multiple,maxFiles }) {
-  if ((!multiple && files.length > 1) ||(multiple &&  files.length > maxFiles) ) {
+  if ((!multiple && files.length > 1) ||(multiple && maxFiles >= 1 &&  files.length > maxFiles) ) {
     return false;
   }
 

--- a/src/utils/index.spec.js
+++ b/src/utils/index.spec.js
@@ -230,7 +230,6 @@ it('rejects file when single accept criteria as array', () => {
 
 })
 describe('allFilesAccepted()', () => {
-  
   let utils
   beforeEach(async done => {
     utils = await import('./index')
@@ -249,6 +248,7 @@ describe('allFilesAccepted()', () => {
     expect(utils.allFilesAccepted({ files, multiple: true, maxFiles: 1 })).toEqual(false)
   })
 })
+
 function createFile(name, size, type) {
   const file = new File([], name, { type })
   Object.defineProperty(file, 'size', {

--- a/src/utils/index.spec.js
+++ b/src/utils/index.spec.js
@@ -229,6 +229,7 @@ it('rejects file when single accept criteria as array', () => {
 })
 
 })
+
 describe('allFilesAccepted()', () => {
   let utils
   beforeEach(async done => {

--- a/src/utils/index.spec.js
+++ b/src/utils/index.spec.js
@@ -229,7 +229,26 @@ it('rejects file when single accept criteria as array', () => {
 })
 
 })
-
+describe('allFilesAccepted()', () => {
+  
+  let utils
+  beforeEach(async done => {
+    utils = await import('./index')
+    done()
+  })
+  it('rejects file when multiple accept criteria', () => {
+    const files = [createFile('hamster.pdf', 100, 'application/pdf'),createFile('fish.pdf', 100, 'application/pdf')];
+    const images = [createFile('cats.gif', 1234, 'image/gif'), createFile('dogs.gif', 2345, 'image/jpeg')]
+    expect(utils.allFilesAccepted({ files, multiple: true})).toEqual(true)
+    expect(utils.allFilesAccepted({ files, multiple: true, maxFiles: 10 })).toEqual(true)
+    expect(utils.allFilesAccepted({ files, multiple: false, maxFiles: 10 })).toEqual(false)
+    expect(utils.allFilesAccepted({ files, multiple: true, accept:'image/jpeg' })).toEqual(false) 
+    expect(utils.allFilesAccepted({ files: images, multiple: true,accept:'image/*' })).toEqual(true) 
+    expect(utils.allFilesAccepted({ files, multiple: true, minSize: 110 })).toEqual(false)
+    expect(utils.allFilesAccepted({ files, multiple: true, maxSize: 99 })).toEqual(false)
+    expect(utils.allFilesAccepted({ files, multiple: true, maxFiles: 1 })).toEqual(false)
+  })
+})
 function createFile(name, size, type) {
   const file = new File([], name, { type })
   Object.defineProperty(file, 'size', {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

- [x] bugfix
- [ ] feature
- [ ] refactoring / style
- [ ] build / chore
- [ ] documentation

**Did you add tests for your changes?**

- [x] Yes, my code is well tested
- [ ] Not relevant

**If relevant, did you update the documentation?**

- [ ] Yes, I've updated the documentation
- [x] Not relevant

**Summary**
There is a bug in maxFiles feature that `isDragReject` doesn't change when DragEvent contains more than the max number of files
This bug reported #1017 
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->
shouldn't
**Other information**
