### PR TITLE
make contributions easier with the online automated dev setup

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,6 @@
+tasks:
+  - init: yarn install && yarn run build
+    command: yarn run start
+ports:
+  - port: 8080
+    onOpen: open-preview

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 [![codecov](https://img.shields.io/codecov/c/gh/react-dropzone/react-dropzone/master.svg?style=flat-square)](https://codecov.io/gh/react-dropzone/react-dropzone)
 [![Open Collective](https://img.shields.io/opencollective/backers/react-dropzone.svg?style=flat-square)](#backers)
 [![Open Collective](https://img.shields.io/opencollective/sponsors/react-dropzone.svg?style=flat-square)](#sponsors)
+[![Gitpod Ready-to-Code](https://img.shields.io/badge/Gitpod-Ready--to--Code-blue?logo=gitpod)](https://gitpod.io/#https://github.com/react-dropzone/react-dropzone) 
 
 Simple React hook to create a HTML5-compliant drag'n'drop zone for files.
 

--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -1,12 +1,15 @@
 /* eslint import/no-extraneous-dependencies: 0 */
 const path = require('path')
-const { createConfig, babel, css } = require('webpack-blocks')
+const { createConfig, babel, css, devServer } = require('webpack-blocks')
 
 // https://react-styleguidist.js.org/docs/configuration.html
 module.exports = {
   title: 'react-dropzone',
   styleguideDir: path.join(__dirname, 'styleguide'),
-  webpackConfig: createConfig([babel(), css()]),
+  webpackConfig: createConfig([babel(), css(), devServer({
+    disableHostCheck: true,
+    host: '0.0.0.0',
+  })]),
   exampleMode: 'expand',
   usageMode: 'expand',
   showSidebar: false,


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

Hi.

I work for Gitpod. This PR adds gitpod config to the repo to make contributions easier for newcomers i.e with a single click it will launch a workspace and automatically:

- clone the `react-dropzone` repo.
- install the dependencies.
- run `yarn build` and `yarn start`.

This can be helpful for beginners i.e they can start coding instantly without setting anything up.

You can give it a try on my fork of the repo via the following link:

https://gitpod.io/#https://github.com/nisarhassan12/react-dropzone

This is how it looks:

![image](https://user-images.githubusercontent.com/46004116/97088497-9ea5f780-164a-11eb-9d4b-1a2bc642a3e0.png)

- [ ] bugfix
- [ ] feature
- [ ] refactoring / style
- [ ] build / chore
- [ ] documentation

**Did you add tests for your changes?**

- [ ] Yes, my code is well tested
- [x] Not relevant

**If relevant, did you update the documentation?**

- [ ] Yes, I've updated the documentation
- [x] Not relevant

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**
