### PR TITLE
Fix: make sure changes to maxFiles prop are reflected in behaviour

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -657,6 +657,7 @@ export function useDropzone(options = {}) {
       accept,
       minSize,
       maxSize,
+      maxFiles,
       getFilesFromEvent,
       onDrop,
       onDropAccepted,

--- a/src/index.spec.js
+++ b/src/index.spec.js
@@ -2137,6 +2137,36 @@ describe('useDropzone() hook', () => {
       ], expect.anything())
     })
 
+    it('rejects all files if {multiple} is true and maxFiles has been updated so that it is less than files', async () => {
+      const onDropSpy = jest.fn()
+      const onDropRejectedSpy = jest.fn()
+      const ui = (maxFiles) => (
+        <Dropzone accept="image/*" onDrop={onDropSpy} multiple={true} maxFiles={maxFiles} onDropRejected={onDropRejectedSpy}>
+          {({ getRootProps, getInputProps }) => (
+            <div {...getRootProps()}>
+              <input {...getInputProps()} />
+            </div>
+          )}
+        </Dropzone>
+      )
+      const { container, rerender } = render(ui(3))
+      const dropzone = container.querySelector('div')
+
+      fireDrop(dropzone, createDtWithFiles(images))
+      await flushPromises(rerender, ui(3))
+      expect(onDropRejectedSpy).not.toHaveBeenCalled()
+      expect(onDropSpy).toHaveBeenCalledWith(images, [], expect.anything())
+
+      rerender(ui(1));
+
+      fireDrop(dropzone, createDtWithFiles(images))
+      await flushPromises(rerender, ui(1))
+      expect(onDropRejectedSpy).toHaveBeenCalledWith(
+        expect.arrayContaining(images.map((image) => expect.objectContaining({ errors: expect.any(Array), file: image }))),
+        expect.anything()
+      )
+    })
+
     it('accepts multiple files if {multiple} is true and {accept} criteria is met', async () => {
       const onDropSpy = jest.fn()
       const onDropRejectedSpy = jest.fn()


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

- [x] bugfix
- [ ] feature
- [ ] refactoring / style
- [ ] build / chore
- [ ] documentation

**Did you add tests for your changes?**

- [x] Yes, my code is well tested
- [ ] Not relevant

**If relevant, did you update the documentation?**

- [ ] Yes, I've updated the documentation
- [x] Not relevant

**Summary**
Fix for https://github.com/react-dropzone/react-dropzone/issues/1025 

Adds `maxFiles` as a dependency to `onDropCb` callback, so that changes to `maxFiles` parameter are reflected in the behaviour of that function.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->
No
**Other information**
