### PR TITLE
Fix Validator Type

### DIFF
--- a/typings/react-dropzone.d.ts
+++ b/typings/react-dropzone.d.ts
@@ -34,7 +34,7 @@ export type DropzoneOptions = Pick<React.HTMLProps<HTMLElement>, PropTypes> & {
   onDropRejected?: (fileRejections: FileRejection[], event: DropEvent) => void;
   getFilesFromEvent?: (event: DropEvent) => Promise<Array<File | DataTransferItem>>;
   onFileDialogCancel?: () => void;
-  validator?: <T extends File>(file: T) => FileError | FileError[]; 
+  validator?: <T extends File>(file: T) => FileError | FileError[] | null;
 };
 
 export type DropEvent = React.DragEvent<HTMLElement> | React.ChangeEvent<HTMLInputElement> | DragEvent | Event;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

- [x] bugfix
- [ ] feature
- [ ] refactoring / style
- [ ] build / chore
- [ ] documentation

**Did you add tests for your changes?**

- [ ] Yes, my code is well tested
- [x] Not relevant

**If relevant, did you update the documentation?**

- [ ] Yes, I've updated the documentation
- [x] Not relevant

**Summary**

In the Validator readme.md, it says:
>The value must be a function that accepts File object and returns null if file should be accepted or error object/array of error objects if file should me rejected.

The issue is, with the current TypeScript bindings, returning `null` isn't a valid return type. 

This PR fixes this.