### PR TITLE
build(deps): bump attr-accept from 2.2.1 to 2.2.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5598,9 +5598,9 @@
       "dev": true
     },
     "attr-accept": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/attr-accept/-/attr-accept-2.2.1.tgz",
-      "integrity": "sha512-GpefLMsbH5ojNgfTW+OBin2xKzuHfyeNA+qCktzZojBhbA/lPZdCFMWdwk5ajb989Ok7ZT+EADqvW3TAFNMjhA=="
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/attr-accept/-/attr-accept-2.2.2.tgz",
+      "integrity": "sha512-7prDjvt9HmqiZ0cl5CRjtS84sEyhsHP2coDkaZKRKVfCDo9s7iw7ChVmar78Gu9pC4SoR/28wFu/G5JJhTnqEg=="
     },
     "awesome-typescript-loader": {
       "version": "5.2.1",

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "react": ">= 16.8"
   },
   "dependencies": {
-    "attr-accept": "^2.2.1",
+    "attr-accept": "^2.2.2",
     "file-selector": "^0.2.2",
     "prop-types": "^15.7.2"
   },


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

- [ ] bugfix
- [ ] feature
- [ ] refactoring / style
- [x] build / chore
- [ ] documentation

**Did you add tests for your changes?**

- [ ] Yes, my code is well tested
- [x] Not relevant

**If relevant, did you update the documentation?**

- [ ] Yes, I've updated the documentation
- [x] Not relevant

**Summary**


The package `attr-accept` is behind one version that adds support for lowercased MIME filters.
Package File and Package Lock have the version to 2.2.1.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**

#1005

https://github.com/react-dropzone/attr-accept/issues/50

https://github.com/react-dropzone/attr-accept/pull/51