### PR TITLE
fix: Check drag event contains files before showing "copy" cursor

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -554,13 +554,14 @@ export function useDropzone(options = {}) {
       event.persist()
       stopPropagation(event)
 
-      if (event.dataTransfer) {
+      const hasFiles = isEvtWithFiles(event);
+      if (hasFiles && event.dataTransfer) {
         try {
           event.dataTransfer.dropEffect = 'copy'
         } catch {} /* eslint-disable-line no-empty */
       }
 
-      if (isEvtWithFiles(event) && onDragOver) {
+      if (hasFiles && onDragOver) {
         onDragOver(event)
       }
 


### PR DESCRIPTION
**What kind of change does this PR introduce?**

- [x] bugfix
- [ ] feature
- [ ] refactoring / style
- [ ] build / chore
- [ ] documentation

**Did you add tests for your changes?**

- [ ] Yes, my code is well tested
- [x] Not relevant

**If relevant, did you update the documentation?**

- [ ] Yes, I've updated the documentation
- [x] Not relevant

**Summary**

A green "plus" symbol shows when dragging links and other non-file items across a dropzone. This is particularly noticable if you combine `react-dropzone` with a draggable library like `react-dnd`, but it's also noticeable in the examples even in the docs.

closes #1042
