### PR TITLE
fix: Modified type definitions for getRootProps and getInputProps

### DIFF
--- a/typings/react-dropzone.d.ts
+++ b/typings/react-dropzone.d.ts
@@ -50,8 +50,8 @@ export type DropzoneState = DropzoneRef & {
   fileRejections: FileRejection[];
   rootRef: React.RefObject<HTMLElement>;
   inputRef: React.RefObject<HTMLInputElement>;
-  getRootProps: (props?: DropzoneRootProps) => DropzoneRootProps;
-  getInputProps: (props?: DropzoneInputProps) => DropzoneInputProps;
+  getRootProps: <T extends DropzoneRootProps>(props?: T) => T;
+  getInputProps: <T extends DropzoneInputProps>(props?: T) => T;
 };
 
 export interface DropzoneRef {


### PR DESCRIPTION
Modified type definitions for getRootProps and getInputProps to:
- accept a parameterized type that extends DropzoneRootProps and DropzoneInputProps respectively
- which allows for more meaningful type information to be passed from getRootProps and getInputProps to their respective components

Example:

```ts
interface IStyledProps {
  isDragActive: boolean;
  isDragAccept: boolean;
  isDragReject: boolean;
}

const getColor = (props: IStyledProps) => {
  if (props.isDragAccept) {
    return "#00e676";
  }
  if (props.isDragReject) {
    return "#ff1744";
  }
  if (props.isDragActive) {
    return "#2196f3";
  }
  return "#eeeeee";
};

const Container = styled.div<IStyledProps>`
  ...
  border-color: ${(props) => getColor(props)};
  ...
`;

const DropzoneUploader: FunctionComponent = () => {
  const {
    getRootProps,
    getInputProps,
    isDragActive,
    isDragAccept,
    isDragReject,
  } = useDropzone({ accept: "image/*" });

  return (
    <div className="container">
      <Container
        {...getRootProps({ isDragActive, isDragAccept, isDragReject })}
      >
        <input {...getInputProps()} />
        <p>Drag 'n' drop some files here, or click to select files</p>
      </Container>
    </div>
  );
};

export default DropzoneUploader;
```

Without this change, TypeScript returns the following error for the `Container` styled component:
```
No overload matches this call.
  Overload 1 of 2, '(props: Omit<Omit<Pick<DetailedHTMLProps<HTMLAttributes<HTMLDivElement>, HTMLDivElement>, "key" | keyof HTMLAttributes<...>> & { ...; } & IStyledProps, never> & Partial<...>, "theme"> & { ...; } & { ...; }): ReactElement<...>', gave the following error.
    Type '{ children: Element[]; refKey?: string | undefined; defaultChecked?: boolean | undefined; defaultValue?: string | number | readonly string[] | undefined; suppressContentEditableWarning?: boolean | undefined; ... 249 more ...; onTransitionEndCapture?: TransitionEventHandler<...> | undefined; }' is missing the following properties from type 'Omit<Omit<Pick<DetailedHTMLProps<HTMLAttributes<HTMLDivElement>, HTMLDivElement>, "key" | keyof HTMLAttributes<HTMLDivElement>> & { ...; } & IStyledProps, never> & Partial<...>, "theme">': isDragActive, isDragAccept, isDragReject
  Overload 2 of 2, '(props: StyledComponentPropsWithAs<"div", any, IStyledProps, never, "div">): ReactElement<StyledComponentPropsWithAs<"div", any, IStyledProps, never, "div">, string | JSXElementConstructor<...>>', gave the following error.
    Type '{ children: Element[]; refKey?: string | undefined; defaultChecked?: boolean | undefined; defaultValue?: string | number | readonly string[] | undefined; suppressContentEditableWarning?: boolean | undefined; ... 249 more ...; onTransitionEndCapture?: TransitionEventHandler<...> | undefined; }' is missing the following properties from type 'Omit<Omit<Pick<DetailedHTMLProps<HTMLAttributes<HTMLDivElement>, HTMLDivElement>, "key" | keyof HTMLAttributes<HTMLDivElement>> & { ...; } & IStyledProps, never> & Partial<...>, "theme">': isDragActive, isDragAccept, isDragRejectts(2769)
```

This is because, as far as TypeScript knows, `getRootProps` isn't returning all of the props that the `Container` styled component requires.

One other thing to note - with this change the developer does not have to specify the type explicitly to `getRootProps` and `getInputProps` since TypeScript can infer this information based on what we pass to each function.

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

- [x] bugfix
- [ ] feature
- [ ] refactoring / style
- [ ] build / chore
- [ ] documentation

**Did you add tests for your changes?**

- [ ] Yes, my code is well tested
- [x] Not relevant

**If relevant, did you update the documentation?**

- [ ] Yes, I've updated the documentation
- [x] Not relevant

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

As far as I can tell - no.