### PR TITLE
fix: use initial state when reset state

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -824,12 +824,7 @@ function reducer(state, action) {
       }
     case 'reset':
       return {
-        ...state,
-        isFileDialogActive: false,
-        isDragActive: false,
-        draggedFiles: [],
-        acceptedFiles: [],
-        fileRejections: [],
+        ...initialState
       }
     default:
       return state


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

- [ ] bugfix
- [ ] feature
- [x] refactoring / style
- [ ] build / chore
- [ ] documentation

**Did you add tests for your changes?**

- [ ] Yes, my code is well tested
- [x] Not relevant

**If relevant, did you update the documentation?**

- [ ] Yes, I've updated the documentation
- [x] Not relevant

**Summary**

We can just use initial state state instead of copy so many state into the reset code block.
