### PR TITLE
Stop shipping the vendor directory

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -6,3 +6,4 @@ styleguide/
 coverage/
 yarn.lock
 .babelrc
+vendor


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

- [x] bugfix
- [ ] feature
- [ ] refactoring / style
- [ ] build / chore
- [ ] documentation

**Did you add tests for your changes?**

- [ ] Yes, my code is well tested
- [x] Not relevant

**If relevant, did you update the documentation?**

- [ ] Yes, I've updated the documentation
- [x] Not relevant

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

This fixes #1076. This PR is presented as an alternative to #1083.

`react-dropzone` is apparently intended to be compatible with the Doka image editor ([now called "Pintura" apparently](https://pqina.nl/pintura/)), which explains why it's potentially desirable to have `doka` code in the repository for the purposes of evaluating this compatibility. However, `react-dropzone` should not be redistributing `doka`'s own code, which is released under [this specialist licence](https://pqina.nl/pintura/license/), as `react-dropzone` itself is [released under the MIT licence](https://github.com/react-dropzone/react-dropzone/blob/master/LICENSE), and it's highly unlikely that the two are compatible.

**Does this PR introduce a breaking change?**
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

No. The `doka` code is only used at development time, `react-dropzone` does not use it at run time.

**Other information**

N/A