### PR TITLE
Add ErrorCode object to runtime

### DIFF
--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -6,6 +6,13 @@ export const FILE_TOO_LARGE = 'file-too-large'
 export const FILE_TOO_SMALL = 'file-too-small'
 export const TOO_MANY_FILES = 'too-many-files'
 
+export const ErrorCode = {
+  FileInvalidType: FILE_INVALID_TYPE,
+  FileTooLarge: FILE_TOO_LARGE,
+  FileTooSmall: FILE_TOO_SMALL,
+  TooManyFiles: TOO_MANY_FILES,
+}
+
 // File Errors
 export const getInvalidTypeRejectionErr = accept => {
   accept = Array.isArray(accept) && accept.length === 1 ? accept[0] : accept

--- a/src/utils/index.spec.js
+++ b/src/utils/index.spec.js
@@ -260,3 +260,18 @@ function createFile(name, size, type) {
   return file
 }
 
+describe('ErrorCode', () => {
+  let utils
+  beforeEach(async done => {
+    utils = await import('./index')
+    done()
+  })
+
+  it('should exist and have known error code properties', () => {
+    expect(utils.ErrorCode.FileInvalidType).toEqual(utils.FILE_INVALID_TYPE)
+    expect(utils.ErrorCode.FileTooLarge).toEqual(utils.FILE_TOO_LARGE)
+    expect(utils.ErrorCode.FileTooSmall).toEqual(utils.FILE_TOO_SMALL)
+    expect(utils.ErrorCode.TooManyFiles).toEqual(utils.TOO_MANY_FILES)
+  })
+})
+


### PR DESCRIPTION
**What kind of change does this PR introduce?**

- [x] bugfix
- [ ] feature
- [ ] refactoring / style
- [ ] build / chore
- [ ] documentation

**Did you add tests for your changes?**

- [x] Yes, my code is well tested
- [ ] Not relevant

**If relevant, did you update the documentation?**

- [ ] Yes, I've updated the documentation
- [x] Not relevant

**Summary**

In https://github.com/react-dropzone/react-dropzone/pull/1061, the `ErrorCode` enum was introduced to the Typescript definitions, but it was never added to the runtime script. This adds it to the `utils.js` file so it can be accessed without throwing an import error.

Fixes https://github.com/react-dropzone/react-dropzone/issues/1091

**Does this PR introduce a breaking change?**
No

**Other information**
