### PR TITLE
Re-export ErrorCode from './utils'

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -831,3 +831,5 @@ function reducer(state, action) {
       return state
   }
 }
+
+export { ErrorCode } from './utils'


### PR DESCRIPTION
**What kind of change does this PR introduce?**

- [x] bugfix
- [ ] feature
- [ ] refactoring / style
- [ ] build / chore
- [ ] documentation

**Did you add tests for your changes?**

- [ ] Yes, my code is well tested
- [x] Not relevant

**If relevant, did you update the documentation?**

- [ ] Yes, I've updated the documentation
- [x] Not relevant

**Summary**

Fixes https://github.com/react-dropzone/react-dropzone/issues/1094 - needs to re-export the `ErrorCode` from `utils` to make it available and match the Typescript definitions.

**Does this PR introduce a breaking change?**
No.

**Other information**
