### PR TITLE
ref: Replace separate error variables with ErrorCode object

### DIFF
--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -1,16 +1,10 @@
 import accepts from 'attr-accept'
 
-// Error codes
-export const FILE_INVALID_TYPE = 'file-invalid-type'
-export const FILE_TOO_LARGE = 'file-too-large'
-export const FILE_TOO_SMALL = 'file-too-small'
-export const TOO_MANY_FILES = 'too-many-files'
-
 export const ErrorCode = {
-  FileInvalidType: FILE_INVALID_TYPE,
-  FileTooLarge: FILE_TOO_LARGE,
-  FileTooSmall: FILE_TOO_SMALL,
-  TooManyFiles: TOO_MANY_FILES,
+  FileInvalidType: 'file-invalid-type',
+  FileTooLarge: 'file-too-large',
+  FileTooSmall: 'file-too-small',
+  TooManyFiles: 'too-many-files',
 }
 
 // File Errors
@@ -18,27 +12,27 @@ export const getInvalidTypeRejectionErr = accept => {
   accept = Array.isArray(accept) && accept.length === 1 ? accept[0] : accept
   const messageSuffix = Array.isArray(accept) ? `one of ${accept.join(', ')}` : accept
   return {
-    code: FILE_INVALID_TYPE,
+    code: ErrorCode.FileInvalidType,
     message: `File type must be ${messageSuffix}`
   }
 }
 
 export const getTooLargeRejectionErr = maxSize => {
   return {
-    code: FILE_TOO_LARGE,
+    code: ErrorCode.FileTooLarge,
     message: `File is larger than ${maxSize} bytes`
   }
 }
 
 export const getTooSmallRejectionErr = minSize => {
   return {
-    code: FILE_TOO_SMALL,
+    code: ErrorCode.FileTooSmall,
     message: `File is smaller than ${minSize} bytes`
   }
 }
 
 export const TOO_MANY_FILES_REJECTION = {
-  code: TOO_MANY_FILES,
+  code: ErrorCode.TooManyFiles,
   message: 'Too many files'
 }
 

--- a/src/utils/index.spec.js
+++ b/src/utils/index.spec.js
@@ -259,19 +259,3 @@ function createFile(name, size, type) {
   })
   return file
 }
-
-describe('ErrorCode', () => {
-  let utils
-  beforeEach(async done => {
-    utils = await import('./index')
-    done()
-  })
-
-  it('should exist and have known error code properties', () => {
-    expect(utils.ErrorCode.FileInvalidType).toEqual(utils.FILE_INVALID_TYPE)
-    expect(utils.ErrorCode.FileTooLarge).toEqual(utils.FILE_TOO_LARGE)
-    expect(utils.ErrorCode.FileTooSmall).toEqual(utils.FILE_TOO_SMALL)
-    expect(utils.ErrorCode.TooManyFiles).toEqual(utils.TOO_MANY_FILES)
-  })
-})
-


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

- [ ] bugfix
- [ ] feature
- [x] refactoring / style
- [ ] build / chore
- [ ] documentation

**Did you add tests for your changes?**

- [x] Yes, my code is well tested
- [ ] Not relevant

**If relevant, did you update the documentation?**

- [ ] Yes, I've updated the documentation
- [x] Not relevant

**Summary**
It seems a little bit strange, that you store errors as separate variables, that you use in the code and at the same time you have ErrorCode object (aka enum), that has all the same errors, but you don't use it at all.
<img width="709" alt="Снимок экрана 2021-09-24 в 11 09 02" src="https://user-images.githubusercontent.com/37641303/134603599-0f265d5a-6725-42f9-a449-8317fab0c96b.png">

According to the type declaration, error is expected to be of ErrorCode enum type, but in code you use separate strings. It seems to be a little bit confusing, don't you think?
<img width="360" alt="Снимок экрана 2021-09-24 в 11 13 41" src="https://user-images.githubusercontent.com/37641303/134603611-c0af19ab-f949-48ba-bbe9-5c9cddc29d45.png">

So, you use ErrorCode object only for typing, but this typing doesn't describe real code realization.

I suggest to store errors only in the ErrorCode object (as it said in the type declaration) and to use ErrorCode object in the code instead of usage of separate error variables.


**Does this PR introduce a breaking change?**
Changes from this PR could be breaking for projects, that use imports of separate error variables (that were deleted in this PR).



