### PR TITLE
docs: add a line to inform users where to pass accesibility props

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ This is in order to avoid your props being overridden (or overriding the props r
   })}
 />
 ```
+> ♿ this is also where you pass accessibility props like `role`, `aria-labelledby` ...etc.
 
 In the example above, the provided `{onClick}` handler will be invoked before the internal one, therefore, internal callbacks can be prevented by simply using [stopPropagation](https://developer.mozilla.org/en-US/docs/Web/API/Event/stopPropagation).
 See [Events](https://react-dropzone.js.org#events) for more examples.


### PR DESCRIPTION
- [x] documentation

**Did you add tests for your changes?**

- [ ] Yes, my code is well tested
- [x] Not relevant

**Summary**

In reference to [this issue](https://github.com/react-dropzone/react-dropzone/issues/1085), I thought it'd good if we have a line in the documentation to _remind_ users that they need to take care of making the dropzone accessible.

