### PR TITLE
added onFileDialogOpen callback

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -158,6 +158,11 @@ Dropzone.propTypes = {
    */
   onFileDialogCancel: PropTypes.func,
 
+    /**
+     * Cb for when opening the file dialog
+     */
+  onFileDialogOpen: PropTypes.func,
+
   /**
    * Cb for when the `dragenter` event occurs.
    *
@@ -230,7 +235,7 @@ Dropzone.propTypes = {
   onDropRejected: PropTypes.func,
 
   /**
-   * Custom validation function 
+   * Custom validation function
    * @param {File} file
    * @returns {FileError|FileError[]}
    */
@@ -354,6 +359,7 @@ const initialState = {
  * @param {boolean} [props.disabled=false] Enable/disable the dropzone
  * @param {getFilesFromEvent} [props.getFilesFromEvent] Use this to provide a custom file aggregator
  * @param {Function} [props.onFileDialogCancel] Cb for when closing the file dialog with no selection
+ * @param {Function} [props.onFileDialogOpen] Cb for when opening the file dialog
  * @param {dragCb} [props.onDragEnter] Cb for when the `dragenter` event occurs.
  * @param {dragCb} [props.onDragLeave] Cb for when the `dragleave` event occurs
  * @param {dragCb} [props.onDragOver] Cb for when the `dragover` event occurs
@@ -402,6 +408,7 @@ export function useDropzone(options = {}) {
     onDropAccepted,
     onDropRejected,
     onFileDialogCancel,
+    onFileDialogOpen,
     preventDropOnDocument,
     noClick,
     noKeyboard,
@@ -423,10 +430,13 @@ export function useDropzone(options = {}) {
   const openFileDialog = useCallback(() => {
     if (inputRef.current) {
       dispatch({ type: 'openDialog' })
+      if (typeof onFileDialogOpen === 'function') {
+        onFileDialogOpen()
+      }
       inputRef.current.value = null
       inputRef.current.click()
     }
-  }, [dispatch])
+  }, [dispatch, onFileDialogOpen])
 
   // Update file dialog active state when the window is focused on
   const onWindowFocus = () => {
@@ -467,7 +477,7 @@ export function useDropzone(options = {}) {
         openFileDialog()
       }
     },
-    [rootRef, inputRef]
+    [rootRef, inputRef, openFileDialog]
   )
 
   // Update focus state for the dropzone
@@ -492,7 +502,7 @@ export function useDropzone(options = {}) {
     } else {
       openFileDialog()
     }
-  }, [inputRef, noClick])
+  }, [inputRef, noClick, openFileDialog])
 
   const dragTargetsRef = useRef([])
   const onDocumentDrop = event => {
@@ -631,7 +641,7 @@ export function useDropzone(options = {}) {
               acceptedFiles.push(file)
             } else {
               let errors = [acceptError, sizeError];
-              
+
               if (customErrors) {
                 errors = errors.concat(customErrors);
               }
@@ -647,7 +657,7 @@ export function useDropzone(options = {}) {
             })
             acceptedFiles.splice(0)
           }
-        
+
           dispatch({
             acceptedFiles,
             fileRejections,

--- a/src/index.spec.js
+++ b/src/index.spec.js
@@ -2628,6 +2628,49 @@ describe('useDropzone() hook', () => {
     })
   })
 
+  describe('onFileDialogOpen', () => {
+    it('is invoked when opening the file dialog', () => {
+      const onFileDialogOpenSpy = jest.fn()
+      const { container } = render(
+        <Dropzone
+          onFileDialogOpen={onFileDialogOpenSpy}>
+          {({ getRootProps, getInputProps }) => (
+            <div {...getRootProps()}>
+              <input {...getInputProps()} />
+            </div>
+          )}
+        </Dropzone>
+      )
+
+      const dropzone = container.querySelector('div')
+      fireEvent.click(dropzone)
+
+      expect(onFileDialogOpenSpy).toHaveBeenCalled()
+    })
+
+    it('is invoked when opening the file dialog programmatically', () => {
+      const onFileDialogOpenSpy = jest.fn()
+      const { container } = render(
+        <Dropzone
+          onFileDialogOpen={onFileDialogOpenSpy}>
+          {({ getRootProps, getInputProps, open }) => (
+            <div {...getRootProps()}>
+              <input {...getInputProps()} />
+              <button type="button" onClick={open}>
+                Open
+              </button>
+            </div>
+          )}
+        </Dropzone>
+      )
+
+      const btn = container.querySelector('button')
+      btn.click()
+
+      expect(onFileDialogOpenSpy).toHaveBeenCalled()
+    })
+  })
+
   describe('{open}', () => {
     it('can open file dialog programmatically', () => {
       const onClickSpy = jest.spyOn(HTMLInputElement.prototype, 'click')
@@ -2728,7 +2771,7 @@ describe('useDropzone() hook', () => {
 
         return null;
       }
-      
+
       const onDropSpy = jest.fn()
 
       const ui = (

--- a/typings/react-dropzone.d.ts
+++ b/typings/react-dropzone.d.ts
@@ -41,6 +41,7 @@ export type DropzoneOptions = Pick<React.HTMLProps<HTMLElement>, PropTypes> & {
   onDropRejected?: (fileRejections: FileRejection[], event: DropEvent) => void;
   getFilesFromEvent?: (event: DropEvent) => Promise<Array<File | DataTransferItem>>;
   onFileDialogCancel?: () => void;
+  onFileDialogOpen?: ()=> void;
   validator?: <T extends File>(file: T) => FileError | FileError[] | null;
 };
 

--- a/typings/tests/all.tsx
+++ b/typings/tests/all.tsx
@@ -13,7 +13,8 @@ export default class Test extends React.Component {
           onDragLeave={event => console.log(event)}
           onDropAccepted={(files, event) => console.log(files, event)}
           onDropRejected={(files, event) => console.log(files, event)}
-          onFileDialogCancel={() => console.log("abc")}
+          onFileDialogCancel={() => console.log("onFileDialogCancel invoked")}
+          onFileDialogOpen={() => console.log("onFileDialogOpen invoked")}
           minSize={2000}
           maxSize={Infinity}
           preventDropOnDocument

--- a/typings/tests/file-dialog.tsx
+++ b/typings/tests/file-dialog.tsx
@@ -2,7 +2,10 @@ import React from "react";
 import Dropzone from "../../";
 
 export const dropzone = (
-  <Dropzone onDrop={files => console.log(files)}>
+  <Dropzone
+    onDrop={files => console.log(files)}
+    onFileDialogCancel={() => console.log("onFileDialogCancel invoked")}
+    onFileDialogOpen={() => console.log("onFileDialogOpen invoked")}>
     {({getRootProps, getInputProps, open}) => (
       <div {...getRootProps()}>
         <input {...getInputProps()} />


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

- [ ] bugfix
- [x] feature
- [ ] refactoring / style
- [ ] build / chore
- [ ] documentation

**Did you add tests for your changes?**

- [x] Yes, my code is well tested
- [ ] Not relevant

**If relevant, did you update the documentation?**

- [x] Yes, I've updated the documentation
- [ ] Not relevant

**Summary**
I needed to push monitor events when the file chooser showing up. We did have onDragEnter/Leave to understand users can drag files instead of using the file chooser to select files. It would be beneficial to have this callback for the situation.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**
No. 
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**
