### PR TITLE
Declare module as side effect free

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "description": "Simple HTML5 drag-drop zone with React.js",
   "main": "dist/index.js",
   "module": "dist/es/index.js",
+  "sideEffects": false,
   "scripts": {
     "ci": "git-cz",
     "clean": "rimraf ./dist",


### PR DESCRIPTION
Declare module as side effect free to assist webpack tree shaking.

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

- [ ] bugfix
- [ ] feature
- [ ] refactoring / style
- [x] build / chore
- [ ] documentation

**Did you add tests for your changes?**

- [ ] Yes, my code is well tested
- [x] Not relevant

**If relevant, did you update the documentation?**

- [ ] Yes, I've updated the documentation
- [x] Not relevant

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

We're using react-dropzone in our UI library that is used across various microfrontend modules. Unfortunately react-dropzone doesn't tree-shake away when a module is not using the dropzone part of our UI library.

**Does this PR introduce a breaking change?**
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

No

**Other information**
