### PR TITLE
[Documentation] Move unused active drag style to be used on focus instead

### DIFF
--- a/examples/styling/README.md
+++ b/examples/styling/README.md
@@ -22,7 +22,7 @@ const baseStyle = {
   transition: 'border .24s ease-in-out'
 };
 
-const activeStyle = {
+const focusedStyle = {
   borderColor: '#2196f3'
 };
 
@@ -38,20 +38,20 @@ function StyledDropzone(props) {
   const {
     getRootProps,
     getInputProps,
-    isDragActive,
+    isFocused,
     isDragAccept,
     isDragReject
   } = useDropzone({accept: 'image/*'});
 
   const style = useMemo(() => ({
     ...baseStyle,
-    ...(isDragActive ? activeStyle : {}),
+    ...(isFocused ? focusedStyle : {}),
     ...(isDragAccept ? acceptStyle : {}),
     ...(isDragReject ? rejectStyle : {})
   }), [
-    isDragActive,
-    isDragReject,
-    isDragAccept
+    isFocused,
+    isDragAccept,
+    isDragReject
   ]);
 
   return (
@@ -81,7 +81,7 @@ const getColor = (props) => {
   if (props.isDragReject) {
       return '#ff1744';
   }
-  if (props.isDragActive) {
+  if (props.isFocused) {
       return '#2196f3';
   }
   return '#eeeeee';
@@ -107,14 +107,14 @@ function StyledDropzone(props) {
   const {
     getRootProps,
     getInputProps,
-    isDragActive,
+    isFocused,
     isDragAccept,
     isDragReject
   } = useDropzone({accept: 'image/*'});
   
   return (
     <div className="container">
-      <Container {...getRootProps({isDragActive, isDragAccept, isDragReject})}>
+      <Container {...getRootProps({isFocused, isDragAccept, isDragReject})}>
         <input {...getInputProps()} />
         <p>Drag 'n' drop some files here, or click to select files</p>
       </Container>


### PR DESCRIPTION
**What kind of change does this PR introduce?**

- [ ] bugfix
- [ ] feature
- [ ] refactoring / style
- [ ] build / chore
- [x] documentation

**Did you add tests for your changes?**

- [ ] Yes, my code is well tested
- [x] Not relevant

**If relevant, did you update the documentation?**

- [ ] Yes, I've updated the documentation
- [x] Not relevant

**Summary**
In the Styling example, the active drag style is always overridden by either the drag accept or reject style when a file is dragged over the component. This change updates the active drag style to instead be used when the component is focused, to match the Basic example. When the components are clicked/focused, their border colors will be blue.

**Does this PR introduce a breaking change?**
No.

**Other information**