### PR TITLE
feat: set role attr to button by default on the root and close #1110

### DIFF
--- a/src/__snapshots__/index.spec.js.snap
+++ b/src/__snapshots__/index.spec.js.snap
@@ -1,3 +1,3 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`useDropzone() hook behavior renders the root and input nodes with the necessary props 1`] = `"<div tabindex=\\"0\\"><input multiple=\\"\\" type=\\"file\\" style=\\"display: none;\\" autocomplete=\\"off\\" tabindex=\\"-1\\"></div>"`;
+exports[`useDropzone() hook behavior renders the root and input nodes with the necessary props 1`] = `"<div role=\\"button\\" tabindex=\\"0\\"><input multiple=\\"\\" type=\\"file\\" style=\\"display: none;\\" autocomplete=\\"off\\" tabindex=\\"-1\\"></div>"`;

--- a/src/index.js
+++ b/src/index.js
@@ -752,6 +752,7 @@ export function useDropzone(options = {}) {
   const getRootProps = useMemo(
     () => ({
       refKey = 'ref',
+      role,
       onKeyDown,
       onFocus,
       onBlur,
@@ -770,6 +771,7 @@ export function useDropzone(options = {}) {
       onDragOver: composeDragHandler(composeEventHandlers(onDragOver, onDragOverCb)),
       onDragLeave: composeDragHandler(composeEventHandlers(onDragLeave, onDragLeaveCb)),
       onDrop: composeDragHandler(composeEventHandlers(onDrop, onDropCb)),
+      role: typeof role === 'string' && role !== '' ? role : 'button',
       [refKey]: rootRef,
       ...(!disabled && !noKeyboard ? {tabIndex: 0} : {}),
       ...rest

--- a/src/index.spec.js
+++ b/src/index.spec.js
@@ -2996,6 +2996,34 @@ describe('useDropzone() hook', () => {
       ], expect.anything())
     })
   })
+
+  describe('accessibility', () => {
+    it('sets the role attribute to button by default on the root', () => {
+      const { container } = render(
+        <Dropzone>
+          {({ getRootProps }) => (
+            <div id="root" {...getRootProps()} />
+          )}
+        </Dropzone>
+      )
+      const root = container.querySelector('#root')
+
+      expect(root).toHaveAttribute('role', 'button')
+    })
+
+    test('users can override the default role attribute on the root', () => {
+      const { container } = render(
+        <Dropzone>
+          {({ getRootProps }) => (
+            <div id="root" {...getRootProps({role: 'generic'})} />
+          )}
+        </Dropzone>
+      )
+      const root = container.querySelector('#root')
+
+      expect(root).toHaveAttribute('role', 'generic')
+    })
+  })
 })
 
 async function flushPromises(rerender, ui) {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

- [ ] bugfix
- [x] feature
- [ ] refactoring / style
- [ ] build / chore
- [ ] documentation

**Did you add tests for your changes?**

- [x] Yes, my code is well tested
- [ ] Not relevant

**If relevant, did you update the documentation?**

- [ ] Yes, I've updated the documentation
- [x] Not relevant

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
Set the `role` attribute to `button` by default on the dropzone.

**Does this PR introduce a breaking change?**
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->
No.

**Other information**
Gotta merge https://github.com/react-dropzone/react-dropzone/pull/1123 first.