### PR TITLE
fix: disable file system access API usage by default and close #1131

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -63,7 +63,8 @@ const defaultProps = {
   noKeyboard: false,
   noDrag: false,
   noDragEventsBubbling: false,
-  validator: null
+  validator: null,
+  useFsAccessApi: false,
 }
 
 Dropzone.defaultProps = defaultProps
@@ -164,6 +165,12 @@ Dropzone.propTypes = {
    * Cb for when opening the file dialog
    */
   onFileDialogOpen: PropTypes.func,
+
+  /**
+   * Set to true to use the https://developer.mozilla.org/en-US/docs/Web/API/File_System_Access_API
+   * to open the file picker instead of using an `<input type="file">` click event.
+   */
+  useFsAccessApi: PropTypes.bool,
 
   /**
    * Cb for when the `dragenter` event occurs.
@@ -361,6 +368,8 @@ const initialState = {
  * @param {boolean} [props.disabled=false] Enable/disable the dropzone
  * @param {getFilesFromEvent} [props.getFilesFromEvent] Use this to provide a custom file aggregator
  * @param {Function} [props.onFileDialogCancel] Cb for when closing the file dialog with no selection
+ * @param {boolean} [props.useFsAccessApi] Set to true to use the https://developer.mozilla.org/en-US/docs/Web/API/File_System_Access_API
+ * to open the file picker instead of using an `<input type="file">` click event.
  * @param {Function} [props.onFileDialogOpen] Cb for when opening the file dialog
  * @param {dragCb} [props.onDragEnter] Cb for when the `dragenter` event occurs.
  * @param {dragCb} [props.onDragLeave] Cb for when the `dragleave` event occurs
@@ -411,6 +420,7 @@ export function useDropzone(options = {}) {
     onDropRejected,
     onFileDialogCancel,
     onFileDialogOpen,
+    useFsAccessApi,
     preventDropOnDocument,
     noClick,
     noKeyboard,
@@ -452,7 +462,7 @@ export function useDropzone(options = {}) {
     }
   }
   useEffect(() => {
-    if (canUseFileSystemAccessAPI()) {
+    if (useFsAccessApi && canUseFileSystemAccessAPI()) {
       return () => {}
     }
 
@@ -460,7 +470,7 @@ export function useDropzone(options = {}) {
     return () => {
       window.removeEventListener('focus', onWindowFocus, false)
     }
-  }, [inputRef, isFileDialogActive, onFileDialogCancelCb])
+  }, [inputRef, isFileDialogActive, onFileDialogCancelCb, useFsAccessApi])
 
   const dragTargetsRef = useRef([])
   const onDocumentDrop = event => {
@@ -660,7 +670,7 @@ export function useDropzone(options = {}) {
 
   // Fn for opening the file dialog programmatically
   const openFileDialog = useCallback(() => {
-    if (canUseFileSystemAccessAPI()) {
+    if (useFsAccessApi && canUseFileSystemAccessAPI()) {
       dispatch({type: 'openDialog'})
       onFileDialogOpenCb()
       // https://developer.mozilla.org/en-US/docs/Web/API/window/showOpenFilePicker
@@ -686,6 +696,7 @@ export function useDropzone(options = {}) {
     dispatch,
     onFileDialogOpenCb,
     onFileDialogCancelCb,
+    useFsAccessApi,
     setFiles,
     accept,
     multiple

--- a/src/index.spec.js
+++ b/src/index.spec.js
@@ -1318,7 +1318,60 @@ describe('useDropzone() hook', () => {
       isIeOrEdgeSpy.mockClear()
     })
 
-    it('should use showOpenFilePicker() if supported and not trigger click on input', async () => {
+    it('should not use showOpenFilePicker() if supported and {useFsAccessApi} is not true', async () => {
+      jest.useFakeTimers()
+
+      const activeRef = createRef()
+      const active = <span ref={activeRef}>I am active</span>
+      const onClickSpy = jest.spyOn(HTMLInputElement.prototype, 'click')
+
+      const handlers = files.map(f => createFileSystemFileHandle(f))
+      const showOpenFilePickerMock = jest.fn().mockReturnValue(Promise.resolve(handlers))
+
+      window.showOpenFilePicker = showOpenFilePickerMock
+
+      const onDropSpy = jest.fn()
+      const onFileDialogOpenSpy = jest.fn()
+
+      const ui = (
+        <Dropzone
+          onDrop={onDropSpy}
+          onFileDialogOpen={onFileDialogOpenSpy}
+          accept="application/pdf"
+          multiple
+        >
+          {({ getRootProps, getInputProps, isFileDialogActive }) => (
+            <div {...getRootProps()}>
+              <input {...getInputProps()} />
+              {isFileDialogActive && active}
+            </div>
+          )}
+        </Dropzone>
+      )
+
+      const { container, rerender } = render(ui)
+
+      const dropzone = container.querySelector('div')
+
+      fireEvent.click(dropzone)
+
+      await flushPromises(rerender, ui)
+
+      dispatchEvt(document.body, 'focus')
+      drainTimers()
+
+      expect(onFileDialogOpenSpy).toHaveBeenCalled()
+
+      expect(activeRef.current).toBeNull()
+      expect(dropzone).not.toContainElement(activeRef.current)
+      expect(onClickSpy).toHaveBeenCalled()
+      expect(showOpenFilePickerMock).not.toHaveBeenCalled()
+      expect(onDropSpy).not.toHaveBeenCalled()
+
+      jest.useRealTimers()
+    })
+
+    it('should use showOpenFilePicker() if supported and {useFsAccessApi} is true, and not trigger click on input', async () => {
       const activeRef = createRef()
       const active = <span ref={activeRef}>I am active</span>
       const onClickSpy = jest.spyOn(HTMLInputElement.prototype, 'click')
@@ -1338,6 +1391,7 @@ describe('useDropzone() hook', () => {
           onFileDialogOpen={onFileDialogOpenSpy}
           accept="application/pdf"
           multiple
+          useFsAccessApi
         >
           {({ getRootProps, getInputProps, isFileDialogActive }) => (
             <div {...getRootProps()}>
@@ -1376,7 +1430,7 @@ describe('useDropzone() hook', () => {
       expect(onDropSpy).toHaveBeenCalledWith(files, [], null)
     })
 
-    test('if showOpenFilePicker() is supported it should work without the <input>', async () => {
+    test('if showOpenFilePicker() is supported and {useFsAccessApi} is true, it should work without the <input>', async () => {
       const activeRef = createRef()
       const active = <span ref={activeRef}>I am active</span>
 
@@ -1389,7 +1443,11 @@ describe('useDropzone() hook', () => {
       const onFileDialogOpenSpy = jest.fn()
 
       const ui = (
-        <Dropzone onDrop={onDropSpy} onFileDialogOpen={onFileDialogOpenSpy}>
+        <Dropzone
+          onDrop={onDropSpy}
+          onFileDialogOpen={onFileDialogOpenSpy}
+          useFsAccessApi
+        >
           {({ getRootProps, isFileDialogActive }) => (
             <div {...getRootProps()}>
               {isFileDialogActive && active}
@@ -1412,7 +1470,7 @@ describe('useDropzone() hook', () => {
       expect(onFileDialogOpenSpy).toHaveBeenCalled()
     })
 
-    test('if showOpenFilePicker() is supported and the user cancels it should call onFileDialogCancel', async () => {
+    test('if showOpenFilePicker() is supported and {useFsAccessApi} is true, and the user cancels it should call onFileDialogCancel', async () => {
       const activeRef = createRef()
       const active = <span ref={activeRef}>I am active</span>
 
@@ -1424,7 +1482,11 @@ describe('useDropzone() hook', () => {
       const onFileDialogCancelSpy = jest.fn()
 
       const ui = (
-        <Dropzone onDrop={onDropSpy} onFileDialogCancel={onFileDialogCancelSpy}>
+        <Dropzone
+          onDrop={onDropSpy}
+          onFileDialogCancel={onFileDialogCancelSpy}
+          useFsAccessApi
+        >
           {({ getRootProps, isFileDialogActive }) => (
             <div {...getRootProps()}>
               {isFileDialogActive && active}
@@ -1447,7 +1509,7 @@ describe('useDropzone() hook', () => {
       expect(onFileDialogCancelSpy).toHaveBeenCalled()
     })
 
-    test('window focus evt is not bound if showOpenFilePicker() is supported', async () => {
+    test('window focus evt is not bound if showOpenFilePicker() is supported and {useFsAccessApi} is true', async () => {
       jest.useFakeTimers()
 
       const activeRef = createRef()
@@ -1460,7 +1522,11 @@ describe('useDropzone() hook', () => {
       window.showOpenFilePicker = showOpenFilePickerMock
 
       const ui = (
-        <Dropzone onFileDialogCancel={onFileDialogCancelSpy} noClick>
+        <Dropzone
+          onFileDialogCancel={onFileDialogCancelSpy}
+          noClick
+          useFsAccessApi
+        >
           {({ getRootProps, isFileDialogActive, open }) => (
             <div {...getRootProps()}>
               {isFileDialogActive && active}


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

- [x] bugfix
- [ ] feature
- [ ] refactoring / style
- [ ] build / chore
- [ ] documentation

**Did you add tests for your changes?**

- [x] Yes, my code is well tested
- [ ] Not relevant

**If relevant, did you update the documentation?**

- [ ] Yes, I've updated the documentation
- [x] Not relevant

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

As discussed in https://github.com/react-dropzone/react-dropzone/discussions/1130, using FS access API introduces a breaking change in how the `accept` attribute works.
This change just adds a new option `useFsAccessApi` (false by default) which can be used to disable using the FS access API.

**Does this PR introduce a breaking change?**
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->
No.

**Other information**
