### PR TITLE
feat: enable file system access API by default

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -64,7 +64,7 @@ const defaultProps = {
   noDrag: false,
   noDragEventsBubbling: false,
   validator: null,
-  useFsAccessApi: false,
+  useFsAccessApi: true,
 };
 
 Dropzone.defaultProps = defaultProps;

--- a/src/index.spec.js
+++ b/src/index.spec.js
@@ -1370,6 +1370,7 @@ describe("useDropzone() hook", () => {
           onFileDialogOpen={onFileDialogOpenSpy}
           accept="application/pdf"
           multiple
+          useFsAccessApi={false}
         >
           {({ getRootProps, getInputProps, isFileDialogActive }) => (
             <div {...getRootProps()}>


### PR DESCRIPTION
**What kind of change does this PR introduce?**
- [ ] Bug Fix
- [x] Feature
- [ ] Refactoring
- [ ] Style
- [ ] Build
- [ ] Chore
- [ ] Documentation
- [ ] CI

**Did you add tests for your changes?**
- [x] Yes, my code is well tested
- [ ] Not relevant

**If relevant, did you update the documentation?**
- [ ] Yes, I've updated the documentation
- [x] Not relevant

**Summary**
Enable the [File System Access API](https://developer.mozilla.org/en-US/docs/Web/API/File_System_Access_API) by default.

**Does this PR introduce a breaking change?**
As of this change, the `accept` attribute does not work with file extensions anymore (at least not when picking files using the file dialog). Check https://developer.mozilla.org/en-US/docs/Web/API/window/showOpenFilePicker#parameters for more information.

**Other information**
