### PR TITLE
Use "KeyboardEvent.key" instead of "Keyboard.keyCode"

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -743,8 +743,8 @@ export function useDropzone(options = {}) {
       }
 
       if (
-        (event.key === 'Enter' || event.key === ' ') ||
-        (event.keyCode === 32 || event.keyCode === 13)
+        event.key === 'Enter' || event.key === ' ' ||
+        event.keyCode === 32 || event.keyCode === 13
       ) {
         event.preventDefault();
         openFileDialog();

--- a/src/index.js
+++ b/src/index.js
@@ -743,8 +743,10 @@ export function useDropzone(options = {}) {
       }
 
       if (
-        event.key === 'Enter' || event.key === ' ' ||
-        event.keyCode === 32 || event.keyCode === 13
+        event.key === " " ||
+        event.key === "Enter" ||
+        event.keyCode === 32 ||
+        event.keyCode === 13
       ) {
         event.preventDefault();
         openFileDialog();

--- a/src/index.js
+++ b/src/index.js
@@ -742,7 +742,11 @@ export function useDropzone(options = {}) {
         return;
       }
 
-      if (event.keyCode === 32 || event.keyCode === 13) {
+      if (
+        (event.key === 'Enter' || event.key === ' ') ||
+        (event.code === 'Enter' || event.code === 'Space') ||
+        (event.keyCode === 32 || event.keyCode === 13)
+      ) {
         event.preventDefault();
         openFileDialog();
       }

--- a/src/index.js
+++ b/src/index.js
@@ -744,7 +744,6 @@ export function useDropzone(options = {}) {
 
       if (
         (event.key === 'Enter' || event.key === ' ') ||
-        (event.code === 'Enter' || event.code === 'Space') ||
         (event.keyCode === 32 || event.keyCode === 13)
       ) {
         event.preventDefault();

--- a/src/index.spec.js
+++ b/src/index.spec.js
@@ -1789,17 +1789,25 @@ describe("useDropzone() hook", () => {
       const dropzone = container.querySelector("div");
 
       fireEvent.keyDown(dropzone, {
-        keyCode: 32,
+        keyCode: 32, // Space
       });
 
       fireEvent.keyDown(dropzone, {
-        keyCode: 13,
+        keyCode: 13, // Enter
+      });
+
+      fireEvent.keyDown(dropzone, {
+        key: " ", // Space
+      });
+
+      fireEvent.keyDown(dropzone, {
+        key: "Enter",
       });
 
       const ref = activeRef.current;
       expect(ref).not.toBeNull();
       expect(dropzone).toContainElement(ref);
-      expect(onClickSpy).toHaveBeenCalledTimes(2);
+      expect(onClickSpy).toHaveBeenCalledTimes(4);
     });
 
     it("does not trigger the click event on the input if the dropzone is not in focus", () => {
@@ -1817,7 +1825,11 @@ describe("useDropzone() hook", () => {
       const input = container.querySelector("input");
 
       fireEvent.keyDown(input, {
-        keyCode: 32,
+        keyCode: 32, // Space
+      });
+
+      fireEvent.keyDown(input, {
+        key: " ", // Space
       });
 
       expect(onClickSpy).not.toHaveBeenCalled();
@@ -1842,7 +1854,10 @@ describe("useDropzone() hook", () => {
       const dropzone = container.querySelector("div");
 
       fireEvent.keyDown(dropzone, {
-        keyCode: 32,
+        keyCode: 32, // Space
+      });
+      fireEvent.keyDown(dropzone, {
+        key: " ", // Space
       });
       expect(onClickSpy).not.toHaveBeenCalled();
     });
@@ -1862,7 +1877,10 @@ describe("useDropzone() hook", () => {
       const dropzone = container.querySelector("div");
 
       fireEvent.keyDown(dropzone, {
-        keyCode: 32,
+        keyCode: 32, // Space
+      });
+      fireEvent.keyDown(dropzone, {
+        key: " ", // Space
       });
       expect(onClickSpy).not.toHaveBeenCalled();
     });
@@ -1882,7 +1900,10 @@ describe("useDropzone() hook", () => {
       const dropzone = container.querySelector("div");
 
       fireEvent.keyDown(dropzone, {
-        keyCode: 32,
+        keyCode: 32, // Space
+      });
+      fireEvent.keyDown(dropzone, {
+        key: " ", // Space
       });
       expect(onClickSpy).not.toHaveBeenCalled();
 
@@ -1897,9 +1918,12 @@ describe("useDropzone() hook", () => {
       );
 
       fireEvent.keyDown(dropzone, {
-        keyCode: 32,
+        keyCode: 32, // Space
       });
-      expect(onClickSpy).toHaveBeenCalled();
+      fireEvent.keyDown(dropzone, {
+        key: " ", // Space
+      });
+      expect(onClickSpy).toHaveBeenCalledTimes(2);
     });
 
     it("does not trigger the click event on the input for other keys", () => {
@@ -1917,7 +1941,10 @@ describe("useDropzone() hook", () => {
       const dropzone = container.querySelector("div");
 
       fireEvent.keyDown(dropzone, {
-        keyCode: 97,
+        keyCode: 97, // Numpad1
+      });
+      fireEvent.keyDown(dropzone, {
+        key: "1",
       });
       expect(onClickSpy).not.toHaveBeenCalled();
     });


### PR DESCRIPTION
**What kind of change does this PR introduce?**
- [ ] Bug Fix
- [ ] Feature
- [X] Refactoring
- [ ] Style
- [ ] Build
- [ ] Chore
- [ ] Documentation
- [ ] CI

**Did you add tests for your changes?**
- [X] Yes, my code is well tested
- [ ] Not relevant

**If relevant, did you update the documentation?**
- [ ] Yes, I've updated the documentation
- [X] Not relevant

**Summary**
`KeyboardEvent.keyCode` is [deprecated](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/keyCode) and should not be used anymore.  
Browsers could drop support anytime and it's not recommended to use it.

**Does this PR introduce a breaking change?**
I don't think so.