### PR TITLE
feat: allow passing file ext. to the file picker options and close #1141

### DIFF
--- a/README.md
+++ b/README.md
@@ -343,8 +343,6 @@ As one can imagine, this doesn't really work if there's a lot of files or large 
 
 Fortunately, there's the [File System Access API](https://developer.mozilla.org/en-US/docs/Web/API/File_System_Access_API), which is currently a working draft and some browsers support it (see [browser compatibility](https://developer.mozilla.org/en-US/docs/Web/API/window/showOpenFilePicker#browser_compatibility)), that provides a reliable way to prompt the user for file selection and capture cancellation. 
 
-And this lib makes use of it if available. Though, there's a small catch: using file extensions for the `accept` property is not supported; you must use MIME types as described in [common MIME types](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types/Common_types). Also check [accepting specific file types](https://react-dropzone.js.org/#section-accepting-specific-file-types) for more info on the subject of `accept` limitations.
-
 Also keep in mind that the FS access API can only be used in [secure contexts](https://developer.mozilla.org/en-US/docs/Web/Security/Secure_Contexts).
 
 **NOTE** You can disable using the FS access API with the `useFsAccessApi` property: `useDropzone({useFsAccessApi: false})`.

--- a/examples/accept/README.md
+++ b/examples/accept/README.md
@@ -1,20 +1,16 @@
 By providing `accept` prop you can make the dropzone accept specific file types and reject the others.
 
-The value must be a comma-separated list of unique content type specifiers:
-* A file extension starting with the STOP character (U+002E). (e.g. .jpg, .png, .doc).
-* A valid MIME type with no extensions.
-* audio/* representing sound files.
-* video/* representing video files.
-* image/* representing image files.
+The value must be an object with a common [MIME type](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types/Common_types) as keys and an array of file extensions as values (similar to [showOpenFilePicker](https://developer.mozilla.org/en-US/docs/Web/API/window/showOpenFilePicker)'s types `accept` option).
+```js static
+useDropzone({
+  accept: {
+    'image/png': ['.png'],
+    'text/html': ['.html', '.htm'],
+  }
+})
+```
 
 For more information see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/Input.
-
-**IMPORTANT** As of [v12.0.0](https://github.com/react-dropzone/react-dropzone/releases/tag/v12.0.0), there has been some changes that affect how `accept` works.
-See [file dialog cancel callback](../../README.md#file-dialog-cancel-callback) to read more about why this change was introduced. In summary:
-1. In browsers that **do not support** the FS access API, the `accept` attr works exactly the same as in previous versions of react-dropozone, for both file picker and dag 'n' drop
-2. In browsers that **support** the FS access API, when passing file extensions to `accept` (e.g `".jpg,.png"`), the file picker will not apply those filters, but drag 'n' drop will - though, the [browser limitations](#browser-limitations) described in this document still apply
-3. If you want the same behaviour in all browsers, regardless of using the FS access API or not, you need to use MIME types - [browser limitations](#browser-limitations) still apply
-4. The use of FS access API can be turned off via `useDropzone({useFsAccessApi: false})`
 
 ```jsx harmony
 import React from 'react';
@@ -27,7 +23,10 @@ function Accept(props) {
     getRootProps,
     getInputProps
   } = useDropzone({
-    accept: 'image/jpeg,image/png'
+    accept: {
+      'image/jpeg': [],
+      'image/png': []
+    }
   });
 
   const acceptedFileItems = acceptedFiles.map(file => (
@@ -85,7 +84,9 @@ function Accept(props) {
     isDragAccept,
     isDragReject
   } = useDropzone({
-    accept: '.jpeg,.png'
+    accept: {
+      'image/jpeg': ['.jpeg', '.png']
+    }
   });
 
   return (
@@ -117,7 +118,9 @@ function Accept(props) {
     isDragAccept,
     isDragReject
   } = useDropzone({
-    accept: 'image/jpeg,image/png'
+    accept: {
+      'image/*': ['.jpeg', '.png']
+    }
   });
 
   return (

--- a/examples/pintura/README.md
+++ b/examples/pintura/README.md
@@ -77,7 +77,9 @@ const editImage = (image, done) => {
 function App() {
     const [files, setFiles] = useState([]);
     const { getRootProps, getInputProps } = useDropzone({
-        accept: 'image/*',
+        accept: {
+          'image/*': [],
+        },
         onDrop: (acceptedFiles) => {
             setFiles(
                 acceptedFiles.map((file) =>

--- a/examples/previews/README.md
+++ b/examples/previews/README.md
@@ -41,7 +41,9 @@ const img = {
 function Previews(props) {
   const [files, setFiles] = useState([]);
   const {getRootProps, getInputProps} = useDropzone({
-    accept: 'image/*',
+    accept: {
+      'image/*': []
+    },
     onDrop: acceptedFiles => {
       setFiles(acceptedFiles.map(file => Object.assign(file, {
         preview: URL.createObjectURL(file)

--- a/examples/styling/README.md
+++ b/examples/styling/README.md
@@ -41,7 +41,7 @@ function StyledDropzone(props) {
     isFocused,
     isDragAccept,
     isDragReject
-  } = useDropzone({accept: 'image/*'});
+  } = useDropzone({accept: {'image/*': []}});
 
   const style = useMemo(() => ({
     ...baseStyle,
@@ -110,7 +110,7 @@ function StyledDropzone(props) {
     isFocused,
     isDragAccept,
     isDragReject
-  } = useDropzone({accept: 'image/*'});
+  } = useDropzone({accept: {'image/*': []}});
   
   return (
     <div className="container">

--- a/src/index.spec.js
+++ b/src/index.spec.js
@@ -41,7 +41,9 @@ describe("useDropzone() hook", () => {
     });
 
     it("sets {accept} prop on the <input>", () => {
-      const accept = "image/jpeg";
+      const accept = {
+        "image/jpeg": [],
+      };
       const { container } = render(
         <Dropzone accept={accept}>
           {({ getRootProps, getInputProps }) => (
@@ -54,12 +56,16 @@ describe("useDropzone() hook", () => {
 
       const input = container.querySelector("input");
 
-      expect(input).toHaveAttribute("accept", accept);
+      expect(input).toHaveAttribute("accept", "image/jpeg");
     });
 
     it("updates {multiple} prop on the <input> when it changes", () => {
       const { container, rerender } = render(
-        <Dropzone accept="image/jpeg">
+        <Dropzone
+          accept={{
+            "image/jpeg": [],
+          }}
+        >
           {({ getRootProps, getInputProps }) => (
             <div {...getRootProps()}>
               <input {...getInputProps()} />
@@ -74,7 +80,11 @@ describe("useDropzone() hook", () => {
       );
 
       rerender(
-        <Dropzone accept="image/png">
+        <Dropzone
+          accept={{
+            "image/png": [],
+          }}
+        >
           {({ getRootProps, getInputProps }) => (
             <div {...getRootProps()}>
               <input {...getInputProps()} />
@@ -1368,7 +1378,9 @@ describe("useDropzone() hook", () => {
         <Dropzone
           onDrop={onDropSpy}
           onFileDialogOpen={onFileDialogOpenSpy}
-          accept="application/pdf"
+          accept={{
+            "application/pdf": [],
+          }}
           multiple
           useFsAccessApi={false}
         >
@@ -1425,7 +1437,9 @@ describe("useDropzone() hook", () => {
         <Dropzone
           onDrop={onDropSpy}
           onFileDialogOpen={onFileDialogOpenSpy}
-          accept="application/pdf"
+          accept={{
+            "application/pdf": [],
+          }}
           multiple
         >
           {({ getRootProps, getInputProps, isFileDialogActive }) => (
@@ -1481,7 +1495,9 @@ describe("useDropzone() hook", () => {
         <Dropzone
           onDrop={onDropSpy}
           onFileDialogOpen={onFileDialogOpenSpy}
-          accept="application/pdf"
+          accept={{
+            "application/pdf": [],
+          }}
           multiple
           useFsAccessApi
         >
@@ -1516,7 +1532,6 @@ describe("useDropzone() hook", () => {
         multiple: true,
         types: [
           {
-            description: "everything",
             accept: { "application/pdf": [] },
           },
         ],
@@ -1680,7 +1695,9 @@ describe("useDropzone() hook", () => {
         <Dropzone
           onDrop={onDropSpy}
           onFileDialogOpen={onFileDialogOpenSpy}
-          accept="application/pdf"
+          accept={{
+            "application/pdf": [],
+          }}
           multiple
           useFsAccessApi
         >
@@ -2215,7 +2232,11 @@ describe("useDropzone() hook", () => {
 
     it("sets {isDragActive} and {isDragReject} of some files are not accepted on dragenter", async () => {
       const ui = (
-        <Dropzone accept="image/*">
+        <Dropzone
+          accept={{
+            "image/*": [],
+          }}
+        >
           {({
             getRootProps,
             getInputProps,
@@ -2269,7 +2290,12 @@ describe("useDropzone() hook", () => {
 
     it("sets {isDragActive, isDragAccept, isDragReject} if any files are rejected and {multiple} is false on dragenter", async () => {
       const ui = (
-        <Dropzone accept="image/*" multiple={false}>
+        <Dropzone
+          accept={{
+            "image/*": [],
+          }}
+          multiple={false}
+        >
           {({
             getRootProps,
             getInputProps,
@@ -2337,7 +2363,11 @@ describe("useDropzone() hook", () => {
 
     it("updates {isDragActive} if {accept} changes mid-drag", async () => {
       const ui = (
-        <Dropzone accept="image/*">
+        <Dropzone
+          accept={{
+            "image/*": [],
+          }}
+        >
           {({
             getRootProps,
             getInputProps,
@@ -2366,7 +2396,11 @@ describe("useDropzone() hook", () => {
       expect(dropzone).not.toHaveTextContent("dragReject");
 
       rerender(
-        <Dropzone accept="text/*">
+        <Dropzone
+          accept={{
+            "text/*": [],
+          }}
+        >
           {({
             getRootProps,
             getInputProps,
@@ -2391,7 +2425,11 @@ describe("useDropzone() hook", () => {
 
     it("resets {isDragActive, isDragAccept, isDragReject} on dragleave", async () => {
       const ui = (
-        <Dropzone accept="image/*">
+        <Dropzone
+          accept={{
+            "image/*": [],
+          }}
+        >
           {({
             getRootProps,
             getInputProps,
@@ -2514,7 +2552,11 @@ describe("useDropzone() hook", () => {
         Array.from(errorList).every((item) => item.textContent === code);
 
       const ui = (
-        <Dropzone accept="image/*">
+        <Dropzone
+          accept={{
+            "image/*": [],
+          }}
+        >
           {({ getRootProps, getInputProps, acceptedFiles, fileRejections }) => (
             <div {...getRootProps()}>
               <input {...getInputProps()} />
@@ -2586,7 +2628,13 @@ describe("useDropzone() hook", () => {
     it("rejects all files if {multiple} is false and {accept} criteria is not met", async () => {
       const onDropSpy = jest.fn();
       const ui = (
-        <Dropzone accept="image/*" onDrop={onDropSpy} multiple={false}>
+        <Dropzone
+          accept={{
+            "image/*": [],
+          }}
+          onDrop={onDropSpy}
+          multiple={false}
+        >
           {({ getRootProps, getInputProps }) => (
             <div {...getRootProps()}>
               <input {...getInputProps()} />
@@ -2619,7 +2667,13 @@ describe("useDropzone() hook", () => {
     it("rejects all files if {multiple} is false and {accept} criteria is met", async () => {
       const onDropSpy = jest.fn();
       const ui = (
-        <Dropzone accept="image/*" onDrop={onDropSpy} multiple={false}>
+        <Dropzone
+          accept={{
+            "image/*": [],
+          }}
+          onDrop={onDropSpy}
+          multiple={false}
+        >
           {({ getRootProps, getInputProps }) => (
             <div {...getRootProps()}>
               <input {...getInputProps()} />
@@ -2663,7 +2717,9 @@ describe("useDropzone() hook", () => {
       const onDropRejectedSpy = jest.fn();
       const ui = (
         <Dropzone
-          accept="image/*"
+          accept={{
+            "image/*": [],
+          }}
           onDrop={onDropSpy}
           onDropRejected={onDropRejectedSpy}
           multiple={true}
@@ -2718,7 +2774,9 @@ describe("useDropzone() hook", () => {
       const onDropRejectedSpy = jest.fn();
       const ui = (maxFiles) => (
         <Dropzone
-          accept="image/*"
+          accept={{
+            "image/*": [],
+          }}
           onDrop={onDropSpy}
           multiple={true}
           maxFiles={maxFiles}
@@ -2758,7 +2816,9 @@ describe("useDropzone() hook", () => {
       const onDropRejectedSpy = jest.fn();
       const ui = (
         <Dropzone
-          accept="image/*"
+          accept={{
+            "image/*": [],
+          }}
           onDrop={onDropSpy}
           multiple={true}
           maxFiles={3}
@@ -2783,7 +2843,13 @@ describe("useDropzone() hook", () => {
     it("accepts a single files if {multiple} is false and {accept} criteria is met", async () => {
       const onDropSpy = jest.fn();
       const ui = (
-        <Dropzone accept="image/*" onDrop={onDropSpy} multiple={false}>
+        <Dropzone
+          accept={{
+            "image/*": [],
+          }}
+          onDrop={onDropSpy}
+          multiple={false}
+        >
           {({ getRootProps, getInputProps }) => (
             <div {...getRootProps()}>
               <input {...getInputProps()} />
@@ -2855,7 +2921,12 @@ describe("useDropzone() hook", () => {
     it("gets invoked with both accepted/rejected files", async () => {
       const onDropSpy = jest.fn();
       const ui = (
-        <Dropzone accept="image/*" onDrop={onDropSpy}>
+        <Dropzone
+          accept={{
+            "image/*": [],
+          }}
+          onDrop={onDropSpy}
+        >
           {({ getRootProps, getInputProps }) => (
             <div {...getRootProps()}>
               <input {...getInputProps()} />
@@ -2912,7 +2983,12 @@ describe("useDropzone() hook", () => {
     test("onDropAccepted callback is invoked if some files are accepted", async () => {
       const onDropAcceptedSpy = jest.fn();
       const ui = (
-        <Dropzone accept="image/*" onDropAccepted={onDropAcceptedSpy}>
+        <Dropzone
+          accept={{
+            "image/*": [],
+          }}
+          onDropAccepted={onDropAcceptedSpy}
+        >
           {({ getRootProps, getInputProps }) => (
             <div {...getRootProps()}>
               <input {...getInputProps()} />
@@ -2941,7 +3017,12 @@ describe("useDropzone() hook", () => {
     test("onDropRejected callback is invoked if some files are rejected", async () => {
       const onDropRejectedSpy = jest.fn();
       const ui = (
-        <Dropzone accept="image/*" onDropRejected={onDropRejectedSpy}>
+        <Dropzone
+          accept={{
+            "image/*": [],
+          }}
+          onDropRejected={onDropRejectedSpy}
+        >
           {({ getRootProps, getInputProps }) => (
             <div {...getRootProps()}>
               <input {...getInputProps()} />
@@ -2996,7 +3077,12 @@ describe("useDropzone() hook", () => {
     it("accepts a dropped image when Firefox provides a bogus file type", async () => {
       const onDropSpy = jest.fn();
       const ui = (
-        <Dropzone accept="image/*" onDrop={onDropSpy}>
+        <Dropzone
+          accept={{
+            "image/*": [],
+          }}
+          onDrop={onDropSpy}
+        >
           {({ getRootProps, getInputProps }) => (
             <div {...getRootProps()}>
               <input {...getInputProps()} />

--- a/src/utils/index.spec.js
+++ b/src/utils/index.spec.js
@@ -3,6 +3,10 @@ beforeEach(() => {
 });
 
 describe("fileMatchSize()", () => {
+  /**
+   * @constant
+   * @type {import('./index')}
+   */
   let utils;
   beforeEach(async () => {
     utils = await import("./index");
@@ -63,6 +67,10 @@ describe("fileMatchSize()", () => {
 });
 
 describe("isIeOrEdge", () => {
+  /**
+   * @constant
+   * @type {import('./index')}
+   */
   let utils;
   beforeEach(async () => {
     utils = await import("./index");
@@ -98,6 +106,10 @@ describe("isIeOrEdge", () => {
 
 describe("isKindFile()", () => {
   it('should return true for DataTransferItem of kind "file"', async () => {
+    /**
+     * @constant
+     * @type {import('./index')}
+     */
     const utils = await import("./index");
     expect(utils.isKindFile({ kind: "file" })).toBe(true);
     expect(utils.isKindFile({ kind: "text/html" })).toBe(false);
@@ -109,6 +121,10 @@ describe("isKindFile()", () => {
 describe("isPropagationStopped()", () => {
   const trueFn = jest.fn(() => true);
 
+  /**
+   * @constant
+   * @type {import('./index')}
+   */
   let utils;
   beforeEach(async () => {
     utils = await import("./index");
@@ -130,6 +146,10 @@ describe("isPropagationStopped()", () => {
 });
 
 describe("isEvtWithFiles()", () => {
+  /**
+   * @constant
+   * @type {import('./index')}
+   */
   let utils;
   beforeEach(async () => {
     utils = await import("./index");
@@ -176,7 +196,11 @@ describe("isEvtWithFiles()", () => {
   });
 });
 
-describe("composeEventHandlers", () => {
+describe("composeEventHandlers()", () => {
+  /**
+   * @constant
+   * @type {import('./index')}
+   */
   let utils;
   beforeEach(async () => {
     utils = await import("./index");
@@ -223,7 +247,11 @@ describe("composeEventHandlers", () => {
   });
 });
 
-describe("fileAccepted", () => {
+describe("fileAccepted()", () => {
+  /**
+   * @constant
+   * @type {import('./index')}
+   */
   let utils;
   beforeEach(async () => {
     utils = await import("./index");
@@ -273,6 +301,10 @@ describe("fileAccepted", () => {
 });
 
 describe("allFilesAccepted()", () => {
+  /**
+   * @constant
+   * @type {import('./index')}
+   */
   let utils;
   beforeEach(async () => {
     utils = await import("./index");
@@ -316,6 +348,10 @@ describe("allFilesAccepted()", () => {
 });
 
 describe("ErrorCode", () => {
+  /**
+   * @constant
+   * @type {import('./index')}
+   */
   let utils;
   beforeEach(async () => {
     utils = await import("./index");
@@ -330,6 +366,10 @@ describe("ErrorCode", () => {
 });
 
 describe("canUseFileSystemAccessAPI()", () => {
+  /**
+   * @constant
+   * @type {import('./index')}
+   */
   let utils;
   beforeEach(async () => {
     utils = await import("./index");
@@ -346,87 +386,109 @@ describe("canUseFileSystemAccessAPI()", () => {
   });
 });
 
-describe("filePickerOptionsTypes()", () => {
+describe("pickerOptionsFromAccept()", () => {
+  /**
+   * @constant
+   * @type {import('./index')}
+   */
   let utils;
   beforeEach(async () => {
     utils = await import("./index");
   });
 
-  it("should return proper types when the arg is a MIME type", () => {
-    expect(utils.filePickerOptionsTypes("application/zip")).toEqual([
-      {
-        description: "everything",
-        accept: { "application/zip": [] },
-      },
-    ]);
-  });
-
-  it("should return proper types when the arg is an array of MIME types", () => {
+  it("converts the {accept} prop to file picker options", () => {
     expect(
-      utils.filePickerOptionsTypes(["application/zip", "application/json"])
+      utils.pickerOptionsFromAccept({
+        "image/*": [".png", ".jpg"], // ok
+        "text/*": [".txt", ".pdf"], // ok
+        "audio/*": ["mp3"], // not ok
+        "*": [".p12"], // not ok
+      })
     ).toEqual([
       {
-        description: "everything",
         accept: {
-          "application/zip": [],
-          "application/json": [],
+          "image/*": [".png", ".jpg"],
         },
       },
-    ]);
-  });
-
-  it("should exclude anything that's not a MIME type", () => {
-    expect(
-      utils.filePickerOptionsTypes([
-        "audio/*",
-        "video/*",
-        "image/*",
-        ".txt",
-        "text/*",
-      ])
-    ).toEqual([
       {
-        description: "everything",
         accept: {
-          "audio/*": [],
-          "video/*": [],
-          "image/*": [],
-          "text/*": [],
+          "text/*": [".txt", ".pdf"],
         },
-      },
-    ]);
-  });
-
-  it("should work with comma separated string of MIME types", () => {
-    expect(
-      utils.filePickerOptionsTypes(
-        "audio/*,video/*,image/*,.txt,text/*,application/zip"
-      )
-    ).toEqual([
-      {
-        description: "everything",
-        accept: {
-          "audio/*": [],
-          "video/*": [],
-          "image/*": [],
-          "text/*": [],
-          "application/zip": [],
-        },
-      },
-    ]);
-  });
-
-  it("should return empty otherwise", () => {
-    expect(utils.filePickerOptionsTypes("")).toEqual([
-      {
-        description: "everything",
-        accept: {},
       },
     ]);
   });
 });
 
+describe("acceptPropAsAcceptAttr()", () => {
+  /**
+   * @constant
+   * @type {import('./index')}
+   */
+  let utils;
+  beforeEach(async () => {
+    utils = await import("./index");
+  });
+
+  it("converts {accept} to an array of strings", () => {
+    expect(
+      utils.acceptPropAsAcceptAttr({
+        "image/*": [".png", ".jpg"],
+        "text/*": [".txt", ".pdf"],
+        "audio/*": ["mp3"], // `mp3` not ok
+        "*": [".p12"], // `*` not ok
+      })
+    ).toEqual("image/*,.png,.jpg,text/*,.txt,.pdf,audio/*,.p12");
+  });
+});
+
+describe("isMIMEType()", () => {
+  /**
+   * @constant
+   * @type {import('./index')}
+   */
+  let utils;
+  beforeEach(async () => {
+    utils = await import("./index");
+  });
+
+  it("checks that the value is a valid MIME type string", () => {
+    expect(utils.isMIMEType("text/html")).toBe(true);
+    expect(utils.isMIMEType("text/*")).toBe(true);
+    expect(utils.isMIMEType("image/*")).toBe(true);
+    expect(utils.isMIMEType("video/*")).toBe(true);
+    expect(utils.isMIMEType("audio/*")).toBe(true);
+    expect(utils.isMIMEType("test/*")).toBe(false);
+    expect(utils.isMIMEType("text")).toBe(false);
+    expect(utils.isMIMEType("")).toBe(false);
+    expect(utils.isMIMEType(undefined)).toBe(false);
+  });
+});
+
+describe("isExt()", () => {
+  /**
+   * @constant
+   * @type {import('./index')}
+   */
+  let utils;
+  beforeEach(async () => {
+    utils = await import("./index");
+  });
+
+  it("checks that the value is a valid file extension", () => {
+    expect(utils.isExt(".jpg")).toBe(true);
+    expect(utils.isExt("me.jpg")).toBe(true);
+    expect(utils.isExt("me.prev.png")).toBe(true);
+    expect(utils.isExt("")).toBe(false);
+    expect(utils.isExt("text")).toBe(false);
+    expect(utils.isExt(undefined)).toBe(false);
+  });
+});
+
 describe("isAbort()", () => {
+  /**
+   * @constant
+   * @type {import('./index')}
+   */
   let utils;
   beforeEach(async () => {
     utils = await import("./index");
@@ -453,6 +515,10 @@ describe("isAbort()", () => {
 });
 
 describe("isSecurityError()", () => {
+  /**
+   * @constant
+   * @type {import('./index')}
+   */
   let utils;
   beforeEach(async () => {
     utils = await import("./index");

--- a/typings/react-dropzone.d.ts
+++ b/typings/react-dropzone.d.ts
@@ -28,7 +28,7 @@ export interface FileRejection {
 }
 
 export type DropzoneOptions = Pick<React.HTMLProps<HTMLElement>, PropTypes> & {
-  accept?: string | string[];
+  accept?: Accept;
   minSize?: number;
   maxSize?: number;
   maxFiles?: number;
@@ -90,3 +90,7 @@ export interface DropzoneInputProps
 }
 
 type PropTypes = "multiple" | "onDragEnter" | "onDragOver" | "onDragLeave";
+
+export interface Accept {
+  [key: string]: string[];
+}

--- a/typings/tests/accept.tsx
+++ b/typings/tests/accept.tsx
@@ -12,7 +12,9 @@ export default class Accept extends React.Component {
       <section>
         <div className="dropzone">
           <Dropzone
-            accept="image/jpeg, image/png"
+            accept={{
+              "image/*": [".jpeg", ".png"],
+            }}
             onDrop={(accepted, rejected) => {
               this.setState({ accepted, rejected });
             }}
@@ -50,39 +52,3 @@ export default class Accept extends React.Component {
     );
   }
 }
-
-export const acceptExt = (
-  <Dropzone accept=".jpeg,.png">
-    {({ getRootProps, isDragActive, isDragAccept, isDragReject }) => (
-      <div {...getRootProps()}>
-        {isDragAccept && "All files will be accepted"}
-        {isDragReject && "Some files will be rejected"}
-        {isDragActive && "Drop some files here ..."}
-      </div>
-    )}
-  </Dropzone>
-);
-
-export const acceptMime = (
-  <Dropzone accept="image/jpeg, image/png">
-    {({ getRootProps, isDragActive, isDragAccept, isDragReject }) => (
-      <div {...getRootProps()}>
-        {isDragAccept && "All files will be accepted"}
-        {isDragReject && "Some files will be rejected"}
-        {isDragActive && "Drop some files here ..."}
-      </div>
-    )}
-  </Dropzone>
-);
-
-export const acceptArray = (
-  <Dropzone accept={["image/jpeg", "image/png"]}>
-    {({ getRootProps, isDragActive, isDragAccept, isDragReject }) => (
-      <div {...getRootProps()}>
-        {isDragAccept && "All files will be accepted"}
-        {isDragReject && "Some files will be rejected"}
-        {isDragActive && "Drop some files here ..."}
-      </div>
-    )}
-  </Dropzone>
-);

--- a/typings/tests/all.tsx
+++ b/typings/tests/all.tsx
@@ -25,7 +25,9 @@ export default class Test extends React.Component {
           noDragEventsBubbling={false}
           disabled
           multiple={false}
-          accept="*.png"
+          accept={{
+            "image/*": [".png"],
+          }}
           useFsAccessApi={false}
         >
           {({ getRootProps, getInputProps }) => (


### PR DESCRIPTION
**What kind of change does this PR introduce?**
- [ ] Bug Fix
- [x] Feature
- [ ] Refactoring
- [ ] Style
- [ ] Build
- [ ] Chore
- [ ] Documentation
- [ ] CI

**Did you add tests for your changes?**
- [x] Yes, my code is well tested
- [ ] Not relevant

**If relevant, did you update the documentation?**
- [x] Yes, I've updated the documentation
- [ ] Not relevant

**Summary**
Allow users to pass the file extensions along the MIME type when the FS access API is supported.

**Does this PR introduce a breaking change?**
Yes. The `{accept}` prop will now require an object instead of a string or array of strings.

Before:
```js
useDropzone({
  accept: ".jpeg,.png"
  // accept: [".jpeg", ".png"]
})
```

After:
```js
useDropzone({
  accept: {
    "image/*": [".jpeg", ".png"]
  }
})
```

**Other information**
