### PR TITLE
[fix] - remove autocomplete for file input type

### DIFF
--- a/src/__snapshots__/index.spec.js.snap
+++ b/src/__snapshots__/index.spec.js.snap
@@ -1,3 +1,3 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`useDropzone() hook behavior renders the root and input nodes with the necessary props 1`] = `"<div role=\\"button\\" tabindex=\\"0\\"><input multiple=\\"\\" type=\\"file\\" style=\\"display: none;\\" autocomplete=\\"off\\" tabindex=\\"-1\\"></div>"`;
+exports[`useDropzone() hook behavior renders the root and input nodes with the necessary props 1`] = `"<div role=\\"button\\" tabindex=\\"0\\"><input multiple=\\"\\" type=\\"file\\" style=\\"display: none;\\" tabindex=\\"-1\\"></div>"`;

--- a/src/index.js
+++ b/src/index.js
@@ -867,7 +867,6 @@ export function useDropzone(options = {}) {
           onClick: composeHandler(
             composeEventHandlers(onClick, onInputElementClick)
           ),
-          autoComplete: "off",
           tabIndex: -1,
           [refKey]: inputRef,
         };


### PR DESCRIPTION
**What kind of change does this PR introduce?**
- [x] Bug Fix
- [ ] Feature
- [ ] Refactoring
- [ ] Style
- [ ] Build
- [ ] Chore
- [ ] Documentation
- [ ] CI

**Did you add tests for your changes?**
- [ ] Yes, my code is well tested
- [x] Not relevant

**If relevant, did you update the documentation?**
- [ ] Yes, I've updated the documentation
- [x] Not relevant

**Summary**
Explain the **motivation** for making this change. What existing problem does the pull request solve?
Try to link to an open issue for more information.

Our project is committed to using Web Content Accessibility Guidelines (WCAG) 2.1 Level AA. In particular, correct semantic elements of the HTML Living Standard should be used.
According to https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete `autocomplete` attribute is available on <input> elements that take a text or numeric value as input. 
Thus using `autocomplete` attribute for `file` input type courses errors while validating for the correct semantic elements of the HTML. For validation I use https://validator.w3.org/nu 

**Does this PR introduce a breaking change?**
No

**Other information**
