### PR TITLE
fix: use aria role `presentation` by default and close #1152

### DIFF
--- a/src/__snapshots__/index.spec.js.snap
+++ b/src/__snapshots__/index.spec.js.snap
@@ -1,3 +1,3 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`useDropzone() hook behavior renders the root and input nodes with the necessary props 1`] = `"<div role=\\"button\\" tabindex=\\"0\\"><input multiple=\\"\\" type=\\"file\\" style=\\"display: none;\\" tabindex=\\"-1\\"></div>"`;
+exports[`useDropzone() hook behavior renders the root and input nodes with the necessary props 1`] = `"<div role=\\"presentation\\" tabindex=\\"0\\"><input multiple=\\"\\" type=\\"file\\" style=\\"display: none;\\" tabindex=\\"-1\\"></div>"`;

--- a/src/index.js
+++ b/src/index.js
@@ -885,7 +885,7 @@ export function useDropzone(props = {}) {
           composeEventHandlers(onDragLeave, onDragLeaveCb)
         ),
         onDrop: composeDragHandler(composeEventHandlers(onDrop, onDropCb)),
-        role: typeof role === "string" && role !== "" ? role : "button",
+        role: typeof role === "string" && role !== "" ? role : "presentation",
         [refKey]: rootRef,
         ...(!disabled && !noKeyboard ? { tabIndex: 0 } : {}),
         ...rest,

--- a/src/index.spec.js
+++ b/src/index.spec.js
@@ -3408,7 +3408,7 @@ describe("useDropzone() hook", () => {
 
       expect(container.querySelector("#root")).toHaveAttribute(
         "role",
-        "button"
+        "presentation"
       );
     });
 


### PR DESCRIPTION
**What kind of change does this PR introduce?**
- [x] Bug Fix
- [ ] Feature
- [ ] Refactoring
- [ ] Style
- [ ] Build
- [ ] Chore
- [ ] Documentation
- [ ] CI

**Did you add tests for your changes?**
- [x] Yes, my code is well tested
- [ ] Not relevant

**If relevant, did you update the documentation?**
- [ ] Yes, I've updated the documentation
- [x] Not relevant

**Summary**
Using aria role `button` seems to be causing more issues than not having it set at all (as it was before we introduced the change). So this PR just switches the value to [presentation](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/presentation_role).

**Does this PR introduce a breaking change?**
Not for devs. But it does change how end users that use aids perceive it (easily fixed by overriding it).

**Other information**
