### PR TITLE
fix: call onError if FS access API fails in secure ctx

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -787,6 +787,12 @@ export function useDropzone(props = {}) {
             if (inputRef.current) {
               inputRef.current.value = null;
               inputRef.current.click();
+            } else {
+              onErrCb(
+                new Error(
+                  "Cannot open the file picker because the https://developer.mozilla.org/en-US/docs/Web/API/File_System_Access_API is not supported and no <input> was provided."
+                )
+              );
             }
           } else {
             onErrCb(e);


### PR DESCRIPTION
**What kind of change does this PR introduce?**
- [x] Bug Fix
- [ ] Feature
- [ ] Refactoring
- [ ] Style
- [ ] Build
- [ ] Chore
- [ ] Documentation
- [ ] CI

**Did you add tests for your changes?**
- [x] Yes, my code is well tested
- [ ] Not relevant

**If relevant, did you update the documentation?**
- [ ] Yes, I've updated the documentation
- [x] Not relevant

**Summary**
If the FS access API is supported, but the app is not running in a secure ctx, we'll try to use the input as fallback. But if this is missing, nothing will happen and the user will be confused. This PR just makes sure to call the `onError` cb if that case occurs.

**Does this PR introduce a breaking change?**
No.

**Other information**
