### PR TITLE
Fix not able to accept multiple files types

### DIFF
--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -197,7 +197,7 @@ export function canUseFileSystemAccessAPI() {
  */
 export function pickerOptionsFromAccept(accept) {
   if (isDefined(accept)) {
-    return Object.entries(accept)
+    const acceptForPicker = Object.entries(accept)
       .filter(([mimeType, ext]) => {
         let ok = true;
 
@@ -217,11 +217,18 @@ export function pickerOptionsFromAccept(accept) {
 
         return ok;
       })
-      .map(([mimeType, ext]) => ({
-        accept: {
+      .reduce(
+        (agg, [mimeType, ext]) => ({
+          ...agg,
           [mimeType]: ext,
-        },
-      }));
+        }),
+        {}
+      );
+    return [
+      {
+        accept: acceptForPicker,
+      },
+    ];
   }
   return accept;
 }

--- a/src/utils/index.spec.js
+++ b/src/utils/index.spec.js
@@ -415,10 +415,6 @@ describe("pickerOptionsFromAccept()", () => {
       {
         accept: {
           "image/*": [".png", ".jpg"],
-        },
-      },
-      {
-        accept: {
           "text/*": [".txt", ".pdf"],
         },
       },


### PR DESCRIPTION
**What kind of change does this PR introduce?**
- [X] Bug Fix
- [ ] Feature
- [ ] Refactoring
- [ ] Style
- [ ] Build
- [ ] Chore
- [ ] Documentation
- [ ] CI

**Did you add tests for your changes?**
- [X] Yes, my code is well tested
- [ ] Not relevant

**If relevant, did you update the documentation?**
- [ ] Yes, I've updated the documentation
- [X] Not relevant

**Summary**
Can't accept more than one file type, tried to accept both images and videos and ran into a problem.

**Reproduce**
[Demo on website](https://react-dropzone.js.org/#section-accepting-specific-file-types) - Can't pick png, only first option is available to pick.

**Does this PR introduce a breaking change?**
No
