### PR TITLE
fix: work around Chromium File System Access API bug

### DIFF
--- a/src/index.spec.js
+++ b/src/index.spec.js
@@ -1537,6 +1537,7 @@ describe("useDropzone() hook", () => {
         multiple: true,
         types: [
           {
+            description: "Files",
             accept: { "application/pdf": [] },
           },
         ],

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -226,6 +226,8 @@ export function pickerOptionsFromAccept(accept) {
       );
     return [
       {
+        // description is required due to https://crbug.com/1264708
+        description: "Files",
         accept: acceptForPicker,
       },
     ];

--- a/src/utils/index.spec.js
+++ b/src/utils/index.spec.js
@@ -413,6 +413,7 @@ describe("pickerOptionsFromAccept()", () => {
       })
     ).toEqual([
       {
+        description: "Files",
         accept: {
           "image/*": [".png", ".jpg"],
           "text/*": [".txt", ".pdf"],


### PR DESCRIPTION



**What kind of change does this PR introduce?**
- [x] Bug Fix
- [ ] Feature
- [ ] Refactoring
- [ ] Style
- [ ] Build
- [ ] Chore
- [ ] Documentation
- [ ] CI

**Did you add tests for your changes?**
- [x] Yes, my code is well tested
- [ ] Not relevant

**If relevant, did you update the documentation?**
- [ ] Yes, I've updated the documentation
- [x] Not relevant

**Summary**
This works around https://crbug.com/1264708 by always including a description in the FilePickerAcceptType passed to the options of window.showOpenFilePicker().

Fixes #1127.
Fixes #1222.
Fixes #1190.

**Does this PR introduce a breaking change?**
no
