### PR TITLE
fix: acceptPropAsAcceptAttr will return extensions properly

### DIFF
--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -244,7 +244,10 @@ export function acceptPropAsAcceptAttr(accept) {
   if (isDefined(accept)) {
     return (
       Object.entries(accept)
-        .reduce((a, [mimeType, ext]) => [...a, mimeType, ...ext], [])
+        .reduce((a, [mimeType, ext]) => {
+          const validExt = ext.filter(isExt);
+          return [...a, ...(validExt.length > 0 ? validExt : [mimeType])];
+        }, [])
         // Silently discard invalid entries as pickerOptionsFromAccept warns about these
         .filter((v) => isMIMEType(v) || isExt(v))
         .join(",")

--- a/src/utils/index.spec.js
+++ b/src/utils/index.spec.js
@@ -438,10 +438,11 @@ describe("acceptPropAsAcceptAttr()", () => {
       utils.acceptPropAsAcceptAttr({
         "image/*": [".png", ".jpg"],
         "text/*": [".txt", ".pdf"],
+        "video/*": [],
         "audio/*": ["mp3"], // `mp3` not ok
         "*": [".p12"], // `*` not ok
       })
-    ).toEqual("image/*,.png,.jpg,text/*,.txt,.pdf,audio/*,.p12");
+    ).toEqual(".png,.jpg,.txt,.pdf,video/*,audio/*,.p12");
   });
 });
 


### PR DESCRIPTION
**What kind of change does this PR introduce?**
- [x] Bug Fix
- [ ] Feature
- [ ] Refactoring
- [ ] Style
- [ ] Build
- [ ] Chore
- [ ] Documentation
- [ ] CI

**Did you add tests for your changes?**
- [x] Yes, my code is well tested
- [ ] Not relevant

**If relevant, did you update the documentation?**
- [ ] Yes, I've updated the documentation
- [x] Not relevant

**Summary**
File extensions in the `accept` property were ignored, for example:
```js
useDropzone({
    accept: {
      'image/jpeg': ['.jpg']
    }
  })
```
 This code was accepting `.jfif` files too.

**Does this PR introduce a breaking change?**
Non-breaking change.

**Other information**
