### PR TITLE
Add missing dependency

### DIFF
--- a/examples/previews/README.md
+++ b/examples/previews/README.md
@@ -67,7 +67,7 @@ function Previews(props) {
   useEffect(() => {
     // Make sure to revoke the data uris to avoid memory leaks, will run on unmount
     return () => files.forEach(file => URL.revokeObjectURL(file.preview));
-  }, []);
+  }, [files]);
 
   return (
     <section className="container">


### PR DESCRIPTION
Fixes linting error: 

> React Hook useEffect has a missing dependency: 'files'. Either include it or remove the dependency array. eslint (react-hooks/exhaustive-deps)


**What kind of change does this PR introduce?**
- [ ] Bug Fix
- [ ] Feature
- [ ] Refactoring
- [ ] Style
- [ ] Build
- [ ] Chore
- [x] Documentation
- [ ] CI

**Did you add tests for your changes?**
- [x] Yes, my code is well tested
- [ ] Not relevant

**If relevant, did you update the documentation?**
- [x] Yes, I've updated the documentation
- [ ] Not relevant

**Summary**
Explain the **motivation** for making this change. What existing problem does the pull request solve?
Try to link to an open issue for more information.

**Does this PR introduce a breaking change?**
If this PR introduces a breaking change, please describe the impact and a migration path for existing applications.

**Other information**
