### PR TITLE
feat: accept-folder-drop-overs

### DIFF
--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -54,7 +54,7 @@ export const TOO_MANY_FILES_REJECTION = {
 // that MIME type will always be accepted
 export function fileAccepted(file, accept) {
   const isAcceptable =
-    file.type === "application/x-moz-file" || accepts(file, accept);
+    file.type === "application/x-moz-file" || file.type === '' || accepts(file, accept);
   return [
     isAcceptable,
     isAcceptable ? null : getInvalidTypeRejectionErr(accept),


### PR DESCRIPTION
**What kind of change does this PR introduce?**
- [x] Bug Fix
- [ ] Feature
- [ ] Refactoring
- [ ] Style
- [ ] Build
- [ ] Chore
- [ ] Documentation
- [ ] CI

**Did you add tests for your changes?**
- [ ] Yes, my code is well tested
- [x] Not relevant

**If relevant, did you update the documentation?**
- [ ] Yes, I've updated the documentation
- [ ] Not relevant

**Summary**
`react-dropdown` supports dropping folders but returns `isDragReject`: `true` when dragging folders. This fixes that

**Does this PR introduce a breaking change?**
If this PR introduces a breaking change, please describe the impact and a migration path for existing applications.

**Other information**
