### PR TITLE
[Feature] Add ignoreNonFileDragEvents flag to prevent conflicts with other drag + drop libraries

### DIFF
--- a/examples/events/README.md
+++ b/examples/events/README.md
@@ -162,3 +162,33 @@ import Dropzone from 'react-dropzone';
   )}
 </Dropzone>
 ```
+
+If you would like to apply react-dropzone's event handling behavior only to file drag events, use the `{ignoreNonFileDragEvents}` flag. This can be helpful to prevent interference when used in conjunction with other drag and drop libraries:
+```jsx harmony
+import React from 'react';
+import {useDropzone} from 'react-dropzone';
+
+function Dropzone(props) {
+  const { getRootProps } = useDropzone({
+    ignoreNonFileDragEvents: true,
+    noDragEventsBubbling: true,
+    // Note how this callback is never invoked if you drag a link over the dropzone
+    onDragoOver: files => console.log(files)
+  });
+
+  // this callback is invoked if you drop a link over the dropzone because the dropzone
+  // will ignore the noEventBubbling flag for non-file drag events
+  const handleLinkDrop= event => {
+    console.log(event)
+    // Do something with the link
+  };
+
+  return (
+    <div className="container" onDrop={handleLinkDrop}>
+      <div {...getRootProps()}>
+        <Dropzone />
+      </div>
+    </div>
+  );
+}
+```

--- a/src/index.spec.js
+++ b/src/index.spec.js
@@ -900,6 +900,119 @@ describe("useDropzone() hook", () => {
       expect(innerDragLeave).toHaveBeenCalled();
       expect(parentDragLeave).not.toHaveBeenCalled();
     });
+
+    test("non-file drag events are ignored when {ignoreNonFileDragEvents} is set to true", async () => {
+      const nonFileDtEvent = createDtWithoutFiles();
+
+      const dragEnterSpy = jest.fn();
+      const dragOverSpy = jest.fn();
+      const dragLeaveSpy = jest.fn();
+      const dropSpy = jest.fn();
+
+      const { container } = render(
+        <Dropzone
+          ignoreNonFileDragEvents
+          onDragLeave={dragLeaveSpy}
+          onDragEnter={dragEnterSpy}
+          onDragOver={dragOverSpy}
+          onDrop={dropSpy}
+        >
+          {({ getRootProps, getInputProps }) => (
+            <div id="dropzone" {...getRootProps()}>
+              <input {...getInputProps()} />
+            </div>
+          )}
+        </Dropzone>
+      );
+
+      const zone = container.querySelector("#dropzone");
+
+      await act(() => fireEvent.dragEnter(zone, nonFileDtEvent));
+      await act(() => fireEvent.dragOver(zone, nonFileDtEvent));
+      await act(() => fireEvent.drop(zone, nonFileDtEvent));
+      await act(() => fireEvent.dragLeave(zone, nonFileDtEvent));
+
+      expect(dragEnterSpy).not.toHaveBeenCalled();
+      expect(dragOverSpy).not.toHaveBeenCalled();
+      expect(dragLeaveSpy).not.toHaveBeenCalled();
+      expect(dropSpy).not.toHaveBeenCalled();
+    });
+
+    test("non-file drag events bubble when {ignoreNonFileDragEvents} is set to true", async () => {
+      const nonFileDtEvent = createDtWithoutFiles();
+
+      const dragEnterSpy = jest.fn();
+      const dragOverSpy = jest.fn();
+      const dragLeaveSpy = jest.fn();
+      const dropSpy = jest.fn();
+
+      const { container } = render(
+        <div
+          id="container"
+          onDragLeave={dragLeaveSpy}
+          onDragEnter={dragEnterSpy}
+          onDragOver={dragOverSpy}
+          onDrop={dropSpy}
+        >
+          <Dropzone ignoreNonFileDragEvents noDragEventsBubbling>
+            {({ getRootProps, getInputProps }) => (
+              <div id="dropzone" {...getRootProps()}>
+                <input {...getInputProps()} />
+              </div>
+            )}
+          </Dropzone>
+        </div>
+      );
+
+      const zone = container.querySelector("#dropzone");
+
+      await act(() => fireEvent.dragEnter(zone, nonFileDtEvent));
+      await act(() => fireEvent.dragOver(zone, nonFileDtEvent));
+      await act(() => fireEvent.drop(zone, nonFileDtEvent));
+      await act(() => fireEvent.dragLeave(zone, nonFileDtEvent));
+
+      expect(dragEnterSpy).toHaveBeenCalled();
+      expect(dragOverSpy).toHaveBeenCalled();
+      expect(dragLeaveSpy).toHaveBeenCalled();
+      expect(dropSpy).toHaveBeenCalled();
+    });
+
+    test("file drag events do not bubble when {ignoreNonFileDragEvents} is set to true", async () => {
+      const dragEnterSpy = jest.fn();
+      const dragOverSpy = jest.fn();
+      const dragLeaveSpy = jest.fn();
+      const dropSpy = jest.fn();
+
+      const { container } = render(
+        <div
+          id="container"
+          onDragLeave={dragLeaveSpy}
+          onDragEnter={dragEnterSpy}
+          onDragOver={dragOverSpy}
+          onDrop={dropSpy}
+        >
+          <Dropzone ignoreNonFileDragEvents noDragEventsBubbling>
+            {({ getRootProps, getInputProps }) => (
+              <div id="dropzone" {...getRootProps()}>
+                <input {...getInputProps()} />
+              </div>
+            )}
+          </Dropzone>
+        </div>
+      );
+
+      const zone = container.querySelector("#dropzone");
+
+      await act(() => fireEvent.dragEnter(zone, data));
+      await act(() => fireEvent.dragOver(zone, data));
+      await act(() => fireEvent.drop(zone, data));
+      await act(() => fireEvent.dragLeave(zone, data));
+
+      expect(dragEnterSpy).not.toHaveBeenCalled();
+      expect(dragOverSpy).not.toHaveBeenCalled();
+      expect(dragLeaveSpy).not.toHaveBeenCalled();
+      expect(dropSpy).not.toHaveBeenCalled();
+    });
   });
 
   describe("plugin integration", () => {
@@ -3585,6 +3698,20 @@ function createDtWithFiles(files = []) {
         getAsFile: () => file,
       })),
       types: ["Files"],
+    },
+  };
+}
+
+/**
+ * createDtWithoutFiles creates a mock data transfer object that can be used for non-file drop events
+ * @param {File[]} files
+ */
+function createDtWithoutFiles() {
+  return {
+    dataTransfer: {
+      files: [],
+      items: [],
+      types: [],
     },
   };
 }


### PR DESCRIPTION
**What kind of change does this PR introduce?**
- [ ] Bug Fix
- [x] Feature
- [ ] Refactoring
- [ ] Style
- [ ] Build
- [ ] Chore
- [ ] Documentation
- [ ] CI

**Did you add tests for your changes?**
- [x] Yes, my code is well tested
- [ ] Not relevant

**If relevant, did you update the documentation?**
- [x] Yes, I've updated the documentation
- [ ] Not relevant

**Summary**
We are using `react-dropzone` as part of [a new feature in metabase ](https://github.com/metabase/metabase/issues/29561). Our application has a number of other drag-and-drop interactions throughout the application, and we found that we needed the ability to scope react-dropzone's event handling only to file drag events, because it interfered with other event types.

This pull request adds an optional `ignoreNonFileDragEvents` prop, which allows toggling of the intended behavior. Hopefully this option will be useful in other applications that may be relying on drag/drop events for other purposes.

**Does this PR introduce a breaking change?**
No breaking changes. Simply adds a customization option.

**Other information**
