### PR TITLE
fix: disable file access API by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -337,7 +337,7 @@ Fortunately, there's the [File System Access API](https://developer.mozilla.org/
 
 Also keep in mind that the FS access API can only be used in [secure contexts](https://developer.mozilla.org/en-US/docs/Web/Security/Secure_Contexts).
 
-**NOTE** You can disable using the FS access API with the `useFsAccessApi` property: `useDropzone({useFsAccessApi: false})`.
+**NOTE** You can enable using the FS access API with the `useFsAccessApi` property: `useDropzone({useFsAccessApi: true})`.
 
 ## Supported Browsers
 We use [browserslist](https://github.com/browserslist/browserslist) config to state the browser support for this lib, so check it out on [browserslist.dev](https://browserslist.dev/?q=ZGVmYXVsdHM%3D).

--- a/examples/events/README.md
+++ b/examples/events/README.md
@@ -111,7 +111,7 @@ function DropzoneWithoutClick(props) {
 <DropzoneWithoutClick />
 ```
 
-**NOTE** If the browser supports the [File System Access API](https://developer.mozilla.org/en-US/docs/Web/API/File_System_Access_API), removing the `<input>` has no effect.
+**NOTE** If the browser supports the [File System Access API](https://developer.mozilla.org/en-US/docs/Web/API/File_System_Access_API) and you've set the `useFsAccessApi` to true, removing the `<input>` has no effect.
 
 If you'd like to selectively turn off the default dropzone behavior for drag events, use the `{noDrag}` property:
 ```jsx harmony

--- a/src/index.js
+++ b/src/index.js
@@ -67,7 +67,7 @@ const defaultProps = {
   noDrag: false,
   noDragEventsBubbling: false,
   validator: null,
-  useFsAccessApi: true,
+  useFsAccessApi: false,
   autoFocus: false,
 };
 

--- a/src/index.spec.js
+++ b/src/index.spec.js
@@ -1408,7 +1408,6 @@ describe("useDropzone() hook", () => {
             "application/pdf": [],
           }}
           multiple
-          useFsAccessApi={false}
         >
           {({ getRootProps, getInputProps, isFileDialogActive }) => (
             <div {...getRootProps()}>
@@ -1751,7 +1750,7 @@ describe("useDropzone() hook", () => {
       window.showOpenFilePicker = showOpenFilePickerMock;
 
       const { container } = render(
-        <Dropzone onFileDialogCancel={onFileDialogCancelSpy}>
+        <Dropzone onFileDialogCancel={onFileDialogCancelSpy} useFsAccessApi>
           {({ getRootProps, getInputProps, isFileDialogActive }) => (
             <div {...getRootProps()}>
               <input {...getInputProps()} />


### PR DESCRIPTION
**What kind of change does this PR introduce?**
- [x] Bug Fix
- [ ] Feature
- [ ] Refactoring
- [ ] Style
- [ ] Build
- [ ] Chore
- [ ] Documentation
- [ ] CI

**Did you add tests for your changes?**
- [x] Yes, my code is well tested
- [ ] Not relevant

**If relevant, did you update the documentation?**
- [ ] Yes, I've updated the documentation
- [x] Not relevant

**Summary**
Explain the **motivation** for making this change. What existing problem does the pull request solve?
Try to link to an open issue for more information.

Make the use of file access API  an opt-in instead of opt-out (see https://github.com/react-dropzone/react-dropzone/discussions/1186).

**Does this PR introduce a breaking change?**
If this PR introduces a breaking change, please describe the impact and a migration path for existing applications.

No (well, most likely not, unless users stopped using the `<input>`, in which case this would be a breaking change 😬 ).

**Other information**
