### PR TITLE
fix: fix exports declaration

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,9 +5,14 @@
   "module": "dist/es/index.js",
   "exports": {
     ".": {
-      "import": "./dist/es/index.js",
-      "require": "./dist/index.js",
-      "types": "./typings/react-dropzone.d.ts"
+      "import": {
+        "types": "./typings/react-dropzone.d.ts",
+        "default": "./dist/es/index.js"
+      },
+      "require": {
+        "types": "./typings/react-dropzone.d.ts",
+        "default" : "./dist/index.js"
+      }
     }
   },
   "typesVersions": {


### PR DESCRIPTION
**What kind of change does this PR introduce?**
- [x] Bug Fix
- [ ] Feature
- [ ] Refactoring
- [ ] Style
- [ ] Build
- [ ] Chore
- [ ] Documentation
- [ ] CI

**Did you add tests for your changes?**
- [ ] Yes, my code is well tested
- [x] Not relevant

**If relevant, did you update the documentation?**
- [ ] Yes, I've updated the documentation
- [x] Not relevant

**Summary**

Address the error reported by https://publint.dev/react-dropzone@14.2.9:

<img width="797" alt="Screenshot 2024-10-12 at 13 45 23" src="https://github.com/user-attachments/assets/32f3c788-e9ff-4cdc-9f17-62d620946b04">

**Does this PR introduce a breaking change?**

No.

**Other information**

There are still a few warnings left after the fix which we should address in a subsequent PR.

```
Suggestions:
1. The package does not specify the type field. NodeJS may attempt to detect the package type causing a small performance hit. Consider adding "type": "commonjs".
2. pkg.repository.url is https://github.com/react-dropzone/react-dropzone.git but could be a full git URL like "git+https://github.com/react-dropzone/react-dropzone.git".
3. The package publishes internal tests or config files. You can use pkg.files to only publish certain files and save user bandwidth.
Warnings:
1. pkg.exports["."].import.types types is interpreted as CJS when resolving with the "import" condition. This causes the types to be ambiguous when default importing the package due to its implied interop. Consider splitting out two "types" conditions for "import" and "require", and use the .mts extension, e.g. pkg.exports["."].import.import.types: "./typings/react-dropzone.d.mts"
2. pkg.exports["."].import.default is ./dist/es/index.js and is written in ESM, but is interpreted as CJS. Consider using the .mjs extension, e.g. ./dist/es/index.mjs
```