### PR TITLE
fix: make ESM build compatible with native Node.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,9 +24,10 @@
   "scripts": {
     "cz": "git-cz",
     "clean": "rimraf ./dist",
-    "build": "yarn clean && yarn build:umd && yarn build:es",
+    "build": "yarn clean && yarn build:umd && yarn build:es && yarn build:es-package",
     "build:umd": "cross-env NODE_ENV=es rollup -c",
     "build:es": "cross-env BABEL_ENV=es babel ./src --out-dir ./dist/es --ignore '**/*.spec.js'",
+    "build:es-package": "echo '{\"type\":\"module\"}' > dist/es/package.json",
     "start": "styleguidist server",
     "styleguide": "styleguidist build",
     "test": "cross-env NODE_ENV=test yarn lint && jest --coverage && yarn typescript",

--- a/src/index.js
+++ b/src/index.js
@@ -26,7 +26,7 @@ import {
   onDocumentDragOver,
   pickerOptionsFromAccept,
   TOO_MANY_FILES_REJECTION,
-} from "./utils/index";
+} from "./utils/index.js";
 
 /**
  * Convenience wrapper component for the `useDropzone` hook
@@ -1039,4 +1039,4 @@ function reducer(state, action) {
 
 function noop() {}
 
-export { ErrorCode } from "./utils";
+export { ErrorCode } from "./utils/index.js";


### PR DESCRIPTION
- Add extensions to relative import/export.
- Add `{"type": "module"}` to the ESM build directory.

**What kind of change does this PR introduce?**
- [x] Bug Fix
- [ ] Feature
- [ ] Refactoring
- [ ] Style
- [ ] Build
- [ ] Chore
- [ ] Documentation
- [ ] CI

**Did you add tests for your changes?**
- [ ] Yes, my code is well tested
- [x] Not relevant

**If relevant, did you update the documentation?**
- [ ] Yes, I've updated the documentation
- [x] Not relevant

**Summary**
Explain the **motivation** for making this change. What existing problem does the pull request solve?
Try to link to an open issue for more information.

Allows to `import` the library from Node.js, for example with ESM-native SSR tools like Vite.

**Does this PR introduce a breaking change?**
If this PR introduces a breaking change, please describe the impact and a migration path for existing applications.

It should not be breaking.

**Other information**

Fixes: https://github.com/react-dropzone/react-dropzone/issues/1259