### PR TITLE
Use React.JSX instead of global JSX

### DIFF
--- a/typings/react-dropzone.d.ts
+++ b/typings/react-dropzone.d.ts
@@ -4,11 +4,11 @@ import { FileWithPath } from "file-selector";
 export { FileWithPath };
 export default function Dropzone(
   props: DropzoneProps & React.RefAttributes<DropzoneRef>
-): JSX.Element;
+): React.JSX.Element;
 export function useDropzone(options?: DropzoneOptions): DropzoneState;
 
 export interface DropzoneProps extends DropzoneOptions {
-  children?(state: DropzoneState): JSX.Element;
+  children?(state: DropzoneState): React.JSX.Element;
 }
 
 export enum ErrorCode {


### PR DESCRIPTION
Related to #1400.

**What kind of change does this PR introduce?**
- [x] Bug Fix

**Did you add tests for your changes?**
- [x] Not relevant

**If relevant, did you update the documentation?**
- [x] Not relevant

**Summary**

To be compatible with React 19 typings, where global JSX was removed: https://react.dev/blog/2024/04/25/react-19-upgrade-guide#the-jsx-namespace-in-typescript

**Does this PR introduce a breaking change?**

I don't think it does. In particular, react-dropzone requires React v16.8 or newer, and there are `@types/react` releases for that old React version which include the new `React.JSX` type already. (I haven't verified this myself but read it online.)
