### PR TITLE
Fix for compatible with React 19

### DIFF
--- a/typings/react-dropzone.d.ts
+++ b/typings/react-dropzone.d.ts
@@ -4,11 +4,11 @@ import { FileWithPath } from "file-selector";
 export { FileWithPath };
 export default function Dropzone(
   props: DropzoneProps & React.RefAttributes<DropzoneRef>
-): JSX.Element;
+): React.ReactElement;
 export function useDropzone(options?: DropzoneOptions): DropzoneState;
 
 export interface DropzoneProps extends DropzoneOptions {
-  children?(state: DropzoneState): JSX.Element;
+  children?(state: DropzoneState): React.ReactElement;
 }
 
 export enum ErrorCode {


### PR DESCRIPTION
Related to https://github.com/react-dropzone/react-dropzone/issues/1400

**What kind of change does this PR introduce?**
- [x] Bug Fix

**Did you add tests for your changes?**
- [x] Not relevant

**If relevant, did you update the documentation?**
- [x] Not relevant

**Summary**
To be compatible with React 19 typings, where global JSX was removed: https://react.dev/blog/2024/04/25/react-19-upgrade-guide#the-jsx-namespace-in-typescript

**Does this PR introduce a breaking change?**
Assumed to be unaffected due to type conversion only

**Other information**
ReactElement is more reliable than React.JSX.Element, which “may” be backported in some versions.

See also: similar fixes merged in another library (react-datepicker)
https://github.com/Hacker0x01/react-datepicker/pull/5296