### PR TITLE
fix(event_type): :art: update drop event type to filesystemfile handle

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -154,7 +154,7 @@ Dropzone.propTypes = {
   /**
    * Use this to provide a custom file aggregator
    *
-   * @param {(DragEvent|Event)} event A drag event or input change event (if files were selected via the file dialog)
+   * @param {(DragEvent|Event|Array<FileSystemFileHandle>)} event A drag event or input change event (if files were selected via the file dialog)
    */
   getFilesFromEvent: PropTypes.func,
 
@@ -310,7 +310,7 @@ export default Dropzone;
  * in a asynchronous fashion, from drag or input change events.
  *
  * @callback getFilesFromEvent
- * @param {(DragEvent|Event)} event A drag event or input change event (if files were selected via the file dialog)
+ * @param {(DragEvent|Event|Array<FileSystemFileHandle>)} event A drag event or input change event (if files were selected via the file dialog)
  * @returns {(File[]|Promise<File[]>)}
  */
 

--- a/typings/react-dropzone.d.ts
+++ b/typings/react-dropzone.d.ts
@@ -63,7 +63,8 @@ export type DropEvent =
   | React.DragEvent<HTMLElement>
   | React.ChangeEvent<HTMLInputElement>
   | DragEvent
-  | Event;
+  | Event
+  | Array<FileSystemFileHandle>;
 
 export type DropzoneState = DropzoneRef & {
   isFocused: boolean;


### PR DESCRIPTION
since useFsAccessApi is true by default the types dont caterr for FileSystemFilehandle can also be retuirned

**What kind of change does this PR introduce?**
- [x] Bug Fix
- [ ] Feature
- [ ] Refactoring
- [ ] Style
- [ ] Build
- [ ] Chore
- [x] Documentation
- [ ] CI

**Did you add tests for your changes?**
- [ ] Yes, my code is well tested
- [x] Not relevant

**If relevant, did you update the documentation?**
- [ ] Yes, I've updated the documentation
- [x] Not relevant

**Summary**
since useFsAccessApi is true by default ,
or in newer versions
the types dont handle the type  FileSystemFilehandle which can also be returned
if user selects useFsAccessApi 

