### PR TITLE
Reduce FileError.code type footprint

### DIFF
--- a/typings/react-dropzone.d.ts
+++ b/typings/react-dropzone.d.ts
@@ -20,7 +20,7 @@ export enum ErrorCode {
 
 export interface FileError {
   message: string;
-  code: ErrorCode | string;
+  code: ErrorCode | `${ErrorCode}` | (string & {});
 }
 
 export interface FileRejection {


### PR DESCRIPTION
**What kind of change does this PR introduce?**
- [x] Bug Fix
- [ ] Feature
- [ ] Refactoring
- [ ] Style
- [ ] Build
- [ ] Chore
- [ ] Documentation
- [ ] CI

**Did you add tests for your changes?**
- [ ] Yes, my code is well tested
- [x] Not relevant

**If relevant, did you update the documentation?**
- [ ] Yes, I've updated the documentation
- [x] Not relevant

**Summary**

**First**

In TypeScript whenever a union is created between a literal `type` and literal subtype, the result will be the `type`

https://www.typescriptlang.org/play/?#code/KYOwrgtgBAYg9nKBvAUFKAjAhgJygXigHJsciUBfFFAFwE8AHYKAFWAGcaDYEoAfKJxwBLEAHMUAeknooAPQD8QA

So this piece of TS `ErrorCode | string` becomes `string` in the end.
To avoid this you need to intersect `string` with an `{}`

This `ErrorCode | (string & {})` will stay as is without resolving to `string` https://stackoverflow.com/a/61048124

**Second**

String Enums in TS have the problem that you cannot use a literal value matching the enum.

https://www.typescriptlang.org/play/?#code/KYOwrgtgBAYg9nKBvAUFKAjAhgJygXigHJsciUBfFFAG2ABcp7gBnegRgC5YECe4AdKVoMmregCZu8RIRK4iUAPRKowHDhGNmbAMzTeAHygADACRIZFE33lktYtgBYDiY+csJrt7AC9yQA

Having (below), should allow a string literal that matches the enum value

```
ErrorCode | `${ErrorCode}`
```
