### PR TITLE
fix: label hidden file input

### DIFF
--- a/src/__snapshots__/index.spec.js.snap
+++ b/src/__snapshots__/index.spec.js.snap
@@ -1,3 +1,3 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`useDropzone() hook behavior renders the root and input nodes with the necessary props 1`] = `"<div role=\\"presentation\\" tabindex=\\"0\\"><input multiple=\\"\\" type=\\"file\\" style=\\"border: 0px; clip: rect(0px, 0px, 0px, 0px); clip-path: inset(50%); height: 1px; margin: 0px -1px -1px 0px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap;\\" tabindex=\\"-1\\"></div>"`;
+exports[`useDropzone() hook behavior renders the root and input nodes with the necessary props 1`] = `"<div role=\\"presentation\\" tabindex=\\"0\\"><input multiple=\\"\\" type=\\"file\\" aria-label=\\"file upload\\" style=\\"border: 0px; clip: rect(0px, 0px, 0px, 0px); clip-path: inset(50%); height: 1px; margin: 0px -1px -1px 0px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap;\\" tabindex=\\"-1\\"></div>"`;

--- a/src/index.js
+++ b/src/index.js
@@ -1003,6 +1003,7 @@ export function useDropzone(props = {}) {
           accept: acceptAttr,
           multiple,
           type: "file",
+          "aria-label": "file upload",
           style: {
             border: 0,
             clip: "rect(0, 0, 0, 0)",

--- a/src/index.spec.js
+++ b/src/index.spec.js
@@ -149,6 +149,23 @@ describe("useDropzone() hook", () => {
       expect(container.querySelector("input")).toHaveAttribute("name", name);
     });
 
+    it("labels the hidden file input for accessibility", () => {
+      const { container } = render(
+        <Dropzone multiple>
+          {({ getRootProps, getInputProps }) => (
+            <div {...getRootProps()}>
+              <input {...getInputProps()} />
+            </div>
+          )}
+        </Dropzone>
+      );
+
+      expect(container.querySelector("input")).toHaveAttribute(
+        "aria-label",
+        "file upload"
+      );
+    });
+
     it("sets any props passed to the root props getter on the root node", () => {
       const ariaLabel = "Dropzone area";
       const { container } = render(


### PR DESCRIPTION
## Summary
- Adds a default accessible name to the visually hidden file input returned by `getInputProps()`.
- Covers the default aria-label with a regression test and updates the rendered-props snapshot.

Fixes #1430

## Test Plan
- `yarn jest src/index.spec.js -t 'labels the hidden file input for accessibility' --runInBand`
- `yarn jest src/index.spec.js --runInBand`
- `yarn jest --runInBand`
- `yarn eslint src/index.js src/index.spec.js`
- `yarn lint`
- `yarn typescript`
- `git diff --check`
