### PR TITLE
fix: respect extensions for wildcard accept types

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -461,6 +461,13 @@ export function useDropzone(props = {}) {
   };
 
   const acceptAttr = useMemo(() => acceptPropAsAcceptAttr(accept), [accept]);
+  const inputAcceptAttr = useMemo(
+    () =>
+      acceptPropAsAcceptAttr(accept, {
+        omitWildcardMimeTypesWithExtensions: true,
+      }),
+    [accept]
+  );
   const pickerTypes = useMemo(() => pickerOptionsFromAccept(accept), [accept]);
 
   const onFileDialogOpenCb = useMemo(
@@ -729,7 +736,7 @@ export function useDropzone(props = {}) {
       const fileRejections = [];
 
       files.forEach((file) => {
-        const [accepted, acceptError] = fileAccepted(file, acceptAttr);
+        const [accepted, acceptError] = fileAccepted(file, acceptAttr, accept);
         const [sizeMatch, sizeError] = fileMatchSize(file, minSize, maxSize);
         const customErrors = validator ? validator(file) : null;
 
@@ -778,6 +785,7 @@ export function useDropzone(props = {}) {
     [
       dispatch,
       multiple,
+      accept,
       acceptAttr,
       minSize,
       maxSize,
@@ -1000,7 +1008,7 @@ export function useDropzone(props = {}) {
     () =>
       ({ refKey = "ref", onChange, onClick, ...rest } = {}) => {
         const inputProps = {
-          accept: acceptAttr,
+          accept: inputAcceptAttr,
           multiple,
           type: "file",
           style: {
@@ -1028,7 +1036,7 @@ export function useDropzone(props = {}) {
           ...rest,
         };
       },
-    [inputRef, accept, multiple, onDropCb, disabled]
+    [inputRef, inputAcceptAttr, multiple, onDropCb, disabled]
   );
 
   return {

--- a/src/index.spec.js
+++ b/src/index.spec.js
@@ -54,6 +54,27 @@ describe("useDropzone() hook", () => {
       );
     });
 
+    it("sets only extensions on the <input> when wildcard MIME types include extensions", () => {
+      const { container } = render(
+        <Dropzone
+          accept={{
+            "image/*": [".jpeg", ".png"],
+          }}
+        >
+          {({ getRootProps, getInputProps }) => (
+            <div {...getRootProps()}>
+              <input {...getInputProps()} />
+            </div>
+          )}
+        </Dropzone>
+      );
+
+      expect(container.querySelector("input")).toHaveAttribute(
+        "accept",
+        ".jpeg,.png"
+      );
+    });
+
     it("updates {multiple} prop on the <input> when it changes", () => {
       const { container, rerender } = render(
         <Dropzone
@@ -2641,6 +2662,51 @@ describe("useDropzone() hook", () => {
       );
       // After drop, isDragReject should be false even if files were rejected
       expect(dropzone).not.toHaveTextContent("dragReject");
+    });
+
+    it("rejects dropped files that match a wildcard MIME type but not its extension list", async () => {
+      const onDropSpy = jest.fn();
+      const acceptedImage = createFile("dogs.jpeg", 2345, "image/jpeg");
+      const rejectedImage = createFile("cats.gif", 1234, "image/gif");
+
+      const { container } = render(
+        <Dropzone
+          accept={{
+            "image/*": [".jpeg", ".png"],
+          }}
+          onDrop={onDropSpy}
+        >
+          {({ getRootProps, getInputProps }) => (
+            <div {...getRootProps()}>
+              <input {...getInputProps()} />
+            </div>
+          )}
+        </Dropzone>
+      );
+      const dropzone = container.querySelector("div");
+
+      await act(() =>
+        fireEvent.drop(
+          dropzone,
+          createDtWithFiles([acceptedImage, rejectedImage])
+        )
+      );
+
+      expect(onDropSpy).toHaveBeenCalledWith(
+        [acceptedImage],
+        [
+          {
+            file: rejectedImage,
+            errors: [
+              {
+                code: "file-invalid-type",
+                message: "File type must be one of image/*, .jpeg, .png",
+              },
+            ],
+          },
+        ],
+        expect.anything()
+      );
     });
 
     it("resets {isDragActive, isDragAccept, isDragReject}", async () => {

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -1,6 +1,13 @@
 import _accepts from "attr-accept";
 
 const accepts = typeof _accepts === "function" ? _accepts : _accepts.default;
+const MIME_TYPE_WILDCARDS = [
+  "audio/*",
+  "video/*",
+  "image/*",
+  "text/*",
+  "application/*",
+];
 
 // Error codes
 export const FILE_INVALID_TYPE = "file-invalid-type";
@@ -85,17 +92,62 @@ export function isDataTransferItemWithEmptyType(file) {
  *
  * @param {File} file
  * @param {string} accept
+ * @param {AcceptProp} [acceptProp]
  * @returns
  */
-export function fileAccepted(file, accept) {
+export function fileAccepted(file, accept, acceptProp) {
   const isAcceptable =
     file.type === "application/x-moz-file" ||
-    accepts(file, accept) ||
+    (acceptProp
+      ? acceptsWithAcceptProp(file, accept, acceptProp)
+      : accepts(file, accept)) ||
     isDataTransferItemWithEmptyType(file);
   return [
     isAcceptable,
     isAcceptable ? null : getInvalidTypeRejectionErr(accept),
   ];
+}
+
+function acceptsWithAcceptProp(file, accept, acceptProp) {
+  const validAcceptEntries = Object.entries(acceptProp).filter(
+    ([mimeType, ext]) =>
+      isMIMEType(mimeType) && Array.isArray(ext) && ext.every(isExt)
+  );
+
+  if (validAcceptEntries.length === 0) {
+    return accepts(file, accept);
+  }
+
+  return validAcceptEntries.some(([mimeType, ext]) => {
+    if (isMIMETypeWildcard(mimeType) && ext.length > 0) {
+      return (
+        fileMatchesMimeType(file, mimeType) && fileMatchesExtension(file, ext)
+      );
+    }
+
+    return accepts(file, [mimeType, ...ext].join(","));
+  });
+}
+
+function fileMatchesMimeType(file, mimeType) {
+  const fileType = (file.type || "").toLowerCase();
+  const normalizedMimeType = mimeType.toLowerCase();
+
+  if (!fileType) {
+    return true;
+  }
+
+  if (isMIMETypeWildcard(normalizedMimeType)) {
+    return fileType.startsWith(normalizedMimeType.replace("*", ""));
+  }
+
+  return fileType === normalizedMimeType;
+}
+
+function fileMatchesExtension(file, extensions) {
+  const fileName = (file.name || "").toLowerCase();
+
+  return extensions.some((ext) => fileName.endsWith(ext.toLowerCase()));
 }
 
 export function fileMatchSize(file, minSize, maxSize) {
@@ -277,13 +329,27 @@ export function pickerOptionsFromAccept(accept) {
 /**
  * Convert the `{accept}` dropzone prop to an array of MIME types/extensions.
  * @param {AcceptProp} accept
+ * @param {{omitWildcardMimeTypesWithExtensions?: boolean}} [options]
  * @returns {string}
  */
-export function acceptPropAsAcceptAttr(accept) {
+export function acceptPropAsAcceptAttr(accept, options = {}) {
+  const { omitWildcardMimeTypesWithExtensions = false } = options;
+
   if (isDefined(accept)) {
     return (
       Object.entries(accept)
-        .reduce((a, [mimeType, ext]) => [...a, mimeType, ...ext], [])
+        .reduce(
+          (a, [mimeType, ext]) => [
+            ...a,
+            ...(!omitWildcardMimeTypesWithExtensions ||
+            !isMIMETypeWildcard(mimeType) ||
+            ext.length === 0
+              ? [mimeType]
+              : []),
+            ...ext,
+          ],
+          []
+        )
         // Silently discard invalid entries as pickerOptionsFromAccept warns about these
         .filter((v) => isMIMEType(v) || isExt(v))
         .join(",")
@@ -329,14 +395,11 @@ export function isSecurityError(v) {
  * @param {string} v
  */
 export function isMIMEType(v) {
-  return (
-    v === "audio/*" ||
-    v === "video/*" ||
-    v === "image/*" ||
-    v === "text/*" ||
-    v === "application/*" ||
-    /\w+\/[-+.\w]+/g.test(v)
-  );
+  return isMIMETypeWildcard(v) || /\w+\/[-+.\w]+/g.test(v);
+}
+
+function isMIMETypeWildcard(v) {
+  return MIME_TYPE_WILDCARDS.includes(v);
 }
 
 /**

--- a/src/utils/index.spec.js
+++ b/src/utils/index.spec.js
@@ -315,6 +315,32 @@ describe("fileAccepted()", () => {
       },
     ]);
   });
+
+  it("rejects files that match a wildcard MIME type but not its extension list", () => {
+    const file = createFile("cats.gif", 100, "image/gif");
+
+    expect(
+      utils.fileAccepted(file, "image/*,.jpeg,.png", {
+        "image/*": [".jpeg", ".png"],
+      })
+    ).toEqual([
+      false,
+      {
+        code: "file-invalid-type",
+        message: "File type must be one of image/*, .jpeg, .png",
+      },
+    ]);
+  });
+
+  it("accepts files that match both a wildcard MIME type and its extension list", () => {
+    const file = createFile("cats.png", 100, "image/png");
+
+    expect(
+      utils.fileAccepted(file, "image/*,.jpeg,.png", {
+        "image/*": [".jpeg", ".png"],
+      })
+    ).toEqual([true, null]);
+  });
 });
 
 describe("getTooLargeRejectionErr()", () => {
@@ -505,6 +531,19 @@ describe("acceptPropAsAcceptAttr()", () => {
         "*": [".p12"], // `*` not ok
       })
     ).toEqual("image/*,.png,.jpg,text/*,.txt,.pdf,audio/*,.p12");
+  });
+
+  it("can omit wildcard MIME types that already declare file extensions", () => {
+    expect(
+      utils.acceptPropAsAcceptAttr(
+        {
+          "image/*": [".png", ".jpg"],
+          "text/*": [],
+          "application/pdf": [".pdf"],
+        },
+        { omitWildcardMimeTypesWithExtensions: true }
+      )
+    ).toEqual(".png,.jpg,text/*,application/pdf,.pdf");
   });
 });
 


### PR DESCRIPTION
## Summary
- make wildcard MIME accept entries with extension lists reject files that match only the wildcard after drop/select
- omit wildcard MIME types from the hidden input accept attribute when extensions are provided, so the file picker can filter by extension
- add utility and dropzone regressions for `accept={{ "image/*": [".jpeg", ".png"] }}`

Fixes #1220

## Tests
- `yarn jest src/utils/index.spec.js src/index.spec.js --runInBand -t "wildcard MIME|sets only extensions"`
- `yarn jest src/utils/index.spec.js src/index.spec.js --runInBand`
- `yarn lint`
- `yarn test`
- `git diff --check`
- `yarn build && yarn size`