### PR TITLE
fix(types): keep drop callback events event-shaped

### DIFF
--- a/typings/react-dropzone.d.ts
+++ b/typings/react-dropzone.d.ts
@@ -47,7 +47,7 @@ export type DropzoneOptions = Pick<React.HTMLProps<HTMLElement>, PropTypes> & {
   onDropAccepted?: <T extends File>(files: T[], event: DropEvent) => void;
   onDropRejected?: (fileRejections: FileRejection[], event: DropEvent) => void;
   getFilesFromEvent?: (
-    event: DropEvent
+    event: DropEvent | Array<FileSystemFileHandle>
   ) => Promise<Array<File | DataTransferItem>>;
   onFileDialogCancel?: () => void;
   onFileDialogOpen?: () => void;
@@ -63,8 +63,7 @@ export type DropEvent =
   | React.DragEvent<HTMLElement>
   | React.ChangeEvent<HTMLInputElement>
   | DragEvent
-  | Event
-  | Array<FileSystemFileHandle>;
+  | Event;
 
 export type DropzoneState = DropzoneRef & {
   isFocused: boolean;

--- a/typings/tests/events.tsx
+++ b/typings/tests/events.tsx
@@ -1,18 +1,35 @@
 import React from "react";
 import Dropzone from "../../";
 
+const onDrop: NonNullable<React.ComponentProps<typeof Dropzone>["onDrop"]> = (
+  acceptedFiles,
+  fileRejections,
+  event
+) => {
+  console.log(acceptedFiles, fileRejections);
+  event.preventDefault();
+  event.stopPropagation();
+  console.log(event.type);
+};
+
 export class Events extends React.Component {
   render() {
     return (
       <section>
         <div className="dropzone">
           <Dropzone
-            onDrop={(acceptedFiles, fileRejections, event) =>
-              console.log(acceptedFiles, fileRejections, event)
-            }
+            onDrop={onDrop}
             onDragEnter={(event) => console.log(event)}
             onDragOver={(event) => console.log(event)}
             onDragLeave={(event) => console.log(event)}
+            getFilesFromEvent={(event) => {
+              if (Array.isArray(event)) {
+                console.log(event[0]);
+              } else {
+                event.preventDefault();
+              }
+              return Promise.resolve([]);
+            }}
           >
             {({ getRootProps, getInputProps }) => (
               <div {...getRootProps()}>


### PR DESCRIPTION
`DropEvent` could include `FileSystemFileHandle[]`, so drop callbacks could lose event APIs like `preventDefault()` in TypeScript even though those callbacks receive event-shaped values.

This narrows `DropEvent` back to event inputs and lets `getFilesFromEvent` accept handle arrays directly, while keeping the File System Access custom aggregation path typed. I checked the callback typing case, the handle-array path, the focused Jest file, build, lint, TypeScript, and the full test script with 152 tests passing.

Closes #1419
