### PR TITLE
fix(build): add @types/react as optional peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -115,7 +115,13 @@
   ],
   "license": "MIT",
   "peerDependencies": {
-    "react": ">= 16.8 || 18.0.0"
+    "react": ">= 16.8 || 18.0.0",
+    "@types/react": "*"
+  },
+  "peerDependenciesMeta": {
+    "@types/react": {
+      "optional": true
+    }
   },
   "dependencies": {
     "attr-accept": "^2.2.4",


### PR DESCRIPTION
Fixes #1454

pnpm strict mode fails because `@types/react` is required transitively
by the `.d.ts` type declarations but is not declared as a peer dependency.
Adding it as an optional peer fixes resolution in strict mode.