### PR TITLE
feat!: upgrade file-selector to v4

### DIFF
--- a/docs/pages/examples/accept.mdx
+++ b/docs/pages/examples/accept.mdx
@@ -60,3 +60,26 @@ const {isDragActive, isDragAccept, isDragReject, getRootProps, getInputProps} = 
 ```
 
 > Mime type determination is not reliable across platforms. CSV files, for example, are reported as `text/plain` under macOS but as `application/vnd.ms-excel` under Windows.
+
+## Restoring the full MIME-type table
+
+`react-dropzone` resolves each file's MIME `type` through [file-selector](https://github.com/react-dropzone/file-selector)'s `fromEvent` — the default for the [`getFilesFromEvent`](/examples/plugins) prop — which infers the `type` from the file extension when the browser leaves a file typeless (common with drag 'n' drop and File System Access sources).
+
+As of `file-selector` v4, only a **small built-in set** of common extensions is bundled, so the core stays lightweight. Because `accept` matches by file **extension** as well as MIME type, most configurations keep working regardless. You only need the full table when matching purely by MIME type (e.g. `image/*`) against typeless sources — pass the full `COMMON_MIME_TYPES` table via `getFilesFromEvent` (add `file-selector` to your dependencies to import from it):
+
+```bash
+npm install file-selector
+```
+
+```tsx
+import {useDropzone} from "react-dropzone";
+import {fromEvent} from "file-selector";
+import {COMMON_MIME_TYPES} from "file-selector/mime";
+
+function FullMimeCoverage() {
+  const {getRootProps, getInputProps} = useDropzone({
+    getFilesFromEvent: event => fromEvent(event, {mimeTypes: COMMON_MIME_TYPES})
+  });
+  // ...
+}
+```

--- a/docs/pages/guide/getting-started.mdx
+++ b/docs/pages/guide/getting-started.mdx
@@ -24,6 +24,10 @@ yarn add react-dropzone
 `react-dropzone` ships as ESM and CommonJS with TypeScript types included, and lists
 `react` as a peer dependency (`>= 18`).
 
+:::warning[Breaking change]
+`FileWithPath` (re-exported from [file-selector](https://github.com/react-dropzone/file-selector)) now types `path` and `relativePath` as **required** — a plain `File` is no longer assignable to it. The `onDrop`/`onDropAccepted` callbacks still hand you `File` objects, so type those handlers as `File[]` rather than `FileWithPath[]`.
+:::
+
 ## Usage
 
 Use the `useDropzone` hook to bind the necessary handlers to any element:

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "attr-accept": "^2.2.5",
-        "file-selector": "^2.1.0"
+        "file-selector": "^4.0.1"
       },
       "devDependencies": {
         "@semantic-release/changelog": "^6.0.0",
@@ -9286,15 +9286,12 @@
       }
     },
     "node_modules/file-selector": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/file-selector/-/file-selector-2.1.2.tgz",
-      "integrity": "sha512-QgXo+mXTe8ljeqUFaX3QVHc5osSItJ/Km+xpocx0aSqWGMSCf6qYs/VnzZgS864Pjn5iceMRFigeAV7AfTlaig==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/file-selector/-/file-selector-4.0.1.tgz",
+      "integrity": "sha512-xRKq3z5daY2myzSME3wKMTIDdmESnM4/8QKqKD85L49sUMW/ZxGeZSsyvJK3E8B2gJlCmL3Js4mQPeGhc+lCbQ==",
       "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.7.0"
-      },
       "engines": {
-        "node": ">= 12"
+        "node": ">= 20"
       }
     },
     "node_modules/fill-range": {
@@ -18704,6 +18701,7 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
       "license": "0BSD"
     },
     "node_modules/tsx": {

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
   },
   "dependencies": {
     "attr-accept": "^2.2.5",
-    "file-selector": "^2.1.0"
+    "file-selector": "^4.0.1"
   },
   "devDependencies": {
     "@semantic-release/changelog": "^6.0.0",

--- a/type-tests/accept.tsx
+++ b/type-tests/accept.tsx
@@ -1,9 +1,8 @@
-import type {FileWithPath} from "file-selector";
 import React from "react";
 import Dropzone, {type FileRejection} from "../src";
 
 interface State {
-  accepted: readonly FileWithPath[];
+  accepted: readonly File[];
   rejected: readonly FileRejection[];
 }
 

--- a/type-tests/basic.tsx
+++ b/type-tests/basic.tsx
@@ -1,15 +1,14 @@
-import type {FileWithPath} from "file-selector";
 import React from "react";
 import Dropzone from "../src";
 
 interface State {
-  files: readonly FileWithPath[];
+  files: readonly File[];
 }
 
 export default class Basic extends React.Component<Record<string, never>, State> {
   state: State = {files: []};
 
-  onDrop = (files: FileWithPath[]) => {
+  onDrop = (files: File[]) => {
     this.setState({files});
   };
 


### PR DESCRIPTION
**What kind of change does this PR introduce?**
- [x] Bug Fix
- [x] Feature
- [ ] Refactoring
- [ ] Style
- [ ] Build
- [ ] Chore
- [ ] Documentation
- [ ] CI

**Did you add tests for your changes?**
- [x] Yes, my code is well tested
- [ ] Not relevant

**If relevant, did you update the documentation?**
- [ ] Yes, I've updated the documentation
- [x] Not relevant

**Summary**

Upgrade file-selector to v4.

**Does this PR introduce a breaking change?**

1. `FileWithPath` now requires `path`/`relativePath`, so a plain `File` is no longer assignable - type `onDrop` handlers as `File[]`.
2. The full extension-to-MIME table is no longer bundled; pass `COMMON_MIME_TYPES` from `file-selector/mime` via `getFilesFromEvent` to restore it.

**Other information**
