### PR TITLE
feat: add getErrorMessage prop to override rejection messages

### DIFF
--- a/docs/pages/examples/validator.mdx
+++ b/docs/pages/examples/validator.mdx
@@ -23,3 +23,26 @@ function CustomValidation() {
   // ...render accepted/rejected lists
 }
 ```
+
+## Overriding error messages
+
+The built-in rejection messages (`file-invalid-type`, `file-too-large`, `file-too-small`, `too-many-files`) are in English. Use the `getErrorMessage` prop to override them — e.g. to localize. It's called once per error with the error and the file it belongs to, and its return value replaces the message. Return `error.message` for codes you don't want to change (this also applies to your own `validator` errors).
+
+```tsx
+function LocalizedDropzone() {
+  const {getRootProps, getInputProps} = useDropzone({
+    maxSize: 1024,
+    getErrorMessage: (error, file) => {
+      switch (error.code) {
+        case "file-too-large":
+          return `${file.name} dépasse la taille maximale`;
+        case "too-many-files":
+          return "Trop de fichiers";
+        default:
+          return error.message;
+      }
+    }
+  });
+  // ...
+}
+```

--- a/src/index.spec.tsx
+++ b/src/index.spec.tsx
@@ -3626,6 +3626,76 @@ describe("useDropzone() hook", () => {
     });
   });
 
+  describe("getErrorMessage", () => {
+    it("overrides built-in rejection messages by code and receives the file", async () => {
+      const onDropSpy = vi.fn();
+      const getErrorMessage = (error, file) =>
+        error.code === "file-too-large" ? `${file.name} is too big` : error.message;
+
+      const {container} = render(
+        <Dropzone onDrop={onDropSpy} maxSize={1000} multiple getErrorMessage={getErrorMessage}>
+          {({getRootProps}) => <div {...getRootProps()} />}
+        </Dropzone>
+      );
+
+      await act(() => fireEvent.drop(container.querySelector("div"), createDtWithFiles(images)));
+
+      expect(onDropSpy).toHaveBeenCalledWith(
+        [],
+        [
+          {file: images[0], errors: [{code: "file-too-large", message: "cats.gif is too big"}]},
+          {file: images[1], errors: [{code: "file-too-large", message: "dogs.gif is too big"}]}
+        ],
+        expect.anything()
+      );
+    });
+
+    it("also overrides custom validator error messages", async () => {
+      const onDropSpy = vi.fn();
+      const validator = () => ({code: "not-allowed", message: "Cannot do this!"});
+      const getErrorMessage = error => (error.code === "not-allowed" ? "Localized: not allowed" : error.message);
+
+      const {container} = render(
+        <Dropzone onDrop={onDropSpy} validator={validator} multiple getErrorMessage={getErrorMessage}>
+          {({getRootProps}) => <div {...getRootProps()} />}
+        </Dropzone>
+      );
+
+      await act(() => fireEvent.drop(container.querySelector("div"), createDtWithFiles(images)));
+
+      expect(onDropSpy).toHaveBeenCalledWith(
+        [],
+        [
+          {file: images[0], errors: [{code: "not-allowed", message: "Localized: not allowed"}]},
+          {file: images[1], errors: [{code: "not-allowed", message: "Localized: not allowed"}]}
+        ],
+        expect.anything()
+      );
+    });
+
+    it("overrides the too-many-files rejection message", async () => {
+      const onDropSpy = vi.fn();
+      const getErrorMessage = error => (error.code === "too-many-files" ? "Too many!" : error.message);
+
+      const {container} = render(
+        <Dropzone onDrop={onDropSpy} maxFiles={1} multiple getErrorMessage={getErrorMessage}>
+          {({getRootProps}) => <div {...getRootProps()} />}
+        </Dropzone>
+      );
+
+      await act(() => fireEvent.drop(container.querySelector("div"), createDtWithFiles(images)));
+
+      expect(onDropSpy).toHaveBeenCalledWith(
+        [],
+        [
+          {file: images[0], errors: [{code: "too-many-files", message: "Too many!"}]},
+          {file: images[1], errors: [{code: "too-many-files", message: "Too many!"}]}
+        ],
+        expect.anything()
+      );
+    });
+  });
+
   describe("accessibility", () => {
     it("sets the role attribute to button by default on the root", () => {
       const {container} = render(<Dropzone>{({getRootProps}) => <div id="root" {...getRootProps()} />}</Dropzone>);

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -54,6 +54,12 @@ export type DropzoneOptions = Pick<React.HTMLProps<HTMLElement>, SharedProps> & 
   onFileDialogOpen?: () => void;
   onError?: (err: Error) => void;
   validator?: <T extends File>(file: T) => FileError | readonly FileError[] | null;
+  /**
+   * Override the message of any rejection error (built-in or custom). Called once per error;
+   * receives the error and the file it belongs to and returns the message to use. Return
+   * `error.message` for codes you don't want to change. Useful for localizing error messages.
+   */
+  getErrorMessage?: (error: FileError, file: File) => string;
   useFsAccessApi?: boolean;
   autoFocus?: boolean;
 };
@@ -183,7 +189,8 @@ export function useDropzone(props: DropzoneOptions = {}): DropzoneState {
     noDrag = false,
     noDragEventsBubbling = false,
     onError,
-    validator
+    validator,
+    getErrorMessage
   } = props;
 
   // `acceptAttr` keeps wildcard MIME types (e.g. `image/*`) so the drag-time
@@ -455,6 +462,9 @@ export function useDropzone(props: DropzoneOptions = {}): DropzoneState {
       const acceptedFiles: FileWithPath[] = [];
       const fileRejections: FileRejection[] = [];
 
+      const localizeError = (error: FileError, file: File): FileError =>
+        getErrorMessage ? {...error, message: getErrorMessage(error, file)} : error;
+
       files.forEach(file => {
         const [accepted, acceptError] = fileAccepted(file, inputAcceptAttr);
         const [sizeMatch, sizeError] = fileMatchSize(file, minSize, maxSize);
@@ -471,7 +481,7 @@ export function useDropzone(props: DropzoneOptions = {}): DropzoneState {
 
           fileRejections.push({
             file,
-            errors: errors.filter((e): e is FileError => e != null)
+            errors: errors.filter((e): e is FileError => e != null).map(error => localizeError(error, file))
           });
         }
       });
@@ -479,7 +489,7 @@ export function useDropzone(props: DropzoneOptions = {}): DropzoneState {
       if ((!multiple && acceptedFiles.length > 1) || (multiple && maxFiles >= 1 && acceptedFiles.length > maxFiles)) {
         // Reject everything and empty accepted files
         acceptedFiles.forEach(file => {
-          fileRejections.push({file, errors: [TOO_MANY_FILES_REJECTION]});
+          fileRejections.push({file, errors: [localizeError(TOO_MANY_FILES_REJECTION, file)]});
         });
         acceptedFiles.splice(0);
       }
@@ -502,7 +512,19 @@ export function useDropzone(props: DropzoneOptions = {}): DropzoneState {
         onDropAccepted(acceptedFiles, event);
       }
     },
-    [dispatch, multiple, inputAcceptAttr, minSize, maxSize, maxFiles, onDrop, onDropAccepted, onDropRejected, validator]
+    [
+      dispatch,
+      multiple,
+      inputAcceptAttr,
+      minSize,
+      maxSize,
+      maxFiles,
+      onDrop,
+      onDropAccepted,
+      onDropRejected,
+      validator,
+      getErrorMessage
+    ]
   );
 
   const onDropCb = useCallback(


### PR DESCRIPTION
**What kind of change does this PR introduce?**
- [ ] Bug Fix
- [x] Feature
- [ ] Refactoring
- [ ] Style
- [ ] Build
- [ ] Chore
- [ ] Documentation
- [ ] CI

**Did you add tests for your changes?**
- [x] Yes, my code is well tested
- [ ] Not relevant

**If relevant, did you update the documentation?**
- [x] Yes, I've updated the documentation
- [ ] Not relevant

**Summary**

Allow users to override error messages. A lighter alternative to https://github.com/react-dropzone/react-dropzone/pull/1304.

**Does this PR introduce a breaking change?**

No.

**Other information**
