### PR TITLE
feat: add isDragUnknown state and skip validator during drag

### DIFF
--- a/docs/pages/examples/accept.mdx
+++ b/docs/pages/examples/accept.mdx
@@ -63,6 +63,20 @@ const {isDragActive, isDragAccept, isDragReject, getRootProps, getInputProps} = 
 
 > Mime type determination is not reliable across platforms. CSV files, for example, are reported as `text/plain` under macOS but as `application/vnd.ms-excel` under Windows.
 
+### `isDragUnknown` and custom validators
+
+Your custom `validator` is typed `(file: File) => …` and usually reads `file.name`, `file.size`, etc. During a drag those aren't available (the browser only exposes a MIME `type`), so react-dropzone **doesn't run the validator until drop**. While a validator is configured and the built-in checks pass, the drag state is neither accept nor reject but `isDragUnknown` — the outcome can only be confirmed once the real files are dropped:
+
+```tsx
+const {isDragAccept, isDragReject, isDragUnknown, getRootProps, getInputProps} = useDropzone({
+  validator: myValidator
+});
+
+// isDragUnknown === true  → "these files might be rejected on drop"
+```
+
+A file whose MIME type is _confidently_ wrong (or a selection that breaks `multiple`/`maxFiles`) is still `isDragReject` during the drag, even with a validator — a validator can only ever add rejections on drop, never rescue one.
+
 ## Restoring the full MIME-type table
 
 `react-dropzone` resolves each file's MIME `type` through [file-selector](https://github.com/react-dropzone/file-selector)'s `fromEvent` — the default for the [`getFilesFromEvent`](/examples/plugins) prop — which infers the `type` from the file extension when the browser leaves a file typeless (common with drag 'n' drop and File System Access sources).

--- a/src/index.spec.tsx
+++ b/src/index.spec.tsx
@@ -3705,7 +3705,10 @@ describe("useDropzone() hook", () => {
       );
     });
 
-    it("sets {isDragAccept, isDragReject}", async () => {
+    // A custom validator is typed `(file: File) => ...` but during a drag we only have
+    // DataTransferItems (no name/size), so we can't run it - the drag outcome is {isDragUnknown}
+    // rather than a misleading accept/reject. See https://github.com/react-dropzone/react-dropzone/issues/1244
+    it("sets {isDragUnknown} during a drag when a validator is set", async () => {
       const data = createDtWithFiles(images);
       const validator = () => ({
         code: "not-allowed",
@@ -3714,11 +3717,12 @@ describe("useDropzone() hook", () => {
 
       const ui = (
         <Dropzone validator={validator} multiple={true}>
-          {({getRootProps, getInputProps, isDragAccept, isDragReject}) => (
+          {({getRootProps, getInputProps, isDragAccept, isDragReject, isDragUnknown}) => (
             <div {...getRootProps()}>
               <input {...getInputProps()} />
               {isDragAccept && "dragAccept"}
               {isDragReject && "dragReject"}
+              {isDragUnknown && "dragUnknown"}
             </div>
           )}
         </Dropzone>
@@ -3730,7 +3734,68 @@ describe("useDropzone() hook", () => {
       await act(() => fireEvent.dragEnter(dropzone, data));
 
       expect(dropzone).not.toHaveTextContent("dragAccept");
+      expect(dropzone).not.toHaveTextContent("dragReject");
+      expect(dropzone).toHaveTextContent("dragUnknown");
+    });
+
+    // A confidently-failing MIME check can't be rescued by a validator on drop, so it stays a
+    // reject during the drag even when a validator is configured.
+    it("keeps {isDragReject} over {isDragUnknown} when a file's MIME type is confidently rejected", async () => {
+      const data = createDtWithFiles(images);
+      const validator = () => null;
+
+      const ui = (
+        <Dropzone validator={validator} accept={{"application/pdf": [".pdf"]}} multiple={true}>
+          {({getRootProps, getInputProps, isDragAccept, isDragReject, isDragUnknown}) => (
+            <div {...getRootProps()}>
+              <input {...getInputProps()} />
+              {isDragAccept && "dragAccept"}
+              {isDragReject && "dragReject"}
+              {isDragUnknown && "dragUnknown"}
+            </div>
+          )}
+        </Dropzone>
+      );
+
+      const {container} = render(ui);
+      const dropzone = container.querySelector("div");
+
+      await act(() => fireEvent.dragEnter(dropzone, data));
+
       expect(dropzone).toHaveTextContent("dragReject");
+      expect(dropzone).not.toHaveTextContent("dragUnknown");
+      expect(dropzone).not.toHaveTextContent("dragAccept");
+    });
+
+    // Regression for https://github.com/react-dropzone/react-dropzone/issues/1408: a validator
+    // that reads `file.name` throws on a DataTransferItem (name is undefined). Previously the throw
+    // aborted the drag handler and {isDragActive} never flipped to true. We must not run the
+    // validator during a drag.
+    it("still activates the drag when a validator reads file.name (#1408)", async () => {
+      const data = createDtWithFiles(images);
+      const onErrorSpy = vi.fn();
+      const validator = file => (file.name.endsWith(".csv") ? null : {code: "file-invalid-type", message: "nope"});
+
+      const ui = (
+        <Dropzone validator={validator} onError={onErrorSpy} multiple={true}>
+          {({getRootProps, getInputProps, isDragActive, isDragUnknown}) => (
+            <div {...getRootProps()}>
+              <input {...getInputProps()} />
+              {isDragActive && "dragActive"}
+              {isDragUnknown && "dragUnknown"}
+            </div>
+          )}
+        </Dropzone>
+      );
+
+      const {container} = render(ui);
+      const dropzone = container.querySelector("div");
+
+      await act(() => fireEvent.dragEnter(dropzone, data));
+
+      expect(dropzone).toHaveTextContent("dragActive");
+      expect(dropzone).toHaveTextContent("dragUnknown");
+      expect(onErrorSpy).not.toHaveBeenCalled();
     });
   });
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -4,12 +4,12 @@ import type * as React from "react";
 import {forwardRef, useCallback, useEffect, useImperativeHandle, useMemo, useReducer, useRef} from "react";
 import {
   acceptPropAsAcceptAttr,
-  allFilesAccepted,
   canUseFileSystemAccessAPI,
   composeEventHandlers,
   ErrorCode,
   fileAccepted,
   fileMatchSize,
+  getDragVerdict,
   isAbort,
   isEvtWithFiles,
   isIeOrEdge,
@@ -76,6 +76,7 @@ export type DropzoneState = DropzoneRef & {
   isDragActive: boolean;
   isDragAccept: boolean;
   isDragReject: boolean;
+  isDragUnknown: boolean;
   isDragGlobal: boolean;
   isFileDialogActive: boolean;
   acceptedFiles: readonly FileWithPath[];
@@ -130,6 +131,7 @@ interface DropzoneInternalState {
   isDragActive: boolean;
   isDragAccept: boolean;
   isDragReject: boolean;
+  isDragUnknown: boolean;
   isDragGlobal: boolean;
   acceptedFiles: FileWithPath[];
   fileRejections: FileRejection[];
@@ -141,6 +143,7 @@ const initialState: DropzoneInternalState = {
   isDragActive: false,
   isDragAccept: false,
   isDragReject: false,
+  isDragUnknown: false,
   isDragGlobal: false,
   acceptedFiles: [],
   fileRejections: []
@@ -367,22 +370,26 @@ export function useDropzone(props: DropzoneOptions = {}): DropzoneState {
             }
 
             const fileCount = files.length;
-            const isDragAccept =
-              fileCount > 0 &&
-              allFilesAccepted({
-                files: files as File[],
-                accept: acceptAttr,
-                minSize,
-                maxSize,
-                multiple,
-                maxFiles,
-                validator
-              });
-            const isDragReject = fileCount > 0 && !isDragAccept;
+            // During a drag we only have DataTransferItems (MIME type, no name/size), so the
+            // custom validator can't run yet - a validator-configured dropzone is "unknown" until
+            // drop rather than a misleading accept/reject. See getDragVerdict for the details.
+            const verdict =
+              fileCount > 0
+                ? getDragVerdict({
+                    files: files as Array<File | DataTransferItem>,
+                    accept: acceptAttr,
+                    minSize,
+                    maxSize,
+                    multiple,
+                    maxFiles,
+                    validator
+                  })
+                : null;
 
             dispatch({
-              isDragAccept,
-              isDragReject,
+              isDragAccept: verdict === "accept",
+              isDragReject: verdict === "reject",
+              isDragUnknown: verdict === "unknown",
               isDragActive: true,
               type: "setDraggedFiles"
             });
@@ -455,7 +462,8 @@ export function useDropzone(props: DropzoneOptions = {}): DropzoneState {
         type: "setDraggedFiles",
         isDragActive: false,
         isDragAccept: false,
-        isDragReject: false
+        isDragReject: false,
+        isDragUnknown: false
       });
 
       if (isEvtWithFiles(event) && onDragLeave) {
@@ -793,14 +801,16 @@ function reducer(state: DropzoneInternalState, action: any): DropzoneInternalSta
         ...state,
         isDragActive: action.isDragActive,
         isDragAccept: action.isDragAccept,
-        isDragReject: action.isDragReject
+        isDragReject: action.isDragReject,
+        isDragUnknown: action.isDragUnknown
       };
     case "setFiles":
       return {
         ...state,
         acceptedFiles: action.acceptedFiles,
         fileRejections: action.fileRejections,
-        isDragReject: false
+        isDragReject: false,
+        isDragUnknown: false
       };
     case "setDragGlobal":
       return {

--- a/src/utils/index.spec.ts
+++ b/src/utils/index.spec.ts
@@ -401,6 +401,68 @@ describe("allFilesAccepted()", () => {
   });
 });
 
+describe("getDragVerdict()", () => {
+  /**
+   * @constant
+   * @type {import('./index')}
+   */
+  let utils;
+  beforeEach(async () => {
+    utils = await import("./index");
+  });
+
+  const pdfs = () => [
+    createFile("hamster.pdf", 100, "application/pdf"),
+    createFile("fish.pdf", 100, "application/pdf")
+  ];
+
+  it("returns 'accept' when every file passes the drag-evaluable checks", () => {
+    expect(utils.getDragVerdict({files: pdfs(), multiple: true})).toEqual("accept");
+    expect(utils.getDragVerdict({files: pdfs(), multiple: true, accept: "application/pdf"})).toEqual("accept");
+  });
+
+  it("returns 'reject' when the file count exceeds the limit", () => {
+    expect(utils.getDragVerdict({files: pdfs(), multiple: false})).toEqual("reject");
+    expect(utils.getDragVerdict({files: pdfs(), multiple: true, maxFiles: 1})).toEqual("reject");
+  });
+
+  it("returns 'reject' when a non-empty MIME type doesn't match {accept}", () => {
+    expect(utils.getDragVerdict({files: pdfs(), multiple: true, accept: "image/*"})).toEqual("reject");
+  });
+
+  it("returns 'reject' when a file falls outside the size bounds", () => {
+    expect(utils.getDragVerdict({files: pdfs(), multiple: true, minSize: 110})).toEqual("reject");
+    expect(utils.getDragVerdict({files: pdfs(), multiple: true, maxSize: 99})).toEqual("reject");
+  });
+
+  it("returns 'unknown' (never runs the validator) when a validator is configured and built-in checks pass", () => {
+    const validator = vi.fn(() => ({code: "not-allowed", message: "Cannot do this!"}));
+    expect(utils.getDragVerdict({files: pdfs(), multiple: true, validator})).toEqual("unknown");
+    // The validator must not run during a drag - it's typed (file: File) and would throw on a
+    // DataTransferItem. See https://github.com/react-dropzone/react-dropzone/issues/1408
+    expect(validator).not.toHaveBeenCalled();
+  });
+
+  it("prefers a confident 'reject' over 'unknown' even with a validator", () => {
+    const validator = () => null;
+    expect(utils.getDragVerdict({files: pdfs(), multiple: true, accept: "image/*", validator})).toEqual("reject");
+    expect(utils.getDragVerdict({files: pdfs(), multiple: false, validator})).toEqual("reject");
+  });
+
+  it("treats empty-type DataTransferItems as 'accept', or 'unknown' when a validator is set", () => {
+    const emptyTypeItems = [
+      {type: "", getAsFile: () => null},
+      {type: "", getAsFile: () => null}
+    ];
+    expect(utils.getDragVerdict({files: emptyTypeItems, multiple: true, accept: "text/markdown,.md"})).toEqual(
+      "accept"
+    );
+    expect(
+      utils.getDragVerdict({files: emptyTypeItems, multiple: true, accept: "text/markdown,.md", validator: () => null})
+    ).toEqual("unknown");
+  });
+});
+
 describe("ErrorCode", () => {
   /**
    * @constant

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -162,6 +162,70 @@ export function allFilesAccepted({
   });
 }
 
+/**
+ * The outcome of the drag-time acceptance check.
+ *
+ * - `accept`  - every file passes the checks we can evaluate during a drag.
+ * - `reject`  - at least one file confidently fails a check we can fully evaluate during a
+ *               drag (the file count, or a non-empty MIME type that doesn't match `accept`).
+ * - `unknown` - nothing confidently fails, but the outcome can't be confirmed until drop,
+ *               because a custom `validator` is configured and can't be evaluated yet.
+ */
+export type DragVerdict = "accept" | "reject" | "unknown";
+
+/**
+ * Classify a set of dragged files for the `isDragAccept`/`isDragReject`/`isDragUnknown` states.
+ *
+ * During `dragenter`/`dragover` the browser only exposes `DataTransferItem`s, which carry a MIME
+ * `type` but no file name, extension or size (see https://html.spec.whatwg.org/multipage/dnd.html#dndevents).
+ * So the drag-time check is deliberately optimistic about anything it can't see:
+ *
+ * - The custom `validator` is **never** run here. It is typed `(file: File) => ...` and users
+ *   routinely read `file.name`/`file.size`, which are `undefined` on a `DataTransferItem` - running
+ *   it would throw and abort the whole drag handler (leaving `isDragActive` stuck at `false`).
+ *   See https://github.com/react-dropzone/react-dropzone/issues/1408
+ * - When a `validator` is configured we therefore can't promise the files are acceptable, so the
+ *   verdict is `unknown` rather than a misleading `reject` (or a premature `accept`).
+ *   See https://github.com/react-dropzone/react-dropzone/issues/1244
+ *
+ * The full check (including the `validator`) still runs on drop in {@link fileAccepted}/`setFiles`.
+ */
+export function getDragVerdict({
+  files,
+  accept,
+  minSize,
+  maxSize,
+  multiple,
+  maxFiles = 0,
+  validator
+}: {
+  files: Array<File | DataTransferItem>;
+  accept?: string;
+  minSize?: number;
+  maxSize?: number;
+  multiple?: boolean;
+  maxFiles?: number;
+  validator?: (file: File) => FileError | readonly FileError[] | null;
+}): DragVerdict {
+  // The file count is knowable during a drag, so an over-the-limit selection is a confident reject.
+  if ((!multiple && files.length > 1) || (multiple && maxFiles >= 1 && files.length > maxFiles)) {
+    return "reject";
+  }
+
+  const confidentlyRejected = files.some(file => {
+    const [accepted] = fileAccepted(file as File, accept);
+    const [sizeMatch] = fileMatchSize(file as File, minSize, maxSize);
+    return !accepted || !sizeMatch;
+  });
+  if (confidentlyRejected) {
+    return "reject";
+  }
+
+  // Built-in checks pass. A custom validator can only ever add rejections on drop, never rescue
+  // one - so with a validator present the drag outcome is unknown until we have real Files.
+  return validator ? "unknown" : "accept";
+}
+
 // React's synthetic events has event.isPropagationStopped,
 // but to remain compatibility with other libs (Preact) fall back
 // to check event.cancelBubble


### PR DESCRIPTION
**What kind of change does this PR introduce?**
- [ ] Bug Fix
- [x] Feature
- [ ] Refactoring
- [ ] Style
- [ ] Build
- [ ] Chore
- [ ] Documentation
- [ ] CI

**Did you add tests for your changes?**
- [x] Yes, my code is well tested
- [ ] Not relevant

**If relevant, did you update the documentation?**
- [x] Yes, I've updated the documentation
- [ ] Not relevant

**Summary**

Add a new validation state: `isDragUnknown`. This signals we cannot confidently validate the in-operation files. Addresses #1408 and #1244.

**Does this PR introduce a breaking change?**

No.

**Other information**
