### PR TITLE
docs: warn that a button root needs type=button inside a form

### DIFF
--- a/docs/pages/examples/file-dialog.mdx
+++ b/docs/pages/examples/file-dialog.mdx
@@ -4,6 +4,8 @@ import {DropzoneWithButton, RefDropzone} from "../../components/examples";
 
 You can open the native file prompt with the `open` method returned by the hook. Most browsers require the call to originate from a direct user interaction (e.g. a click).
 
+Note the `type="button"` on the button below: inside a `<form>` a `<button>` defaults to `type="submit"`, which would submit the form instead of just opening the dialog.
+
 <DropzoneWithButton />
 
 ```tsx

--- a/docs/pages/examples/forms.mdx
+++ b/docs/pages/examples/forms.mdx
@@ -4,6 +4,10 @@ import {FormExample} from "../../components/examples";
 
 react-dropzone does not submit files in form submissions by default. If you need this, add a hidden file input and set the files into it.
 
+:::warning[Spreading `getRootProps()` onto a `<button>`?]
+Set `type="button"` on it. A `<button>` inside a `<form>` defaults to `type="submit"`, so clicking it to open the file dialog also submits (and reloads) the form, clearing its fields.
+:::
+
 <FormExample />
 
 ```tsx


### PR DESCRIPTION
**What kind of change does this PR introduce?**
- [ ] Bug Fix
- [ ] Feature
- [ ] Refactoring
- [ ] Style
- [ ] Build
- [ ] Chore
- [x] Documentation
- [ ] CI

**Did you add tests for your changes?**
- [ ] Yes, my code is well tested
- [x] Not relevant

**If relevant, did you update the documentation?**
- [x] Yes, I've updated the documentation
- [ ] Not relevant

**Summary**

Clarify issue described in #1292.

**Does this PR introduce a breaking change?**

No.

**Other information**
