### PR TITLE
feat: expose drag file rejections

### DIFF
--- a/src/index.spec.tsx
+++ b/src/index.spec.tsx
@@ -2420,6 +2420,68 @@ describe("useDropzone() hook", () => {
       expect(dropzone).toHaveTextContent("dragReject");
     });
 
+    it("sets {dragFileRejections} with errors while files are dragged", async () => {
+      const {container} = render(
+        <Dropzone
+          accept={{
+            "image/*": []
+          }}
+        >
+          {({getRootProps, getInputProps, dragFileRejections, fileRejections}) => (
+            <div {...getRootProps()}>
+              <input {...getInputProps()} />
+              <span data-testid="drop-rejections">{fileRejections.length}</span>
+              <ul>
+                {dragFileRejections.flatMap(({errors}, rejectionIndex) =>
+                  errors.map(error => (
+                    <li key={`${rejectionIndex}-${error.code}`} data-type="drag-error">
+                      {error.code}
+                    </li>
+                  ))
+                )}
+              </ul>
+            </div>
+          )}
+        </Dropzone>
+      );
+      const dropzone = container.querySelector("div");
+
+      await act(() => fireEvent.dragEnter(dropzone, createDtWithFiles(files)));
+
+      expect(container.querySelector(`[data-testid="drop-rejections"]`)).toHaveTextContent("0");
+      expect(container.querySelectorAll(`[data-type="drag-error"]`)).toHaveLength(files.length);
+      expect(dropzone).toHaveTextContent("file-invalid-type");
+
+      fireEvent.dragLeave(dropzone, createDtWithFiles(files));
+
+      expect(container.querySelectorAll(`[data-type="drag-error"]`)).toHaveLength(0);
+    });
+
+    it("sets {dragFileRejections} for surplus files while dragging", async () => {
+      const {container} = render(
+        <Dropzone multiple={false}>
+          {({getRootProps, getInputProps, dragFileRejections}) => (
+            <div {...getRootProps()}>
+              <input {...getInputProps()} />
+              {dragFileRejections.map(({errors}, rejectionIndex) =>
+                errors.map(error => (
+                  <span key={`${rejectionIndex}-${error.code}`} data-type="drag-error">
+                    {error.code}
+                  </span>
+                ))
+              )}
+            </div>
+          )}
+        </Dropzone>
+      );
+      const dropzone = container.querySelector("div");
+
+      await act(() => fireEvent.dragEnter(dropzone, createDtWithFiles(images)));
+
+      expect(container.querySelectorAll(`[data-type="drag-error"]`)).toHaveLength(1);
+      expect(dropzone).toHaveTextContent("too-many-files");
+    });
+
     it("sets {isDragReject} if some files are too large", async () => {
       const {container} = render(
         <Dropzone maxSize={0}>

--- a/src/index.spec.tsx
+++ b/src/index.spec.tsx
@@ -2468,6 +2468,88 @@ describe("useDropzone() hook", () => {
       expect(dropzone).toHaveTextContent("dragReject");
     });
 
+    it("sets {dragFileRejections} with errors while files are dragged", async () => {
+      const {container} = render(
+        <Dropzone
+          accept={{
+            "image/*": []
+          }}
+        >
+          {({getRootProps, getInputProps, dragFileRejections, fileRejections}) => (
+            <div {...getRootProps()}>
+              <input {...getInputProps()} />
+              <span data-testid="drop-rejections">{fileRejections.length}</span>
+              <ul>
+                {dragFileRejections.flatMap(({errors}, rejectionIndex) =>
+                  errors.map(error => (
+                    <li key={`${rejectionIndex}-${error.code}`} data-type="drag-error">
+                      {error.code}
+                    </li>
+                  ))
+                )}
+              </ul>
+            </div>
+          )}
+        </Dropzone>
+      );
+      const dropzone = container.querySelector("div");
+
+      await act(() => fireEvent.dragEnter(dropzone, createDtWithFiles(files)));
+
+      expect(container.querySelector(`[data-testid="drop-rejections"]`)).toHaveTextContent("0");
+      expect(container.querySelectorAll(`[data-type="drag-error"]`)).toHaveLength(files.length);
+      expect(dropzone).toHaveTextContent("file-invalid-type");
+
+      fireEvent.dragLeave(dropzone, createDtWithFiles(files));
+
+      expect(container.querySelectorAll(`[data-type="drag-error"]`)).toHaveLength(0);
+    });
+
+    it("sets {dragFileRejections} for surplus files while dragging", async () => {
+      const {container} = render(
+        <Dropzone multiple={false}>
+          {({getRootProps, getInputProps, dragFileRejections}) => (
+            <div {...getRootProps()}>
+              <input {...getInputProps()} />
+              {dragFileRejections.map(({errors}, rejectionIndex) =>
+                errors.map(error => (
+                  <span key={`${rejectionIndex}-${error.code}`} data-type="drag-error">
+                    {error.code}
+                  </span>
+                ))
+              )}
+            </div>
+          )}
+        </Dropzone>
+      );
+      const dropzone = container.querySelector("div");
+
+      await act(() => fireEvent.dragEnter(dropzone, createDtWithFiles(images)));
+
+      expect(container.querySelectorAll(`[data-type="drag-error"]`)).toHaveLength(1);
+      expect(dropzone).toHaveTextContent("too-many-files");
+    });
+
+    it("keeps drag acceptance and rejections aligned for wildcard MIME types with extensions", async () => {
+      const {container} = render(
+        <Dropzone accept={{"image/*": [".png"]}}>
+          {({getRootProps, getInputProps, isDragReject, dragFileRejections}) => (
+            <div {...getRootProps()}>
+              <input {...getInputProps()} />
+              <span data-testid="drag-reject">{String(isDragReject)}</span>
+              <span data-testid="drag-rejections">{dragFileRejections.length}</span>
+            </div>
+          )}
+        </Dropzone>
+      );
+      const dropzone = container.querySelector("div");
+
+      await act(() => fireEvent.dragEnter(dropzone, createDtWithFiles([images[0]])));
+
+      expect(container.querySelector(`[data-testid="drag-reject"]`)).toHaveTextContent("false");
+      expect(container.querySelector(`[data-testid="drag-rejections"]`)).toHaveTextContent("0");
+    });
+
     it("sets {isDragReject} if some files are too large", async () => {
       const {container} = render(
         <Dropzone maxSize={0}>

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -35,6 +35,11 @@ export interface FileRejection {
   errors: readonly FileError[];
 }
 
+export interface DragFileRejection {
+  file: FileWithPath | DataTransferItem;
+  errors: readonly FileError[];
+}
+
 type SharedProps = "multiple" | "onDragEnter" | "onDragOver" | "onDragLeave";
 
 export type DropzoneOptions = Pick<React.HTMLProps<HTMLElement>, SharedProps> & {
@@ -101,6 +106,7 @@ export type DropzoneState = DropzoneRef & {
   isProcessing: boolean;
   acceptedFiles: readonly FileWithPath[];
   fileRejections: readonly FileRejection[];
+  dragFileRejections: readonly DragFileRejection[];
   rootRef: React.RefObject<HTMLElement>;
   inputRef: React.RefObject<HTMLInputElement>;
   getRootProps: <T extends DropzoneRootProps>(props?: T) => T;
@@ -156,6 +162,7 @@ interface DropzoneInternalState {
   isProcessing: boolean;
   acceptedFiles: FileWithPath[];
   fileRejections: FileRejection[];
+  dragFileRejections: DragFileRejection[];
 }
 
 /**
@@ -181,7 +188,8 @@ const initialState: DropzoneInternalState = {
   isDragGlobal: false,
   isProcessing: false,
   acceptedFiles: [],
-  fileRejections: []
+  fileRejections: [],
+  dragFileRejections: []
 };
 
 /**
@@ -449,6 +457,15 @@ export function useDropzone(props: DropzoneOptions = {}): DropzoneState {
               isDragReject: verdict === "reject",
               isDragUnknown: verdict === "unknown",
               isDragActive: true,
+              dragFileRejections: getDragFileRejections({
+                files: files as Array<FileWithPath | DataTransferItem>,
+                accept: inputAcceptAttr,
+                minSize,
+                maxSize,
+                multiple,
+                maxFiles,
+                getErrorMessage
+              }),
               type: "setDraggedFiles"
             });
 
@@ -465,11 +482,13 @@ export function useDropzone(props: DropzoneOptions = {}): DropzoneState {
       onErrCb,
       noDragEventsBubbling,
       acceptAttr,
+      inputAcceptAttr,
       minSize,
       maxSize,
       multiple,
       maxFiles,
-      validator
+      validator,
+      getErrorMessage
     ]
   );
 
@@ -521,7 +540,8 @@ export function useDropzone(props: DropzoneOptions = {}): DropzoneState {
         isDragActive: false,
         isDragAccept: false,
         isDragReject: false,
-        isDragUnknown: false
+        isDragUnknown: false,
+        dragFileRejections: []
       });
 
       if (isEvtWithFiles(event) && onDragLeave) {
@@ -965,7 +985,8 @@ function reducer(state: DropzoneInternalState, action: any): DropzoneInternalSta
         isDragActive: action.isDragActive,
         isDragAccept: action.isDragAccept,
         isDragReject: action.isDragReject,
-        isDragUnknown: action.isDragUnknown
+        isDragUnknown: action.isDragUnknown,
+        dragFileRejections: action.dragFileRejections
       };
     case "setProcessing":
       return {
@@ -977,6 +998,7 @@ function reducer(state: DropzoneInternalState, action: any): DropzoneInternalSta
         ...state,
         acceptedFiles: action.acceptedFiles,
         fileRejections: action.fileRejections,
+        dragFileRejections: [],
         isProcessing: false,
         isDragReject: false,
         isDragUnknown: false
@@ -993,6 +1015,56 @@ function reducer(state: DropzoneInternalState, action: any): DropzoneInternalSta
     default:
       return state;
   }
+}
+
+function getDragFileRejections({
+  files,
+  accept,
+  minSize,
+  maxSize,
+  multiple,
+  maxFiles = 0,
+  getErrorMessage
+}: {
+  files: Array<FileWithPath | DataTransferItem>;
+  accept?: string;
+  minSize?: number;
+  maxSize?: number;
+  multiple?: boolean;
+  maxFiles?: number;
+  getErrorMessage?: (error: FileError, file: File) => string;
+}): DragFileRejection[] {
+  const dragAcceptedFiles: Array<FileWithPath | DataTransferItem> = [];
+  const dragFileRejections: DragFileRejection[] = [];
+
+  const localizeError = (error: FileError, file: FileWithPath | DataTransferItem): FileError =>
+    getErrorMessage && file instanceof File ? {...error, message: getErrorMessage(error, file)} : error;
+
+  files.forEach(file => {
+    const [accepted, acceptError] = fileAccepted(file as File, accept);
+    const [sizeMatch, sizeError] = fileMatchSize(file as File, minSize, maxSize);
+
+    if (accepted && sizeMatch) {
+      dragAcceptedFiles.push(file);
+    } else {
+      dragFileRejections.push({
+        file,
+        errors: [acceptError, sizeError]
+          .filter((error): error is FileError => error != null)
+          .map(error => localizeError(error, file))
+      });
+    }
+  });
+
+  const acceptedFilesLimit = multiple ? (maxFiles >= 1 ? maxFiles : Number.POSITIVE_INFINITY) : 1;
+  if (dragAcceptedFiles.length > acceptedFilesLimit) {
+    const surplusFiles = dragAcceptedFiles.slice(acceptedFilesLimit);
+    surplusFiles.forEach(file => {
+      dragFileRejections.push({file, errors: [localizeError(TOO_MANY_FILES_REJECTION, file)]});
+    });
+  }
+
+  return dragFileRejections;
 }
 
 function noop() {}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -7,10 +7,10 @@ import {
   canUseFileSystemAccessAPI,
   composeEventHandlers,
   ErrorCode,
+  evaluateDragFiles,
   fileAccepted,
   fileMatchSize,
   flattenAccept,
-  getDragVerdict,
   isAbort,
   isEvtWithFiles,
   isIeOrEdge,
@@ -22,7 +22,13 @@ import {
   pickerOptionsFromAccept,
   TOO_MANY_FILES_REJECTION
 } from "./utils";
-import type {Accept, AcceptGroup, FileError, ValidatorResult} from "./utils";
+import type {
+  Accept,
+  AcceptGroup,
+  DragFileRejection as UtilsDragFileRejection,
+  FileError,
+  ValidatorResult
+} from "./utils";
 
 export type {Accept, AcceptGroup, FileError, FileWithPath, ValidatorResult};
 export {ErrorCode};
@@ -35,6 +41,8 @@ export interface FileRejection {
   file: FileWithPath;
   errors: readonly FileError[];
 }
+
+export type DragFileRejection = UtilsDragFileRejection<FileWithPath | DataTransferItem>;
 
 type SharedProps = "multiple" | "onDragEnter" | "onDragOver" | "onDragLeave";
 
@@ -116,6 +124,13 @@ export type DropzoneState = DropzoneRef & {
   isProcessing: boolean;
   acceptedFiles: readonly FileWithPath[];
   fileRejections: readonly FileRejection[];
+  /**
+   * Rejections that can be determined before drop. Standard drag events expose
+   * `DataTransferItem`s with a MIME type but no name or size, so extension, size, and custom
+   * validator failures are only available in {@link fileRejections} after drop. In practice this
+   * state can report MIME-type and surplus-file errors during a standard browser drag.
+   */
+  dragFileRejections: readonly DragFileRejection[];
   rootRef: React.RefObject<HTMLElement>;
   inputRef: React.RefObject<HTMLInputElement>;
   getRootProps: <T extends DropzoneRootProps>(props?: T) => T;
@@ -171,6 +186,7 @@ interface DropzoneInternalState {
   isProcessing: boolean;
   acceptedFiles: FileWithPath[];
   fileRejections: FileRejection[];
+  dragFileRejections: DragFileRejection[];
 }
 
 /**
@@ -196,7 +212,8 @@ const initialState: DropzoneInternalState = {
   isDragGlobal: false,
   isProcessing: false,
   acceptedFiles: [],
-  fileRejections: []
+  fileRejections: [],
+  dragFileRejections: []
 };
 
 /**
@@ -459,28 +476,30 @@ export function useDropzone(props: DropzoneOptions = {}): DropzoneState {
               return;
             }
 
-            const fileCount = files.length;
             // During a drag we only have DataTransferItems (MIME type, no name/size), so the
             // custom validator can't run yet - a validator-configured dropzone is "unknown" until
-            // drop rather than a misleading accept/reject. See getDragVerdict for the details.
-            const verdict =
-              fileCount > 0
-                ? getDragVerdict({
-                    files: files as Array<File | DataTransferItem>,
+            // drop rather than a misleading accept/reject. The verdict and rejection details come
+            // from one evaluation so the two states cannot disagree.
+            const evaluation =
+              files.length > 0
+                ? evaluateDragFiles({
+                    files: files as Array<FileWithPath | DataTransferItem>,
                     accept: acceptAttr,
                     minSize,
                     maxSize,
                     multiple,
                     maxFiles,
-                    validator
+                    validator,
+                    getErrorMessage
                   })
                 : null;
 
             dispatch({
-              isDragAccept: verdict === "accept",
-              isDragReject: verdict === "reject",
-              isDragUnknown: verdict === "unknown",
+              isDragAccept: evaluation?.verdict === "accept",
+              isDragReject: evaluation?.verdict === "reject",
+              isDragUnknown: evaluation?.verdict === "unknown",
               isDragActive: true,
+              dragFileRejections: evaluation?.rejections ?? [],
               type: "setDraggedFiles"
             });
 
@@ -501,7 +520,8 @@ export function useDropzone(props: DropzoneOptions = {}): DropzoneState {
       maxSize,
       multiple,
       maxFiles,
-      validator
+      validator,
+      getErrorMessage
     ]
   );
 
@@ -558,7 +578,8 @@ export function useDropzone(props: DropzoneOptions = {}): DropzoneState {
         isDragActive: false,
         isDragAccept: false,
         isDragReject: false,
-        isDragUnknown: false
+        isDragUnknown: false,
+        dragFileRejections: []
       });
 
       if (isEvtWithFiles(event) && onDragLeave) {
@@ -1058,7 +1079,8 @@ function reducer(state: DropzoneInternalState, action: any): DropzoneInternalSta
         isDragActive: action.isDragActive,
         isDragAccept: action.isDragAccept,
         isDragReject: action.isDragReject,
-        isDragUnknown: action.isDragUnknown
+        isDragUnknown: action.isDragUnknown,
+        dragFileRejections: action.dragFileRejections
       };
     case "setProcessing":
       return {
@@ -1070,6 +1092,7 @@ function reducer(state: DropzoneInternalState, action: any): DropzoneInternalSta
         ...state,
         acceptedFiles: action.acceptedFiles,
         fileRejections: action.fileRejections,
+        dragFileRejections: [],
         isProcessing: false,
         isDragReject: false,
         isDragUnknown: false

--- a/src/utils/index.spec.ts
+++ b/src/utils/index.spec.ts
@@ -505,6 +505,15 @@ describe("getDragVerdict()", () => {
       utils.getDragVerdict({files: emptyTypeItems, multiple: true, accept: "text/markdown,.md", validator: () => null})
     ).toEqual("unknown");
   });
+
+  it("derives the verdict and rejection details from the same wildcard MIME evaluation", () => {
+    const item = {kind: "file", type: "image/gif", getAsFile: () => null};
+
+    expect(utils.evaluateDragFiles({files: [item], multiple: true, accept: "image/*,.png"})).toEqual({
+      verdict: "accept",
+      rejections: []
+    });
+  });
 });
 
 describe("ErrorCode", () => {

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -208,6 +208,19 @@ export function allFilesAccepted({
 export type DragVerdict = "accept" | "reject" | "unknown";
 
 /**
+ * A file rejected by the checks that can run during a drag.
+ */
+export interface DragFileRejection<T extends File | DataTransferItem = File | DataTransferItem> {
+  file: T;
+  errors: readonly FileError[];
+}
+
+export interface DragEvaluation<T extends File | DataTransferItem = File | DataTransferItem> {
+  verdict: DragVerdict;
+  rejections: DragFileRejection<T>[];
+}
+
+/**
  * Classify a set of dragged files for the `isDragAccept`/`isDragReject`/`isDragUnknown` states.
  *
  * During `dragenter`/`dragover` the browser only exposes `DataTransferItem`s, which carry a MIME
@@ -224,16 +237,17 @@ export type DragVerdict = "accept" | "reject" | "unknown";
  *
  * The full check (including the `validator`) still runs on drop in {@link fileAccepted}/`setFiles`.
  */
-export function getDragVerdict({
+export function evaluateDragFiles<T extends File | DataTransferItem>({
   files,
   accept,
   minSize,
   maxSize,
   multiple,
   maxFiles = 0,
-  validator
+  validator,
+  getErrorMessage
 }: {
-  files: Array<File | DataTransferItem>;
+  files: T[];
   accept?: string;
   minSize?: number;
   maxSize?: number;
@@ -242,24 +256,52 @@ export function getDragVerdict({
   // The validator is never invoked here (see the note above), so its async variant is accepted
   // purely so the same `validator` prop is assignable during a drag.
   validator?: (file: File) => ValidatorResult | Promise<ValidatorResult>;
-}): DragVerdict {
-  // The file count is knowable during a drag, so an over-the-limit selection is a confident reject.
-  if ((!multiple && files.length > 1) || (multiple && maxFiles >= 1 && files.length > maxFiles)) {
-    return "reject";
+  getErrorMessage?: (error: FileError, file: File) => string;
+}): DragEvaluation<T> {
+  const acceptedFiles: T[] = [];
+  const rejections: DragFileRejection<T>[] = [];
+
+  const localizeError = (error: FileError, file: T): FileError =>
+    getErrorMessage && typeof File !== "undefined" && file instanceof File
+      ? {...error, message: getErrorMessage(error, file)}
+      : error;
+
+  files.forEach(file => {
+    const [accepted, acceptError] = fileAccepted(file as File, accept);
+    const [sizeMatch, sizeError] = fileMatchSize(file as File, minSize, maxSize);
+
+    if (accepted && sizeMatch) {
+      acceptedFiles.push(file);
+    } else {
+      rejections.push({
+        file,
+        errors: [acceptError, sizeError]
+          .filter((error): error is FileError => error != null)
+          .map(error => localizeError(error, file))
+      });
+    }
+  });
+
+  // Match the drop path: files that already failed a per-file check do not consume the limit,
+  // and only otherwise-valid surplus files receive a too-many-files rejection.
+  const acceptedFilesLimit = multiple ? (maxFiles >= 1 ? maxFiles : Number.POSITIVE_INFINITY) : 1;
+  if (acceptedFiles.length > acceptedFilesLimit) {
+    acceptedFiles.slice(acceptedFilesLimit).forEach(file => {
+      rejections.push({file, errors: [localizeError(TOO_MANY_FILES_REJECTION, file)]});
+    });
   }
 
-  const confidentlyRejected = files.some(file => {
-    const [accepted] = fileAccepted(file as File, accept);
-    const [sizeMatch] = fileMatchSize(file as File, minSize, maxSize);
-    return !accepted || !sizeMatch;
-  });
-  if (confidentlyRejected) {
-    return "reject";
+  if (rejections.length > 0) {
+    return {verdict: "reject", rejections};
   }
 
   // Built-in checks pass. A custom validator can only ever add rejections on drop, never rescue
   // one - so with a validator present the drag outcome is unknown until we have real Files.
-  return validator ? "unknown" : "accept";
+  return {verdict: validator ? "unknown" : "accept", rejections};
+}
+
+export function getDragVerdict(options: Parameters<typeof evaluateDragFiles>[0]): DragVerdict {
+  return evaluateDragFiles(options).verdict;
 }
 
 // React's synthetic events has event.isPropagationStopped,


### PR DESCRIPTION
## Summary

- add `dragFileRejections` to the dropzone state so consumers can inspect reject reasons during drag
- compute drag-time rejection errors for type, size, and surplus-file checks without running the custom validator
- clear drag-time rejections on drag leave and drop so they stay separate from `fileRejections`

Fixes #1288.

## Tests

- `npm test -- --run src/index.spec.tsx`
- `npm run type-check`
- `npm run lint`
- `npm run format:check`
