### PR TITLE
feat: group MIME types in accept (closes #1189)

### DIFF
--- a/docs/pages/examples/accept.mdx
+++ b/docs/pages/examples/accept.mdx
@@ -49,6 +49,24 @@ function Accept() {
 }
 ```
 
+## Grouping types for the file picker
+
+When the [File System Access picker](/examples/file-dialog) is used (`useFsAccessApi: true`, in a secure context, on a supporting browser), `showOpenFilePicker` renders one filter row per _group_ of types. To control that grouping and label each row, pass `accept` as an **array** of `{description, accept}` entries instead of a single map:
+
+```tsx
+const {getRootProps, getInputProps} = useDropzone({
+  useFsAccessApi: true,
+  accept: [
+    {description: "Images", accept: {"image/jpeg": [".jpg", ".jpeg"], "image/png": []}},
+    {description: "Documents", accept: {"application/pdf": [".pdf"]}}
+  ]
+});
+```
+
+The picker then shows two rows - "Images" and "Documents" - rather than a single combined entry. `description` is optional; when omitted it is derived from the group's extensions (the plain object form, which can't express a description, is labeled this way too). Extension values may be a single string or an array (`".pdf"` and `[".pdf"]` are equivalent), matching `showOpenFilePicker`.
+
+> Grouping only affects the File System Access picker. On the native `<input>` fallback - the default, and where the browser doesn't support the FS Access API - all groups are flattened into one `accept` attribute and the descriptions are dropped. Accepted/rejected file validation is identical to listing the same types in the flat object form.
+
 ## Reacting during the drag
 
 Because of HTML5 File API limitations, file names/extensions aren't readable _during_ a drag, so use MIME types (e.g. `image/*`) if you want to react with `isDragAccept` / `isDragReject`:

--- a/src/index.spec.tsx
+++ b/src/index.spec.tsx
@@ -1621,7 +1621,7 @@ describe("useDropzone() hook", () => {
         multiple: true,
         types: [
           {
-            description: "Files",
+            description: "application/pdf",
             accept: {"application/pdf": []}
           }
         ]
@@ -1638,6 +1638,54 @@ describe("useDropzone() hook", () => {
       expect(dropzone).not.toContainElement(activeRef.current);
 
       expect(onDropSpy).toHaveBeenCalledWith(files, [], null);
+    });
+
+    it("passes grouped {accept} to showOpenFilePicker() as separate picker types and flattens it for the <input>", async () => {
+      const handlers = files.map(f => createFileSystemFileHandle(f));
+      const thenable = createThenable();
+      const showOpenFilePickerMock = vi.fn().mockReturnValue(thenable.promise);
+
+      window.showOpenFilePicker = showOpenFilePickerMock;
+
+      const {container} = render(
+        <Dropzone
+          onDrop={vi.fn()}
+          accept={[
+            {description: "Images", accept: {"image/jpeg": [".jpg", ".jpeg"], "image/png": []}},
+            {accept: {"application/pdf": ".pdf"}}
+          ]}
+          multiple
+          useFsAccessApi
+        >
+          {({getRootProps, getInputProps}) => (
+            <div {...getRootProps()}>
+              <input {...getInputProps()} />
+            </div>
+          )}
+        </Dropzone>
+      );
+
+      const dropzone = container.querySelector("div");
+
+      // The native <input> gets the flattened accept attribute (no groups/descriptions).
+      expect(container.querySelector("input")).toHaveAttribute(
+        "accept",
+        "image/jpeg,.jpg,.jpeg,image/png,application/pdf,.pdf"
+      );
+
+      fireEvent.click(dropzone);
+
+      // The FS Access picker keeps each group as its own type; the description-less group is
+      // derived from its extensions, and the bare string extension is normalized to an array.
+      expect(showOpenFilePickerMock).toHaveBeenCalledWith({
+        multiple: true,
+        types: [
+          {description: "Images", accept: {"image/jpeg": [".jpg", ".jpeg"], "image/png": []}},
+          {description: ".pdf", accept: {"application/pdf": [".pdf"]}}
+        ]
+      });
+
+      await act(() => thenable.done(handlers));
     });
 
     test("if showOpenFilePicker() is supported and {useFsAccessApi} is true, it should work without the <input>", async () => {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -9,6 +9,7 @@ import {
   ErrorCode,
   fileAccepted,
   fileMatchSize,
+  flattenAccept,
   getDragVerdict,
   isAbort,
   isEvtWithFiles,
@@ -21,9 +22,9 @@ import {
   pickerOptionsFromAccept,
   TOO_MANY_FILES_REJECTION
 } from "./utils";
-import type {Accept, FileError, ValidatorResult} from "./utils";
+import type {Accept, AcceptGroup, FileError, ValidatorResult} from "./utils";
 
-export type {Accept, FileError, FileWithPath, ValidatorResult};
+export type {Accept, AcceptGroup, FileError, FileWithPath, ValidatorResult};
 export {ErrorCode};
 
 export interface DropzoneProps extends DropzoneOptions {
@@ -38,7 +39,7 @@ export interface FileRejection {
 type SharedProps = "multiple" | "onDragEnter" | "onDragOver" | "onDragLeave";
 
 export type DropzoneOptions = Pick<React.HTMLProps<HTMLElement>, SharedProps> & {
-  accept?: Accept;
+  accept?: Accept | AcceptGroup[];
   minSize?: number;
   maxSize?: number;
   maxFiles?: number;
@@ -247,19 +248,23 @@ export function useDropzone(props: DropzoneOptions = {}): DropzoneState {
     getErrorMessage
   } = props;
 
+  // `accept` may be a MIME->extensions map or an array of labeled groups (for the FS Access
+  // picker). Flatten it to a single map for the native `<input>` and the drag/drop validators,
+  // which have no concept of groups; the picker keeps the groups via `pickerTypes` below.
+  const flatAccept = useMemo(() => flattenAccept(accept), [accept]);
   // `acceptAttr` keeps wildcard MIME types (e.g. `image/*`) so the drag-time
   // `isDragAccept`/`isDragReject` check can react to a file's MIME type - file names
   // (hence extensions) aren't readable during a drag.
-  const acceptAttr = useMemo(() => acceptPropAsAcceptAttr(accept), [accept]);
+  const acceptAttr = useMemo(() => acceptPropAsAcceptAttr(flatAccept), [flatAccept]);
   // `inputAcceptAttr` drops a wildcard MIME type when it is paired with extensions, so the
   // native picker and drop-time validation enforce the extensions instead of accepting any
   // file of that type. See https://github.com/react-dropzone/react-dropzone/issues/1220
   const inputAcceptAttr = useMemo(
     () =>
-      acceptPropAsAcceptAttr(accept, {
+      acceptPropAsAcceptAttr(flatAccept, {
         omitWildcardMimeTypesWithExtensions: true
       }),
-    [accept]
+    [flatAccept]
   );
   const pickerTypes = useMemo(() => pickerOptionsFromAccept(accept), [accept]);
 

--- a/src/utils/index.spec.ts
+++ b/src/utils/index.spec.ts
@@ -556,7 +556,7 @@ describe("pickerOptionsFromAccept()", () => {
     utils = await import("./index");
   });
 
-  it("converts the {accept} prop to file picker options", () => {
+  it("converts the {accept} prop to file picker options, deriving the description from the extensions", () => {
     expect(
       utils.pickerOptionsFromAccept({
         "image/*": [".png", ".jpg"], // ok
@@ -566,13 +566,94 @@ describe("pickerOptionsFromAccept()", () => {
       })
     ).toEqual([
       {
-        description: "Files",
+        description: ".png, .jpg, .txt, .pdf",
         accept: {
           "image/*": [".png", ".jpg"],
           "text/*": [".txt", ".pdf"]
         }
       }
     ]);
+  });
+
+  it("returns undefined for an empty object form", () => {
+    expect(utils.pickerOptionsFromAccept({})).toBeUndefined();
+  });
+
+  it("keeps each group as its own picker entry with a custom description", () => {
+    expect(
+      utils.pickerOptionsFromAccept([
+        {description: "Images", accept: {"image/jpeg": [".jpg", ".jpeg"], "image/png": []}},
+        {description: "Documents", accept: {"application/pdf": [".pdf"]}}
+      ])
+    ).toEqual([
+      {description: "Images", accept: {"image/jpeg": [".jpg", ".jpeg"], "image/png": []}},
+      {description: "Documents", accept: {"application/pdf": [".pdf"]}}
+    ]);
+  });
+
+  it("derives a group's description from its extensions when omitted", () => {
+    expect(utils.pickerOptionsFromAccept([{accept: {"image/jpeg": [".jpg", ".jpeg"], "image/png": [".png"]}}])).toEqual(
+      [{description: ".jpg, .jpeg, .png", accept: {"image/jpeg": [".jpg", ".jpeg"], "image/png": [".png"]}}]
+    );
+  });
+
+  it("falls back to the MIME types when a group has no extensions", () => {
+    expect(utils.pickerOptionsFromAccept([{accept: {"image/jpeg": [], "image/png": []}}])).toEqual([
+      {description: "image/jpeg, image/png", accept: {"image/jpeg": [], "image/png": []}}
+    ]);
+  });
+
+  it("accepts a bare string extension value, matching showOpenFilePicker", () => {
+    expect(utils.pickerOptionsFromAccept([{description: "PDF", accept: {"application/pdf": ".pdf"}}])).toEqual([
+      {description: "PDF", accept: {"application/pdf": [".pdf"]}}
+    ]);
+  });
+
+  it("drops groups left with no valid entries and returns undefined when none remain", () => {
+    expect(
+      utils.pickerOptionsFromAccept([
+        {description: "Bad", accept: {"audio/*": ["mp3"], "*": [".p12"]}},
+        {description: "Empty", accept: {}}
+      ])
+    ).toBeUndefined();
+  });
+
+  it("returns undefined for an empty group array", () => {
+    expect(utils.pickerOptionsFromAccept([])).toBeUndefined();
+  });
+});
+
+describe("flattenAccept()", () => {
+  /**
+   * @constant
+   * @type {import('./index')}
+   */
+  let utils;
+  beforeEach(async () => {
+    utils = await import("./index");
+  });
+
+  it("returns undefined when accept is not provided", () => {
+    expect(utils.flattenAccept(undefined)).toBeUndefined();
+  });
+
+  it("passes the object form through unchanged (as an array-valued map)", () => {
+    expect(utils.flattenAccept({"image/png": [".png"], "application/pdf": ".pdf"})).toEqual({
+      "image/png": [".png"],
+      "application/pdf": [".pdf"]
+    });
+  });
+
+  it("merges groups and unions extensions of duplicate MIME keys", () => {
+    expect(
+      utils.flattenAccept([
+        {description: "A", accept: {"image/*": [".png"], "application/pdf": [".pdf"]}},
+        {description: "B", accept: {"image/*": [".png", ".jpg"]}}
+      ])
+    ).toEqual({
+      "image/*": [".png", ".jpg"],
+      "application/pdf": [".pdf"]
+    });
   });
 });
 

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -8,9 +8,28 @@ const accepts =
 
 /**
  * A map of accepted MIME types to file extensions, as passed to the `accept` prop.
+ *
+ * An extension value may be a single extension string or an array of them - both are
+ * accepted, mirroring the shape of `window.showOpenFilePicker`'s `accept`.
  */
 export interface Accept {
-  [key: string]: readonly string[];
+  [key: string]: string | readonly string[];
+}
+
+/**
+ * A labeled group of accepted types, mirroring one entry of `window.showOpenFilePicker`'s
+ * `types` option. Passing the `accept` prop as an array of these lets the File System Access
+ * picker present multiple named filter rows instead of a single one (see
+ * {@link pickerOptionsFromAccept}). The optional `description` labels the row; when omitted it
+ * is derived from the group's extensions.
+ *
+ * Grouping only surfaces when the FS Access picker is actually used (`useFsAccessApi` +
+ * a secure context + browser support). The native `<input>` fallback has no concept of groups
+ * or descriptions, so every group is flattened into one accept attribute there.
+ */
+export interface AcceptGroup {
+  description?: string;
+  accept: Accept;
 }
 
 /**
@@ -323,41 +342,142 @@ export function canUseFileSystemAccessAPI(): boolean {
 }
 
 /**
- * Convert the `{accept}` dropzone prop to the `{types}` option for showOpenFilePicker.
+ * Coerce an `accept` extension value to an array. `window.showOpenFilePicker` allows a single
+ * extension string as well as an array, so we accept both and normalize to an array. Anything
+ * else (a malformed value) collapses to an empty list.
  */
-export function pickerOptionsFromAccept(accept?: Accept): Array<{description: string; accept: Accept}> | undefined {
-  if (isDefined(accept)) {
-    const acceptForPicker = Object.entries(accept)
-      .filter(([mimeType, ext]) => {
-        let ok = true;
-
-        if (!isMIMEType(mimeType)) {
-          console.warn(
-            `Skipped "${mimeType}" because it is not a valid MIME type. Check https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types/Common_types for a list of valid MIME types.`
-          );
-          ok = false;
-        }
-
-        if (!Array.isArray(ext) || !ext.every(isExt)) {
-          console.warn(`Skipped "${mimeType}" because an invalid file extension was provided.`);
-          ok = false;
-        }
-
-        return ok;
-      })
-      .reduce<Accept>((agg, [mimeType, ext]) => {
-        agg[mimeType] = ext;
-        return agg;
-      }, {});
-    return [
-      {
-        // description is required due to https://crbug.com/1264708
-        description: "Files",
-        accept: acceptForPicker
-      }
-    ];
+function toExtensions(ext: string | readonly string[] | undefined): readonly string[] {
+  if (Array.isArray(ext)) {
+    return ext;
   }
-  return undefined;
+  if (typeof ext === "string") {
+    return [ext];
+  }
+  return [];
+}
+
+/**
+ * Normalize either `accept` form to the internal array of `{description, accept}` groups.
+ *
+ * - The object form (`{mime: ext}`) becomes a single group; its `description` (which the object
+ *   form can't express) is derived from the extensions like any other group.
+ * - The array form is passed through; entries missing an `accept` map are dropped.
+ *
+ * In both cases a missing `description` is filled in later from the group's extensions (see
+ * {@link describeAccept}), so the picker always gets the non-empty description it requires
+ * (https://crbug.com/1264708). Returns `undefined` when no `accept` is provided.
+ */
+function normalizeAcceptGroups(accept?: Accept | readonly AcceptGroup[]): AcceptGroup[] | undefined {
+  if (!isDefined(accept)) {
+    return undefined;
+  }
+  if (Array.isArray(accept)) {
+    return (accept as readonly AcceptGroup[]).filter(group => isDefined(group) && isDefined(group.accept));
+  }
+  return [{accept: accept as Accept}];
+}
+
+/**
+ * Build a human-readable label for a picker group from its (validated) accept map, used when the
+ * caller doesn't supply a `description`. Prefer the file extensions, fall back to the MIME types,
+ * then to a generic label - `showOpenFilePicker` requires a non-empty description (crbug 1264708).
+ */
+function describeAccept(accept: Accept): string {
+  const extensions: string[] = [];
+  const mimeTypes = Object.keys(accept);
+  for (const ext of Object.values(accept)) {
+    for (const e of toExtensions(ext)) {
+      if (!extensions.includes(e)) {
+        extensions.push(e);
+      }
+    }
+  }
+  if (extensions.length > 0) {
+    return extensions.join(", ");
+  }
+  if (mimeTypes.length > 0) {
+    return mimeTypes.join(", ");
+  }
+  return "Files";
+}
+
+/**
+ * Merge every `accept` group into a single MIME-type -> extensions map. Duplicate MIME keys union
+ * their extensions. This flattened map drives the native `<input accept>` attribute and the
+ * drag/drop validators, which have no concept of groups or descriptions.
+ */
+export function flattenAccept(accept?: Accept | readonly AcceptGroup[]): Accept | undefined {
+  const groups = normalizeAcceptGroups(accept);
+  if (!isDefined(groups)) {
+    return undefined;
+  }
+  const merged: Record<string, string[]> = {};
+  for (const group of groups) {
+    for (const [mimeType, ext] of Object.entries(group.accept)) {
+      const existing = merged[mimeType] ?? (merged[mimeType] = []);
+      for (const e of toExtensions(ext)) {
+        if (!existing.includes(e)) {
+          existing.push(e);
+        }
+      }
+    }
+  }
+  return merged;
+}
+
+/**
+ * Convert the `{accept}` dropzone prop to the `{types}` option for showOpenFilePicker.
+ *
+ * Each group becomes one filter row in the picker. Invalid MIME types / extensions are dropped
+ * with a warning; a group left with no valid entries is omitted entirely (showOpenFilePicker
+ * rejects an empty `accept`). Returns `undefined` when nothing valid remains.
+ */
+export function pickerOptionsFromAccept(
+  accept?: Accept | readonly AcceptGroup[]
+): Array<{description: string; accept: Accept}> | undefined {
+  const groups = normalizeAcceptGroups(accept);
+  if (!isDefined(groups)) {
+    return undefined;
+  }
+
+  const options = groups
+    .map(group => {
+      const acceptForPicker = Object.entries(group.accept)
+        .filter(([mimeType, ext]) => {
+          let ok = true;
+
+          if (!isMIMEType(mimeType)) {
+            console.warn(
+              `Skipped "${mimeType}" because it is not a valid MIME type. Check https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types/Common_types for a list of valid MIME types.`
+            );
+            ok = false;
+          }
+
+          const isExtInput = Array.isArray(ext) || typeof ext === "string";
+          if (!isExtInput || !toExtensions(ext).every(isExt)) {
+            console.warn(`Skipped "${mimeType}" because an invalid file extension was provided.`);
+            ok = false;
+          }
+
+          return ok;
+        })
+        .reduce<Accept>((agg, [mimeType, ext]) => {
+          agg[mimeType] = toExtensions(ext);
+          return agg;
+        }, {});
+
+      return {
+        description:
+          isDefined(group.description) && group.description !== ""
+            ? group.description
+            : describeAccept(acceptForPicker),
+        accept: acceptForPicker
+      };
+    })
+    // Drop groups with no valid entries - showOpenFilePicker rejects an empty accept map.
+    .filter(option => Object.keys(option.accept).length > 0);
+
+  return options.length > 0 ? options : undefined;
 }
 
 /**
@@ -379,7 +499,8 @@ export function acceptPropAsAcceptAttr(
   if (isDefined(accept)) {
     return (
       Object.entries(accept)
-        .reduce<string[]>((a, [mimeType, ext]) => {
+        .reduce<string[]>((a, [mimeType, extVal]) => {
+          const ext = toExtensions(extVal);
           if (omitWildcardMimeTypesWithExtensions && isMIMETypeWildcard(mimeType) && ext.some(isExt)) {
             a.push(...ext);
           } else {

--- a/type-tests/accept.tsx
+++ b/type-tests/accept.tsx
@@ -27,6 +27,26 @@ export default class Accept extends React.Component<Record<string, never>, State
             )}
           </Dropzone>
         </div>
+        <div className="dropzone">
+          {/* The grouped form: an array of {description, accept} entries for the FS Access
+              picker. `description` is optional, and an extension value may be a bare string. */}
+          <Dropzone
+            useFsAccessApi
+            accept={[
+              {description: "Images", accept: {"image/jpeg": [".jpg", ".jpeg"], "image/png": []}},
+              {accept: {"application/pdf": ".pdf"}}
+            ]}
+            onDrop={(accepted, rejected) => {
+              this.setState({accepted, rejected});
+            }}
+          >
+            {({getRootProps}) => (
+              <div {...getRootProps()}>
+                <p>Try dropping some files here, or click to select files to upload.</p>
+              </div>
+            )}
+          </Dropzone>
+        </div>
         <aside>
           <h2>Accepted files</h2>
           <ul>


### PR DESCRIPTION
**What kind of change does this PR introduce?**
- [ ] Bug Fix
- [x] Feature
- [ ] Refactoring
- [ ] Style
- [ ] Build
- [ ] Chore
- [ ] Documentation
- [ ] CI

**Did you add tests for your changes?**
- [x] Yes, my code is well tested
- [ ] Not relevant

**If relevant, did you update the documentation?**
- [x] Yes, I've updated the documentation
- [ ] Not relevant

**Summary**

Add support for grouping `accept` - see #1189.

**Does this PR introduce a breaking change?**

No.

**Other information**
